### PR TITLE
LNK-125: Implement implicit_prefix support

### DIFF
--- a/generator/src/eu/neverblink/linkml/generator/shacl/ShaclGenerator.scala
+++ b/generator/src/eu/neverblink/linkml/generator/shacl/ShaclGenerator.scala
@@ -90,7 +90,8 @@ class ShaclGenerator(using sv: SchemaView) {
         addTriple(classNameIri, Shacl.property, property)
         s.derivedRangeView.resolve.foreach {
           case typeView: TypeView =>
-            if (!typeView.isIri) addTriple(property, Shacl.datatype, Iri(typeView.uriStr))
+            val isIri = typeView.isIri || s.slot.implicitPrefix.isDefined
+            if (!isIri) addTriple(property, Shacl.datatype, Iri(typeView.uriStr))
             s.slot.description match {
               case Some(d) => addTriple(property, Shacl.description, Literal(d, XmlSchema.string))
               case _ =>
@@ -98,7 +99,7 @@ class ShaclGenerator(using sv: SchemaView) {
             if (!s.slot.multivalued) addTriple(property, Shacl.maxCount, Literal.one)
             if (s.slot.required) addTriple(property, Shacl.minCount, Literal.one)
             val nodeKind =
-              if (typeView.isIri) Shacl.IRI
+              if (isIri) Shacl.IRI
               else Shacl.Literal
             addTriple(property, Shacl.nodeKind, nodeKind)
           case classView: ClassView =>

--- a/generator/test/src-jvm/eu/neverblink/linkml/generator/jsonschema/CrossJsonSchemaIntegrationSpec.scala
+++ b/generator/test/src-jvm/eu/neverblink/linkml/generator/jsonschema/CrossJsonSchemaIntegrationSpec.scala
@@ -2,36 +2,29 @@ package eu.neverblink.linkml.generator.jsonschema
 
 import com.networknt.schema.dialect.Dialects
 import com.networknt.schema.{ExecutionConfig, ExecutionContext, InputFormat, SchemaRegistry}
-import eu.neverblink.linkml.tests.ModelCatalogue
+import eu.neverblink.linkml.tests.{ModelCatalogue, ModelCatalogueSpec}
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
 import os.Path
 
-class CrossJsonSchemaIntegrationSpec extends AnyWordSpec, Matchers {
+class CrossJsonSchemaIntegrationSpec extends AnyWordSpec, Matchers, ModelCatalogueSpec {
   val sr: SchemaRegistry = SchemaRegistry.withDialect(Dialects.getDraft201909)
   val pwd: Path = Option(System.getenv("MILL_WORKSPACE_ROOT"))
     .map(Path(_))
     .getOrElse(os.pwd)
   val generatedModelsDir: Path = pwd / ".generated" / "tests" / "resources"
   val enabled: Boolean = System.getenv("CI") != null || os.exists(generatedModelsDir)
-  val skipModels: Seq[String] = Seq(
-    // Metamodel extended_types.yaml is not bundled
-    "anything",
-    "typeDesignator",
-    "constraints",
-    "unionRange",
-    // LinkML-py outputs an "accept all" for references
-    "reference",
-    "multivaluedReference",
-    // LinkML-py outputs an "accept all" for an empty default_range
-    // This is off-spec, which specifies this should be a "string":
-    // https://linkml.io/linkml-model/latest/docs/specification/04derived-schemas/#rule-populate-schema-metadata
-    "explicitInlineImplicitlyAsList",
-    "explicitInlineImplicitlyAsSimpleDict",
-    // LinkML-py allows unaliased names to be used in addition to aliased ones
+
+  override val skipModels: Map[String, String] = Map(
+    "anything" -> "Metamodel extended_types.yaml is not bundled in LinkML-py",
+    "typeDesignator" -> "Type designators seem to be very broken in LinkML-py",
+    "unionRange" -> "Metamodel extended_types.yaml is not bundled in LinkML-py",
+  )
+
+  override val skipInstances: Map[(String, String), String] = Map(
     // This seems to contradict the description of the `alias` slot
     // https://linkml.io/linkml-model/latest/docs/alias/
-    "aliases",
+    "aliases" -> "nonRdf" -> "LinkML-py allows unaliased names to be used in addition to aliased ones",
   )
 
   "LinkML Python Json Schema generator" should {
@@ -43,12 +36,14 @@ class CrossJsonSchemaIntegrationSpec extends AnyWordSpec, Matchers {
 
         for valid <- entry.validInstances.filter(_.json.isDefined).distinct do
           s"valid instance '${valid.name}'" in {
-            assume(enabled && (!skipModels.contains(entry.model.root.name)))
+            assume(enabled)
+            processSkip(entry, valid)
             sr.getSchema(jsonSchema).validate(valid.json.get, InputFormat.JSON) shouldBe empty
           }
         for invalid <- entry.invalidInstances.filter(_.json.isDefined).distinct do
           s"invalid data '${invalid.name}'" in {
-            assume(enabled && (!skipModels.contains(entry.model.root.name)))
+            assume(enabled)
+            processSkip(entry, invalid)
             sr.getSchema(jsonSchema).validate(
               invalid.json.get,
               InputFormat.JSON,

--- a/generator/test/src-jvm/eu/neverblink/linkml/generator/jsonschema/JsonSchemaIntegrationSpec.scala
+++ b/generator/test/src-jvm/eu/neverblink/linkml/generator/jsonschema/JsonSchemaIntegrationSpec.scala
@@ -2,13 +2,13 @@ package eu.neverblink.linkml.generator.jsonschema
 
 import com.networknt.schema.{ExecutionConfig, ExecutionContext, InputFormat, SchemaRegistry}
 import com.networknt.schema.dialect.Dialects
-import eu.neverblink.linkml.tests.ModelCatalogue
+import eu.neverblink.linkml.tests.{ModelCatalogue, ModelCatalogueSpec}
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
 
-class JsonSchemaIntegrationSpec extends AnyWordSpec, Matchers {
+class JsonSchemaIntegrationSpec extends AnyWordSpec, Matchers, ModelCatalogueSpec {
   val sr: SchemaRegistry = SchemaRegistry.withDialect(Dialects.getDraft202012)
-  import JsonSchemaGeneratorSpec.skipModels
+  override val skipModels: Map[String, String] = JsonSchemaGeneratorSpec.skipModels
 
   "Json Schema generator" should {
     for entry <- ModelCatalogue.all do
@@ -18,12 +18,12 @@ class JsonSchemaIntegrationSpec extends AnyWordSpec, Matchers {
 
         for valid <- entry.validInstances.filter(_.json.isDefined).distinct do
           s"valid instance '${valid.name}'" in {
-            assume(!skipModels.contains(entry.model.root.name))
+            processSkip(entry, valid)
             sr.getSchema(jsonSchema).validate(valid.json.get, InputFormat.JSON) shouldBe empty
           }
         for invalid <- entry.invalidInstances.filter(_.json.isDefined).distinct do
           s"invalid data '${invalid.name}'" in {
-            assume(!skipModels.contains(entry.model.root.name))
+            processSkip(entry, invalid)
             sr.getSchema(jsonSchema).validate(
               invalid.json.get,
               InputFormat.JSON,

--- a/generator/test/src-jvm/eu/neverblink/linkml/generator/shacl/CrossShaclIntegrationSpec.scala
+++ b/generator/test/src-jvm/eu/neverblink/linkml/generator/shacl/CrossShaclIntegrationSpec.scala
@@ -1,6 +1,6 @@
 package eu.neverblink.linkml.generator.shacl
 
-import eu.neverblink.linkml.tests.ModelCatalogue
+import eu.neverblink.linkml.tests.{ModelCatalogue, ModelCatalogueSpec}
 import org.eclipse.rdf4j.model.impl.SimpleValueFactory
 import org.eclipse.rdf4j.rio.RDFFormat
 import org.eclipse.rdf4j.sail.shacl.ShaclValidator
@@ -8,43 +8,50 @@ import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
 import os.Path
 
-class CrossShaclIntegrationSpec extends AnyWordSpec, Matchers {
+class CrossShaclIntegrationSpec extends AnyWordSpec, Matchers, ModelCatalogueSpec {
   val pwd: Path = Option(System.getenv("MILL_WORKSPACE_ROOT"))
     .map(Path(_))
     .getOrElse(os.pwd)
   val generatedModelsDir: Path = pwd / ".generated" / "tests" / "resources"
   val enabled: Boolean = (System.getenv("CI") != null) || os.exists(generatedModelsDir)
-  val skipModelsShaclPy: Seq[String] = Seq(
-    // Metamodel extended_types.yaml is not bundled
-    "anything",
-    "typeDesignator",
-    "unionRange",
-    // LinkML-py SHACL generator omits constraints on default-ranges
-    "explicitInlineImplicitlyAsSimpleDict",
-    // LinkML-py treats CURIEs as literals instead of expanding them
-    "curie",
+  override val skipModels: Map[String, String] = Map(
+    "anything" -> "Metamodel extended_types.yaml is not bundled",
+    "typeDesignator" -> "Metamodel extended_types.yaml is not bundled",
+    "unionRange" -> "Metamodel extended_types.yaml is not bundled",
+    "explicitInlineImplicitlyAsSimpleDict" -> "LinkML-py SHACL generator omits constraints on default-ranges",
+    "curie" -> "LinkML-py treats CURIEs as literals instead of expanding them",
+  )
+  override val skipInstances: Map[(String, String), String] = Map(
+    ("implicitPrefix", "slotDefined") -> "LinkML-py incorrectly does not lift these instances",
   )
   val vf: SimpleValueFactory = SimpleValueFactory.getInstance()
-  "LinkMl Python Shacl generator" should {
+  "LinkMl Python SHACL generator" should {
     for entry <- ModelCatalogue.all do
-      s"generate Json Schema for model '${entry.model.root.name}'" when {
+      s"generate SHACL for model '${entry.model.root.name}'" when {
         lazy val path = Path(entry.path).segments.toSeq
         lazy val ttl = os.read(generatedModelsDir / path / "shacl.ttl")
         lazy val validator = ShaclValidator.builder().withShapes(ttl, RDFFormat.TURTLE).build()
 
-        for valid <- entry.validInstances.filter(_.turtle.isDefined).distinct do
+        for valid <- entry.validInstances.filter(_.turtle.isDefined) do
           s"valid instance '${valid.name}'" in {
-            assume(enabled && !skipModelsShaclPy.contains(entry.model.root.name))
-            val res =
-              validator.validate(valid.turtle.get + valid.context.getOrElse(""), RDFFormat.TURTLE)
+            assume(enabled)
+            processSkip(entry, valid)
+            val res = validator.validate(
+              valid.turtle.get + valid.context.getOrElse(""),
+              RDFFormat.TURTLE,
+            )
             withClue(res.getValidationResult) {
               res.conforms() shouldBe true
             }
           }
-        for invalid <- entry.invalidInstances.filter(_.turtle.isDefined).distinct do
+        for invalid <- entry.invalidInstances.filter(_.turtle.isDefined) do
           s"invalid data '${invalid.name}'" in {
-            assume(enabled && !skipModelsShaclPy.contains(entry.model.root.name))
-            val res = validator.validate(invalid.turtle.get, RDFFormat.TURTLE)
+            assume(enabled)
+            processSkip(entry, invalid)
+            val res = validator.validate(
+              invalid.turtle.get + invalid.context.getOrElse(""),
+              RDFFormat.TURTLE,
+            )
             res.conforms() shouldBe false
           }
       }

--- a/generator/test/src-jvm/eu/neverblink/linkml/generator/shacl/ShaclGeneratorSpec.scala
+++ b/generator/test/src-jvm/eu/neverblink/linkml/generator/shacl/ShaclGeneratorSpec.scala
@@ -595,6 +595,12 @@ class ShaclGeneratorSpec extends AnyWordSpec, Matchers {
       turtle should include("sh:nodeKind sh:IRI")
     }
 
+    "generate IRI nodeKind constraints for implicitly prefixed slots" in {
+      val result = ShaclGenerator(using ModelCatalogue.implicitPrefix.model).generate()
+      val turtle = RdfUtils.toTurtle(result)
+      turtle should include("sh:nodeKind sh:IRI")
+    }
+
     "ignore identifiers" in {
       val result = ShaclGenerator(using ModelCatalogue.reference.model).generate()
       val turtle = RdfUtils.toTurtle(result)

--- a/generator/test/src-jvm/eu/neverblink/linkml/generator/shacl/ShaclIntegrationSpec.scala
+++ b/generator/test/src-jvm/eu/neverblink/linkml/generator/shacl/ShaclIntegrationSpec.scala
@@ -1,15 +1,15 @@
 package eu.neverblink.linkml.generator.shacl
 
 import eu.neverblink.linkml.generator.rdf.RdfUtils
-import eu.neverblink.linkml.tests.ModelCatalogue
+import eu.neverblink.linkml.tests.{ModelCatalogue, ModelCatalogueSpec}
 import org.eclipse.rdf4j.model.impl.SimpleValueFactory
 import org.eclipse.rdf4j.rio.RDFFormat
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
 import org.eclipse.rdf4j.sail.shacl.ShaclValidator
 
-class ShaclIntegrationSpec extends AnyWordSpec, Matchers {
-  import ShaclGeneratorSpec.skipModels
+class ShaclIntegrationSpec extends AnyWordSpec, Matchers, ModelCatalogueSpec {
+  override val skipModels: Map[String, String] = ShaclGeneratorSpec.skipModels
   val vf: SimpleValueFactory = SimpleValueFactory.getInstance()
   "ShaclGenerator" should {
     for entry <- ModelCatalogue.all do
@@ -21,7 +21,7 @@ class ShaclIntegrationSpec extends AnyWordSpec, Matchers {
 
         for valid <- entry.validInstances.filter(_.turtle.isDefined).distinct do
           s"valid instance '${valid.name}'" in {
-            assume(!skipModels.contains(entry.model.root.name))
+            processSkip(entry, valid)
             val res =
               validator.validate(valid.turtle.get + valid.context.getOrElse(""), RDFFormat.TURTLE)
             withClue(res.getValidationResult) {
@@ -30,7 +30,7 @@ class ShaclIntegrationSpec extends AnyWordSpec, Matchers {
           }
         for invalid <- entry.invalidInstances.filter(_.turtle.isDefined).distinct do
           s"invalid data '${invalid.name}'" in {
-            assume(!skipModels.contains(entry.model.root.name))
+            processSkip(entry, invalid)
             val res = validator.validate(invalid.turtle.get, RDFFormat.TURTLE)
             res.conforms() shouldBe false
           }

--- a/schemaview/src/eu/neverblink/linkml/schemaview/ElementView.scala
+++ b/schemaview/src/eu/neverblink/linkml/schemaview/ElementView.scala
@@ -1,7 +1,9 @@
 package eu.neverblink.linkml.schemaview
 
+import eu.neverblink.linkml
 import eu.neverblink.linkml.metamodel.*
 import eu.neverblink.linkml.runtime.*
+import eu.neverblink.linkml.schemaview
 import eu.neverblink.linkml.schemaview.SchemaView.defaultRangeResolved
 
 import scala.collection.mutable
@@ -81,6 +83,14 @@ final case class ClassView(cls: ClassDefinition, definingSchema: SchemaDefinitio
   def subjectType: Option[SubjectType] = identifier.flatMap(slotView => {
     slotView.derivedRangeView.resolve.collect { case tv: TypeView =>
       tv.subjectType
+    }.map {
+      // Fallback if the type does not define the prefix but the slot does
+      case SubjectType.base =>
+        slotView.implicitPrefixReference match {
+          case Some(prefix) => SubjectType.implicitPrefix(prefix)
+          case None => SubjectType.base
+        }
+      case subject => subject
     }
   })
 
@@ -262,6 +272,11 @@ final case class SlotView(slot: SlotDefinition, definingSchema: SchemaDefinition
 ) extends ElementView[SlotDefinition] {
   def inner: SlotDefinition = slot
 
+  /** Resolved URI string for the implicit_prefix metaslot for this slot, if defined
+    */
+  def implicitPrefixReference: Option[String] =
+    slot.implicitPrefix.flatMap(definingPrefixResolver.resolvePrefix)
+
   /** Get and dereference the direct parents (mixins + inheritance) of this slot
     *
     * @return
@@ -270,7 +285,7 @@ final case class SlotView(slot: SlotDefinition, definingSchema: SchemaDefinition
   def parents: Iterable[SlotDefinition] = getParents(slot)
 
   private def getParents(slot: SlotDefinition): Iterable[SlotDefinition] =
-    (slot.mixins ++ slot.isA).flatMap(sv.resolve) // TODO LNK-23: type refinements
+    (slot.mixins ++ slot.isA).flatMap(sv.resolve)
 
   /** Get and dereference all the ancestors (transitive parents) of this slot.
     *
@@ -347,12 +362,11 @@ final case class TypeView(_type: TypeDefinition, definingSchema: SchemaDefinitio
     case _ =>
       inner.implicitPrefix match {
         case Some(prefix) =>
-          val reference = Uri(
+          val reference =
             definingPrefixResolver.resolvePrefix(prefix).getOrElse(
               sys.error(s"Unknown prefix: $prefix"),
-            ),
-          )
-          SubjectType.implicitPrefix(PrefixImpl(prefix, reference))
+            )
+          SubjectType.implicitPrefix(reference)
         case None => SubjectType.base
       }
   }
@@ -369,7 +383,11 @@ final case class TypeView(_type: TypeDefinition, definingSchema: SchemaDefinitio
     case UriOrCurieType => true
     case UriType => true
     case CurieType => true
-    case _ => false
+    case _ =>
+      subjectType match {
+        case SubjectType.implicitPrefix(_) => true
+        case _ => false
+      }
   }
 
   /** The [[RuntimeType]] representation of this type. Translates Python-ese and LinkML-py runtime

--- a/schemaview/src/eu/neverblink/linkml/schemaview/ElementView.scala
+++ b/schemaview/src/eu/neverblink/linkml/schemaview/ElementView.scala
@@ -344,7 +344,17 @@ final case class TypeView(_type: TypeDefinition, definingSchema: SchemaDefinitio
     case UriType => SubjectType.uri
     case CurieType => SubjectType.curie
     case UriOrCurieType => SubjectType.uriOrCurie
-    case _ => SubjectType.base
+    case _ =>
+      inner.implicitPrefix match {
+        case Some(prefix) =>
+          val reference = Uri(
+            definingPrefixResolver.resolvePrefix(prefix).getOrElse(
+              sys.error(s"Unknown prefix: $prefix"),
+            ),
+          )
+          SubjectType.implicitPrefix(PrefixImpl(prefix, reference))
+        case None => SubjectType.base
+      }
   }
 
   /** @return

--- a/schemaview/src/eu/neverblink/linkml/schemaview/SchemaProblem.scala
+++ b/schemaview/src/eu/neverblink/linkml/schemaview/SchemaProblem.scala
@@ -1,6 +1,7 @@
 package eu.neverblink.linkml.schemaview
 
 import eu.neverblink.linkml.metamodel.{ClassDefinition, SlotDefinition}
+import eu.neverblink.linkml.runtime.NcName
 
 import scala.util.Failure
 
@@ -155,4 +156,8 @@ object SchemaProblem {
       "schema 'default_range' is undefined, and the fallback 'string' type is not available. " +
       "Define the 'range' of the slot, add a 'default_range' to the schema, " +
       "import 'linkml:types', or define a 'string' type to fix."
+
+  final case class UndefinedPrefix(prefix: NcName, position: String) extends Error:
+    lazy val description: String = s"Undefined prefix $prefix at $position"
+    lazy val verbose: String = description
 }

--- a/schemaview/src/eu/neverblink/linkml/schemaview/SchemaValidator.scala
+++ b/schemaview/src/eu/neverblink/linkml/schemaview/SchemaValidator.scala
@@ -1,7 +1,7 @@
 package eu.neverblink.linkml.schemaview
 
 import eu.neverblink.linkml.metamodel.*
-import eu.neverblink.linkml.runtime.Reference
+import eu.neverblink.linkml.runtime.{PrefixResolver, Reference}
 
 import java.util
 import scala.util.{Success, Try}
@@ -237,6 +237,58 @@ final class SchemaValidator(using sv: SchemaView) {
     perClass.flatten.toSeq
   }
 
+  private def slotImplicitPrefix(
+      slotDefinition: SlotDefinition,
+      prefixResolver: PrefixResolver,
+      locationPrefix: String,
+  ): Option[SchemaProblem.Error] = {
+    slotDefinition.implicitPrefix match {
+      case Some(prefix) if prefixResolver.resolvePrefix(prefix).isEmpty =>
+        Some(
+          SchemaProblem.UndefinedPrefix(
+            prefix,
+            s"$locationPrefix/${slotDefinition.name}/implicit_prefix",
+          ),
+        )
+      case _ => None
+    }
+  }
+
+  private lazy val unknownPrefixes: Seq[SchemaProblem.Error] = {
+    sv.root.emitPrefixes.zipWithIndex.flatMap((prefix, idx) =>
+      if sv.rootPrefixResolver.resolvePrefix(prefix).isEmpty
+      then Some(SchemaProblem.UndefinedPrefix(prefix, s"/emit_prefixes/$idx"))
+      else None,
+    ) ++
+      sv.types.values.flatMap(tv => {
+        tv._type.implicitPrefix match {
+          case Some(prefix) if tv.definingPrefixResolver.resolvePrefix(prefix).isEmpty =>
+            Some(SchemaProblem.UndefinedPrefix(prefix, s"/types/${tv._type.name}/implicit_prefix"))
+          case _ => None
+        }
+      }) ++
+      sv.slotDefinitions.values.flatMap(slotView =>
+        slotImplicitPrefix(slotView.inner, slotView.definingPrefixResolver, "/slots"),
+      )
+      ++
+      sv.classes.values.flatMap(classView =>
+        classView.cls.slotUsage.values.flatMap(
+          slotImplicitPrefix(
+            _,
+            classView.definingPrefixResolver,
+            s"/classes/${classView.cls.name}/slot_usage",
+          ),
+        ) ++
+          classView.cls.attributes.values.flatMap(
+            slotImplicitPrefix(
+              _,
+              classView.definingPrefixResolver,
+              s"/classes/${classView.cls.name}/attributes",
+            ),
+          ),
+      )
+  }
+
   /** Any fatal problems that block further processing / validation, if any. */
   lazy val fatalProblems: Seq[SchemaProblem.Fatal] =
     unknownReferences ++
@@ -247,7 +299,8 @@ final class SchemaValidator(using sv: SchemaView) {
   private lazy val errors: Seq[SchemaProblem.Error] =
     identifierAndKey ++
       multipleTreeRoots ++
-      nonUniqueNames
+      nonUniqueNames ++
+      unknownPrefixes
 
   /** Any warnings found in the schema, if any. */
   private lazy val warnings: Seq[SchemaProblem.Warning] =

--- a/schemaview/src/eu/neverblink/linkml/schemaview/SubjectType.scala
+++ b/schemaview/src/eu/neverblink/linkml/schemaview/SubjectType.scala
@@ -1,10 +1,14 @@
 package eu.neverblink.linkml.schemaview
 
+import eu.neverblink.linkml.metamodel.PrefixImpl
+
 /** Enum defining the mapping between non-RDF values and RDF subject-position IRIs.
   *   - uri: value can be lifted directly as an IRI
   *   - curie: value can be lifted by first expanding the IRI
   *   - uriOrCurie: value should be treated as either a URI or CURIE
+  *   - implicitPrefix: value should be lifted using the `implicit_prefix` metaslot
   *   - base: value should be lifted using the default prefix / base
   */
 enum SubjectType:
   case uri, curie, uriOrCurie, base
+  case implicitPrefix(prefix: PrefixImpl)

--- a/schemaview/src/eu/neverblink/linkml/schemaview/SubjectType.scala
+++ b/schemaview/src/eu/neverblink/linkml/schemaview/SubjectType.scala
@@ -1,7 +1,5 @@
 package eu.neverblink.linkml.schemaview
 
-import eu.neverblink.linkml.metamodel.PrefixImpl
-
 /** Enum defining the mapping between non-RDF values and RDF subject-position IRIs.
   *   - uri: value can be lifted directly as an IRI
   *   - curie: value can be lifted by first expanding the IRI
@@ -11,4 +9,4 @@ import eu.neverblink.linkml.metamodel.PrefixImpl
   */
 enum SubjectType:
   case uri, curie, uriOrCurie, base
-  case implicitPrefix(prefix: PrefixImpl)
+  case implicitPrefix(prefix: String)

--- a/tests/resources/models/implicitPrefix/model.yaml
+++ b/tests/resources/models/implicitPrefix/model.yaml
@@ -1,0 +1,38 @@
+id: https://neverblink.eu/linkml/tests/implicitPrefix/
+name: implicitPrefix
+
+prefixes:
+  base: https://neverblink.eu/linkml/tests/implicitPrefix/base/
+
+imports:
+  - linkml:types
+
+classes:
+  SomeClass:
+    tree_root: true
+    attributes:
+      some_slot:
+        range: string
+        implicit_prefix: base
+      one_more_slot:
+        range: prefixed_id
+      some_other_slot:
+        range: SomeOtherClass
+      yet_another_slot:
+        range: YetAnotherClass
+  SomeOtherClass:
+    attributes:
+      id:
+        identifier: true
+        range: string
+        implicit_prefix: base
+  YetAnotherClass:
+    attributes:
+      id:
+        identifier: true
+        range: prefixed_id
+
+types:
+  prefixed_id:
+    base: str
+    implicit_prefix: base

--- a/tests/resources/models/implicitPrefix/valid/slotDefined/data.json
+++ b/tests/resources/models/implicitPrefix/valid/slotDefined/data.json
@@ -1,0 +1,3 @@
+{
+  "some_slot": "value"
+}

--- a/tests/resources/models/implicitPrefix/valid/slotDefined/data.ttl
+++ b/tests/resources/models/implicitPrefix/valid/slotDefined/data.ttl
@@ -1,0 +1,5 @@
+@prefix : <https://neverblink.eu/linkml/tests/implicitPrefix/> .
+@prefix base: <https://neverblink.eu/linkml/tests/implicitPrefix/base/> .
+
+_:b a :SomeClass;
+  :some_slot base:value .

--- a/tests/resources/models/implicitPrefix/valid/slotDefinedReference/context.ttl
+++ b/tests/resources/models/implicitPrefix/valid/slotDefinedReference/context.ttl
@@ -1,0 +1,4 @@
+@prefix : <https://neverblink.eu/linkml/tests/implicitPrefix/> .
+@prefix base: <https://neverblink.eu/linkml/tests/implicitPrefix/base/> .
+
+base:value a :SomeOtherClass .

--- a/tests/resources/models/implicitPrefix/valid/slotDefinedReference/data.json
+++ b/tests/resources/models/implicitPrefix/valid/slotDefinedReference/data.json
@@ -1,0 +1,3 @@
+{
+  "some_other_slot": "value"
+}

--- a/tests/resources/models/implicitPrefix/valid/slotDefinedReference/data.ttl
+++ b/tests/resources/models/implicitPrefix/valid/slotDefinedReference/data.ttl
@@ -1,0 +1,5 @@
+@prefix : <https://neverblink.eu/linkml/tests/implicitPrefix/> .
+@prefix base: <https://neverblink.eu/linkml/tests/implicitPrefix/base/> .
+
+_:b a :SomeClass;
+  :some_other_slot base:value .

--- a/tests/resources/models/implicitPrefix/valid/typeDefined/data.json
+++ b/tests/resources/models/implicitPrefix/valid/typeDefined/data.json
@@ -1,0 +1,3 @@
+{
+  "one_more_slot": "value"
+}

--- a/tests/resources/models/implicitPrefix/valid/typeDefined/data.ttl
+++ b/tests/resources/models/implicitPrefix/valid/typeDefined/data.ttl
@@ -1,0 +1,5 @@
+@prefix : <https://neverblink.eu/linkml/tests/implicitPrefix/> .
+@prefix base: <https://neverblink.eu/linkml/tests/implicitPrefix/base/> .
+
+_:b a :SomeClass;
+  :one_more_slot base:value .

--- a/tests/resources/models/implicitPrefix/valid/typeDefinedReference/context.ttl
+++ b/tests/resources/models/implicitPrefix/valid/typeDefinedReference/context.ttl
@@ -1,0 +1,4 @@
+@prefix : <https://neverblink.eu/linkml/tests/implicitPrefix/> .
+@prefix base: <https://neverblink.eu/linkml/tests/implicitPrefix/base/> .
+
+base:value a :YetAnotherClass .

--- a/tests/resources/models/implicitPrefix/valid/typeDefinedReference/data.json
+++ b/tests/resources/models/implicitPrefix/valid/typeDefinedReference/data.json
@@ -1,0 +1,3 @@
+{
+  "yet_another_slot": "value"
+}

--- a/tests/resources/models/implicitPrefix/valid/typeDefinedReference/data.ttl
+++ b/tests/resources/models/implicitPrefix/valid/typeDefinedReference/data.ttl
@@ -1,0 +1,5 @@
+@prefix : <https://neverblink.eu/linkml/tests/implicitPrefix/> .
+@prefix base: <https://neverblink.eu/linkml/tests/implicitPrefix/base/> .
+
+_:b a :SomeClass;
+  :yet_another_slot base:value .

--- a/tests/resources/models/inlines/explicitInlineImplicitlyAsList/model.yaml
+++ b/tests/resources/models/inlines/explicitInlineImplicitlyAsList/model.yaml
@@ -8,6 +8,7 @@ classes:
   SomeOtherClass:
     attributes:
       other_slot:
+        range: string
   SomeClass:
     tree_root: true
     slots:

--- a/tests/resources/models/inlines/explicitInlineImplicitlyAsSimpleDict/model.yaml
+++ b/tests/resources/models/inlines/explicitInlineImplicitlyAsSimpleDict/model.yaml
@@ -9,7 +9,9 @@ classes:
     attributes:
       id:
         identifier: true
+        range: string
       other_slot:
+        range: string
   SomeClass:
     tree_root: true
     slots:

--- a/tests/resources/models/multivaluedReference/model.yaml
+++ b/tests/resources/models/multivaluedReference/model.yaml
@@ -9,6 +9,7 @@ classes:
     attributes:
       id:
         identifier: true
+        range: string
   SomeClass:
     tree_root: true
     slots:

--- a/tests/resources/models/reference/model.yaml
+++ b/tests/resources/models/reference/model.yaml
@@ -9,6 +9,7 @@ classes:
     attributes:
       id:
         identifier: true
+        range: string
   SomeClass:
     tree_root: true
     slots:

--- a/tests/src/eu/neverblink/linkml/tests/ModelCatalogue.scala
+++ b/tests/src/eu/neverblink/linkml/tests/ModelCatalogue.scala
@@ -25,7 +25,30 @@ object ModelCatalogue {
       turtle: Option[String],
       csv: Option[String],
       context: Option[String],
-  )
+  ):
+    /** @return
+      *   the requested format if available, None otherwise
+      */
+    def inFormat(format: Format): Option[String] = format match {
+      case Format.turtle => turtle
+      case Format.turtleWithContext =>
+        for
+          t <- turtle
+          c <- context
+        yield t + c
+      case Format.json => json
+      case Format.csv => csv
+    }
+
+    /** @return
+      *   true if the format is available
+      */
+    def hasFormat(format: Format): Boolean = inFormat(format).isDefined
+
+  /** Enum for formats of an instance
+    */
+  enum Format:
+    case turtle, turtleWithContext, json, csv
 
   private object InstanceInFormats:
     def apply(path: String, name: String): InstanceInFormats = {
@@ -57,7 +80,8 @@ object ModelCatalogue {
       model: SchemaView,
       validInstances: Seq[InstanceInFormats],
       invalidInstances: Seq[InstanceInFormats],
-  )
+  ):
+    val name: String = model.root.name
 
   private object Entry:
     def apply(path: String): Entry = {

--- a/tests/src/eu/neverblink/linkml/tests/ModelCatalogue.scala
+++ b/tests/src/eu/neverblink/linkml/tests/ModelCatalogue.scala
@@ -134,6 +134,7 @@ object ModelCatalogue {
   val reference: Entry = Entry("/models/reference/")
   val treeRootless: Entry = Entry("/models/treeRootless/")
   val typed: Entry = Entry("/models/typed/")
+  val implicitPrefix: Entry = Entry("/models/implicitPrefix/")
   val inheritance: Entry = Entry("/models/inheritance/")
   val uri: Entry = Entry("/models/uri/")
   val uriOrCurie: Entry = Entry("/models/uriOrCurie/")

--- a/tests/src/eu/neverblink/linkml/tests/ModelCatalogueSpec.scala
+++ b/tests/src/eu/neverblink/linkml/tests/ModelCatalogueSpec.scala
@@ -1,0 +1,38 @@
+package eu.neverblink.linkml.tests
+
+import eu.neverblink.linkml.tests.ModelCatalogue.{Entry, InstanceInFormats}
+import org.scalatest.wordspec.AnyWordSpecLike
+
+/** Mixin trait allowing easier usage of [[ModelCatalogue]] for model/instance skipping. Useful for
+  * writing tests interacting with instances
+  */
+trait ModelCatalogueSpec {
+  this: AnyWordSpecLike =>
+
+  /** Map of "model name" -> "disable reason". If a key is present, then [[processSkip]] will
+    * indicate that tests for this model should be canceled.
+    */
+  def skipModels: Map[String, String] = Map.empty
+
+  /** Map of "model name" -> "instance name" -> "disable reason". If a key is present, then
+    * [[processSkip]] will indicate that tests for this model should be canceled.
+    */
+  def skipInstances: Map[(String, String), String] = Map.empty
+
+  /** Check whether this test should be run as per [[skipModels]] and [[skipInstances]]
+    * @param entry
+    *   Model that is being tested
+    * @param instance
+    *   Instance that is being tested
+    * @throws org.scalatest.exceptions.TestCanceledException
+    *   when the test should be cancelled
+    */
+  final def processSkip(entry: Entry, instance: InstanceInFormats): Unit = {
+    val name = entry.model.root.name
+    assume(!skipModels.contains(name), skipModels.getOrElse(name, ""))
+    assume(
+      !skipInstances.contains((name, instance.name)),
+      skipInstances.getOrElse((name, instance.name), ""),
+    )
+  }
+}


### PR DESCRIPTION
It's not very clear whether it should be "prefix prefix" or "prefix reference" in implicit_prefix. I made it so it's by "prefix prefix". See the model catalogue entry for how it works

Also add a validation step that checks "prefix prefix" references so we can mostly assume they're safe in generators.
And a mild refactor of ModelCatalogue-using tests, now they have a common base class and a standardized way of handling skips.
And some placating linkml-py in cross tests