### PR TITLE
LNK-72: add CLI version command

### DIFF
--- a/build.mill
+++ b/build.mill
@@ -6,6 +6,7 @@
 //| - com.lihaoyi::mill-contrib-scoverage:$MILL_VERSION
 //| - com.carlosedp::mill-aliases::1.1.0
 //| - org.scalameta::scalameta:4.13.4
+//| - com.lihaoyi::mill-contrib-buildinfo:$MILL_VERSION
 //| bspScriptIgnore: [".idea/**"]
 //| mill-jvm-opts: ["-Xss256m", "-Xmx10G"]
 
@@ -21,6 +22,7 @@ import mill.scalajslib.api.ModuleKind
 import scalalib.*
 import io.github.alexarchambault.millnativeimage.NativeImage
 import com.carlosedp.aliases.*
+import mill.contrib.buildinfo.BuildInfo
 import com.sun.net.httpserver.SimpleFileServer
 import mill.api.Evaluator
 import millbuild.{NpmPackage, TsDefsGen}
@@ -29,6 +31,7 @@ import java.net.InetSocketAddress
 
 val scala = "3.8.4"
 val scalaJS = "1.22.0"
+val rdf4j = "5.3.2"
 
 object LinkMlAliases extends Aliases {
   def lint: Seq[String] = alias(
@@ -206,8 +209,8 @@ object generator extends Module {
   object jvm extends CommonModule, GeneratorDeps {
     override def mvnDeps = super.mvnDeps() ++ Seq(
       mvn"com.lihaoyi::os-lib:0.11.8",
-      mvn"org.eclipse.rdf4j:rdf4j-model:5.3.2",
-      mvn"org.eclipse.rdf4j:rdf4j-rio-turtle:5.3.2",
+      mvn"org.eclipse.rdf4j:rdf4j-model:$rdf4j",
+      mvn"org.eclipse.rdf4j:rdf4j-rio-turtle:$rdf4j",
       mvn"com.networknt:json-schema-validator:3.0.6",
     )
 
@@ -219,7 +222,7 @@ object generator extends Module {
       override def moduleDeps = super.moduleDeps :+ build.tests.jvm
 
       override def mvnDeps = super.mvnDeps() ++ Seq(
-        mvn"org.eclipse.rdf4j:rdf4j-shacl:5.3.2",
+        mvn"org.eclipse.rdf4j:rdf4j-shacl:$rdf4j",
         mvn"com.networknt:json-schema-validator:3.0.6",
       )
     }
@@ -291,7 +294,15 @@ object generator extends Module {
 }
 
 object cli extends Module {
-  object jvm extends CommonModule, NativeImage {
+  object jvm extends CommonModule, NativeImage, BuildInfo {
+    def buildInfoPackageName = "eu.neverblink.linkml.cli"
+
+    def buildInfoMembers = Seq(
+      BuildInfo.Value("version", publishVersion()),
+      BuildInfo.Value("scalaVersion", scalaVersion()),
+      BuildInfo.Value("rdf4jVersion", rdf4j),
+    )
+
     override def mainClass = Some(nativeImageMainClass())
 
     def nativeImageMainClass = "eu.neverblink.linkml.cli.App"

--- a/build.mill
+++ b/build.mill
@@ -398,7 +398,14 @@ trait CommonModule
     tagVersion.getOrElse(describeVersion())
   }
 
-  private def describeVersion(): String = {
+  private def describeVersion(): String =
+    try describeVersionUnsafe()
+    catch {
+      // No tags, shallow clone or not a git checkout
+      case _: os.SubprocessException => "0.0.0-SNAPSHOT"
+    }
+
+  private def describeVersionUnsafe(): String = {
     val gitOutput = os.proc("git", "describe", "--tags", "--long", "--match", "v*")
       .call(cwd = mill.api.BuildCtx.workspaceRoot, stderr = os.Pipe)
       .out

--- a/cli/src/eu/neverblink/linkml/cli/App.scala
+++ b/cli/src/eu/neverblink/linkml/cli/App.scala
@@ -13,4 +13,5 @@ object App extends CommandsEntryPoint:
     Rdfs,
     LinkMl,
     TableSchema,
+    Version,
   )

--- a/cli/src/eu/neverblink/linkml/cli/BaseCommand.scala
+++ b/cli/src/eu/neverblink/linkml/cli/BaseCommand.scala
@@ -1,12 +1,27 @@
 package eu.neverblink.linkml.cli
 
-import caseapp.Command
+import caseapp.*
 import eu.neverblink.linkml.schemaview.SchemaView
 
+import java.io.{ByteArrayOutputStream, PrintStream}
 import scala.util.control.NonFatal
 
-trait BaseCommand {
-  this: Command[?] =>
+/** Thrown instead of a real process exit when a command runs in test mode. */
+final case class ExitException(code: Int) extends RuntimeException
+
+/** Base for all CLI commands. Output goes through overridable streams so tests can capture
+  * stdout/stderr via [[runTestCommand]] without touching globals.
+  */
+abstract class BaseCommand[T: {Parser, Help}] extends Command[T] {
+  private var testMode = false
+  protected var out: PrintStream = System.out
+  protected var errStream: PrintStream = System.err
+
+  final override def printLine(line: String, toStderr: Boolean): Unit =
+    if toStderr then errStream.println(line) else out.println(line)
+
+  final override def exit(code: Int): Nothing =
+    if testMode then throw ExitException(code) else super.exit(code)
 
   protected final def err(message: String): Nothing = {
     printLine(message, toStderr = true)
@@ -23,4 +38,25 @@ trait BaseCommand {
             err("Cannot load schema: " + ex.getMessage); null
         }
     }
+
+  /** Runs the whole CLI (via [[App]]) with the given args, capturing stdout and stderr. For tests
+    * only.
+    */
+  final def runTestCommand(args: List[String]): (String, String) = {
+    val bufOut = ByteArrayOutputStream()
+    val bufErr = ByteArrayOutputStream()
+    testMode = true
+    out = PrintStream(bufOut, true, "UTF-8")
+    errStream = PrintStream(bufErr, true, "UTF-8")
+    try App.main(args.toArray)
+    catch { case _: ExitException => () }
+    finally {
+      out.flush()
+      errStream.flush()
+      out = System.out
+      errStream = System.err
+      testMode = false
+    }
+    (bufOut.toString("UTF-8"), bufErr.toString("UTF-8"))
+  }
 }

--- a/cli/src/eu/neverblink/linkml/cli/Generate.scala
+++ b/cli/src/eu/neverblink/linkml/cli/Generate.scala
@@ -17,7 +17,7 @@ trait HasGenerateOptions:
   @Recurse
   val common: GenerateOptions
 
-abstract class Generate[T <: HasGenerateOptions: {Parser, Help}] extends Command[T], BaseCommand {
+abstract class Generate[T <: HasGenerateOptions: {Parser, Help}] extends BaseCommand[T] {
   protected def generatorName: String
 
   /** Returns an iterable of pairs of (filename, content) to be generated.

--- a/cli/src/eu/neverblink/linkml/cli/Validate.scala
+++ b/cli/src/eu/neverblink/linkml/cli/Validate.scala
@@ -6,7 +6,7 @@ import caseapp.*
 @ArgsName("<input-file>")
 final case class ValidateOptions()
 
-object Validate extends Command[ValidateOptions], BaseCommand {
+object Validate extends BaseCommand[ValidateOptions] {
   override def run(options: ValidateOptions, remainingArgs: RemainingArgs): Unit =
     loadSchema(remainingArgs.remaining.headOption)
     printLine("Schema is valid.")

--- a/cli/src/eu/neverblink/linkml/cli/Version.scala
+++ b/cli/src/eu/neverblink/linkml/cli/Version.scala
@@ -7,7 +7,7 @@ import java.time.Year
 @HelpMessage("Print the version of linkml-scala and its key components.")
 final case class VersionOptions()
 
-object Version extends Command[VersionOptions] {
+object Version extends BaseCommand[VersionOptions] {
   override def names: List[List[String]] = List(
     List("version"),
     List("v"),
@@ -15,15 +15,14 @@ object Version extends Command[VersionOptions] {
   )
 
   override def run(options: VersionOptions, remainingArgs: RemainingArgs): Unit = {
+    val jvm = System.getProperty("java.vm.name") + " " + System.getProperty("java.vm.version")
     printLine(
       s"""
          |linkml-scala   ${BuildInfo.version}
          |-------------------------------------------------------------
          |Scala          ${BuildInfo.scalaVersion}
          |RDF4J          ${BuildInfo.rdf4jVersion}
-         |JVM            ${System.getProperty("java.vm.name")} ${System.getProperty(
-          "java.vm.version",
-        )}
+         |JVM            $jvm
          |-------------------------------------------------------------""".stripMargin.trim,
     )
     printLine(

--- a/cli/src/eu/neverblink/linkml/cli/Version.scala
+++ b/cli/src/eu/neverblink/linkml/cli/Version.scala
@@ -1,0 +1,39 @@
+package eu.neverblink.linkml.cli
+
+import caseapp.*
+
+import java.time.Year
+
+@HelpMessage("Print the version of linkml-scala and its key components.")
+final case class VersionOptions()
+
+object Version extends Command[VersionOptions] {
+  override def names: List[List[String]] = List(
+    List("version"),
+    List("v"),
+    List("--version"),
+  )
+
+  override def run(options: VersionOptions, remainingArgs: RemainingArgs): Unit = {
+    printLine(
+      s"""
+         |linkml-scala   ${BuildInfo.version}
+         |-------------------------------------------------------------
+         |Scala          ${BuildInfo.scalaVersion}
+         |RDF4J          ${BuildInfo.rdf4jVersion}
+         |JVM            ${System.getProperty("java.vm.name")} ${System.getProperty(
+          "java.vm.version",
+        )}
+         |-------------------------------------------------------------""".stripMargin.trim,
+    )
+    printLine(
+      s"""
+         |Copyright (C) ${Year.now().getValue} NeverBlink and contributors.
+         |Licensed under the Apache License, Version 2.0.
+         |For details, see https://www.apache.org/licenses/LICENSE-2.0
+         |This software comes with no warranties and is provided 'as-is'.
+         |Documentation and author list: https://github.com/NeverBlink-OSS/linkml-scala
+         |""".stripMargin,
+    )
+  }
+}

--- a/cli/test/src/eu/neverblink/linkml/cli/VersionSpec.scala
+++ b/cli/test/src/eu/neverblink/linkml/cli/VersionSpec.scala
@@ -1,0 +1,23 @@
+package eu.neverblink.linkml.cli
+
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
+
+class VersionSpec extends AnyWordSpec, Matchers {
+  for alias <- Seq("version", "v", "--version") do
+    s"the $alias command" should {
+      "print the tool name and component versions" in {
+        val (out, _) = Version.runTestCommand(List(alias))
+        out should startWith("linkml-scala")
+        out should include("Scala")
+        out should include("RDF4J")
+        out should include("JVM")
+      }
+
+      "include the copyright year and a link to the license" in {
+        val (out, _) = Version.runTestCommand(List(alias))
+        out should include(s"Copyright (C) ${java.time.Year.now().getValue} NeverBlink and contributors")
+        out should include("https://www.apache.org/licenses/LICENSE-2.0")
+      }
+    }
+}


### PR DESCRIPTION
```
linkml-scala   0.8.9
-------------------------------------------------------------
Scala          3.8.4
RDF4J          5.3.2
JVM            OpenJDK 64-Bit Server VM 17.0.18+8
-------------------------------------------------------------

Copyright (C) 2026 NeverBlink and contributors.
Licensed under the Apache License, Version 2.0.
For details, see https://www.apache.org/licenses/LICENSE-2.0
This software comes with no warranties and is provided 'as-is'.
Documentation and author list: https://github.com/NeverBlink-OSS/linkml-scala
```