### PR TITLE
Add basic JMH benchmarks

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -15,6 +15,7 @@ Common tasks with mill:
 - Scan the mill project structure: `./mill resolve _`
 - Compile all modules: `./mill __.compile`
 - Run all tests: `./mill __.test` (prefer specific test running for faster feedback, like `./mill generator.jvm.test`)
+- Run the JMH benchmarks: `./mill benchmark.runJmh` (see [Benchmarks](#benchmarks))
 - Lint the project `./mill lint` (scalafix + scalafmt)
 - Re-generate the metamodel classes `./mill metamodel.regenerate`
 - Fetch the metamodel definitions from [linkml/linkml-model](https://github.com/linkml/linkml-model) `./mill metamodel.definitions`
@@ -44,6 +45,14 @@ npm run watch     # esbuild, rebuilds on change
 npm run typecheck # tsc --noEmit
 npm run build     # one-off bundle
 ```
+
+## Benchmarks
+
+Performance benchmarks live in [`benchmark/`](benchmark/) and use [JMH](https://github.com/openjdk/jmh) via the mill JMH plugin. The module is JVM-only and is never published.
+
+- Run all benchmarks: `./mill benchmark.runJmh`
+- Run a subset (regex over benchmark names): `./mill benchmark.runJmh ".*jsonSchema.*"`
+- List available benchmarks: `./mill benchmark.listJmhBenchmarks`
 
 ## Releasing with GitHub UI
 

--- a/benchmark/resources/schemas/cgmes-core.yml
+++ b/benchmark/resources/schemas/cgmes-core.yml
@@ -1,0 +1,5170 @@
+# Source: https://github.com/Netbeheer-Nederland/cgmes/blob/bb2763d052185579241464791344038f3ba5ffd0/schemas/core-equipment.yaml
+# Original author: Netbeheer Nederland
+# Original license: Apache 2.0
+id: http://iec.ch/TC57/ns/CIM/CoreEquipment-EU#Package_CoreEquipmentProfile
+name: CoreEquipmentProfile
+description: This vocabulary is describing the core equipment profile from IEC 61970-600-2.
+title: Core Equipment Vocabulary
+prefixes:
+  linkml: https://w3id.org/linkml/
+  cim: http://iec.ch/TC57/CIM100#
+  cims: http://iec.ch/TC57/1999/rdf-schema-extensions-19990926#
+  dc: http://purl.org/dc/elements/1.1/
+  dcat: http://www.w3.org/ns/dcat#
+  dct: http://purl.org/dc/terms/
+  eu: http://iec.ch/TC57/CIM100-European#
+  owl: http://www.w3.org/2002/07/owl#
+  profcim: http://iec.ch/TC57/ns/CIM/prof-cim#
+  rdf: http://www.w3.org/1999/02/22-rdf-syntax-ns#
+  rdfs: http://www.w3.org/2000/01/rdf-schema#
+  sh: http://www.w3.org/ns/shacl#
+  skos: http://www.w3.org/2004/02/skos/core#
+  xsd: http://www.w3.org/2001/XMLSchema#
+  eq: http://iec.ch/TC57/ns/CIM/CoreEquipment-EU#
+  this: http://iec.ch/TC57/ns/CIM/CoreEquipment-EU#Package_CoreEquipmentProfile
+imports:
+  - linkml:types
+default_curi_maps:
+  - semweb_context
+default_range: string
+default_prefix: this
+classes:
+  ACDCConverter:
+    class_uri: cim:ACDCConverter
+    attributes:
+      baseS:
+        slot_uri: cim:ACDCConverter.baseS
+        range: ApparentPower
+        multivalued: false
+        required: false
+        description: Base apparent power of the converter pole. The attribute shall
+          be a positive value.
+      idleLoss:
+        slot_uri: cim:ACDCConverter.idleLoss
+        range: ActivePower
+        multivalued: false
+        required: false
+        description: "Active power loss in pole at no power transfer. It is converter\u2019\
+          s configuration data used in power flow. The attribute shall be a positive\
+          \ value."
+      maxUdc:
+        slot_uri: cim:ACDCConverter.maxUdc
+        range: Voltage
+        multivalued: false
+        required: false
+        description: "The maximum voltage on the DC side at which the converter should\
+          \ operate. It is converter\u2019s configuration data used in power flow.\
+          \ The attribute shall be a positive value."
+      minUdc:
+        slot_uri: cim:ACDCConverter.minUdc
+        range: Voltage
+        multivalued: false
+        required: false
+        description: "The minimum voltage on the DC side at which the converter should\
+          \ operate. It is converter\u2019s configuration data used in power flow.\
+          \ The attribute shall be a positive value."
+      numberOfValves:
+        slot_uri: cim:ACDCConverter.numberOfValves
+        range: integer
+        multivalued: false
+        required: false
+        description: Number of valves in the converter. Used in loss calculations.
+      ratedUdc:
+        slot_uri: cim:ACDCConverter.ratedUdc
+        range: Voltage
+        multivalued: false
+        required: false
+        description: "Rated converter DC voltage, also called UdN. The attribute shall\
+          \ be a positive value. It is converter\u2019s configuration data used in\
+          \ power flow. For instance a bipolar HVDC link with value  200 kV has a\
+          \ 400kV difference between the dc lines."
+      resistiveLoss:
+        slot_uri: cim:ACDCConverter.resistiveLoss
+        range: Resistance
+        multivalued: false
+        required: false
+        description: "It is converter\u2019s configuration data used in power flow.\
+          \ Refer to poleLossP. The attribute shall be a positive value."
+      switchingLoss:
+        slot_uri: cim:ACDCConverter.switchingLoss
+        range: ActivePowerPerCurrentFlow
+        multivalued: false
+        required: false
+        description: Switching losses, relative to the base apparent power 'baseS'.
+          Refer to poleLossP. The attribute shall be a positive value.
+      valveU0:
+        slot_uri: cim:ACDCConverter.valveU0
+        range: Voltage
+        multivalued: false
+        required: false
+        description: Valve threshold voltage, also called Uvalve. Forward voltage
+          drop when the valve is conducting. Used in loss calculations, i.e. the switchLoss
+          depend on numberOfValves * valveU0.
+      maxP:
+        slot_uri: cim:ACDCConverter.maxP
+        range: ActivePower
+        multivalued: false
+        required: false
+        description: Maximum active power limit. The value is overwritten by values
+          of VsCapabilityCurve, if present.
+      minP:
+        slot_uri: cim:ACDCConverter.minP
+        range: ActivePower
+        multivalued: false
+        required: false
+        description: Minimum active power limit. The value is overwritten by values
+          of VsCapabilityCurve, if present.
+      PccTerminal:
+        slot_uri: cim:ACDCConverter.PccTerminal
+        range: Terminal
+        multivalued: false
+        required: false
+        description: Point of common coupling terminal for this converter DC side.
+          It is typically the terminal on the power transformer (or switch) closest
+          to the AC network.
+      DCTerminals:
+        slot_uri: cim:ACDCConverter.DCTerminals
+        range: ACDCConverterDCTerminal
+        multivalued: true
+        required: false
+        description: A DC converter have DC converter terminals. A converter has two
+          DC converter terminals.
+    is_a: ConductingEquipment
+    description: A unit with valves for three phases, together with unit control equipment,
+      essential protective and switching devices, DC storage capacitors, phase reactors
+      and auxiliaries, if any, used for conversion.
+  ApparentPower:
+    class_uri: cim:ApparentPower
+    attributes:
+      value:
+        slot_uri: cim:ApparentPower.value
+        range: float
+        multivalued: false
+        required: false
+      multiplier:
+        slot_uri: cim:ApparentPower.multiplier
+        range: UnitMultiplier
+        multivalued: false
+        required: false
+      unit:
+        slot_uri: cim:ApparentPower.unit
+        range: UnitSymbol
+        multivalued: false
+        required: false
+    description: Product of the RMS value of the voltage and the RMS value of the
+      current.
+  ActivePower:
+    class_uri: cim:ActivePower
+    attributes:
+      value:
+        slot_uri: cim:ActivePower.value
+        range: float
+        multivalued: false
+        required: false
+      multiplier:
+        slot_uri: cim:ActivePower.multiplier
+        range: UnitMultiplier
+        multivalued: false
+        required: false
+      unit:
+        slot_uri: cim:ActivePower.unit
+        range: UnitSymbol
+        multivalued: false
+        required: false
+    description: Product of RMS value of the voltage and the RMS value of the in-phase
+      component of the current.
+  Voltage:
+    class_uri: cim:Voltage
+    attributes:
+      value:
+        slot_uri: cim:Voltage.value
+        range: float
+        multivalued: false
+        required: false
+      multiplier:
+        slot_uri: cim:Voltage.multiplier
+        range: UnitMultiplier
+        multivalued: false
+        required: false
+      unit:
+        slot_uri: cim:Voltage.unit
+        range: UnitSymbol
+        multivalued: false
+        required: false
+    description: Electrical voltage, can be both AC and DC.
+  Resistance:
+    class_uri: cim:Resistance
+    attributes:
+      value:
+        slot_uri: cim:Resistance.value
+        range: float
+        multivalued: false
+        required: false
+      unit:
+        slot_uri: cim:Resistance.unit
+        range: UnitSymbol
+        multivalued: false
+        required: false
+      multiplier:
+        slot_uri: cim:Resistance.multiplier
+        range: UnitMultiplier
+        multivalued: false
+        required: false
+    description: Resistance (real part of impedance).
+  ActivePowerPerCurrentFlow:
+    class_uri: cim:ActivePowerPerCurrentFlow
+    attributes:
+      multiplier:
+        slot_uri: cim:ActivePowerPerCurrentFlow.multiplier
+        range: UnitMultiplier
+        multivalued: false
+        required: false
+      unit:
+        slot_uri: cim:ActivePowerPerCurrentFlow.unit
+        range: UnitSymbol
+        multivalued: false
+        required: false
+      value:
+        slot_uri: cim:ActivePowerPerCurrentFlow.value
+        range: float
+        multivalued: false
+        required: false
+    description: Active power variation with current flow.
+  ACDCConverterDCTerminal:
+    class_uri: cim:ACDCConverterDCTerminal
+    attributes:
+      DCConductingEquipment:
+        slot_uri: cim:ACDCConverterDCTerminal.DCConductingEquipment
+        range: ACDCConverter
+        multivalued: false
+        required: true
+        description: A DC converter terminal belong to an DC converter.
+      polarity:
+        slot_uri: cim:ACDCConverterDCTerminal.polarity
+        range: DCPolarityKind
+        multivalued: false
+        required: true
+        description: "Represents the normal network polarity condition. Depending\
+          \ on the converter configuration the value shall be set as follows:\n- For\
+          \ a monopole with two converter terminals use DCPolarityKind \u201Cpositive\u201D\
+          \ and \u201Cnegative\u201D.\n- For a bi-pole or symmetric monopole with\
+          \ three converter terminals use DCPolarityKind \u201Cpositive\u201D, \u201C\
+          middle\u201D and \u201Cnegative\u201D."
+    is_a: DCBaseTerminal
+    description: A DC electrical connection point at the AC/DC converter. The AC/DC
+      converter is electrically connected also to the AC side. The AC connection is
+      inherited from the AC conducting equipment in the same way as any other AC equipment.
+      The AC/DC converter DC terminal is separate from generic DC terminal to restrict
+      the connection with the AC side to AC/DC converter and so that no other DC conducting
+      equipment can be connected to the AC side.
+  ACDCTerminal:
+    class_uri: cim:ACDCTerminal
+    attributes:
+      sequenceNumber:
+        slot_uri: cim:ACDCTerminal.sequenceNumber
+        range: integer
+        multivalued: false
+        required: true
+        description: The orientation of the terminal connections for a multiple terminal
+          conducting equipment.  The sequence numbering starts with 1 and additional
+          terminals should follow in increasing order.   The first terminal is the
+          "starting point" for a two terminal branch.
+      OperationalLimitSet:
+        slot_uri: cim:ACDCTerminal.OperationalLimitSet
+        range: OperationalLimitSet
+        multivalued: true
+        required: false
+        description: The operational limit sets at the terminal.
+      BusNameMarker:
+        slot_uri: cim:ACDCTerminal.BusNameMarker
+        range: BusNameMarker
+        multivalued: false
+        required: false
+        description: The bus name marker used to name the bus (topological node).
+    is_a: IdentifiedObject
+    description: An electrical connection point (AC or DC) to a piece of conducting
+      equipment. Terminals are connected at physical connection points called connectivity
+      nodes.
+  ACLineSegment:
+    class_uri: cim:ACLineSegment
+    attributes:
+      bch:
+        slot_uri: cim:ACLineSegment.bch
+        range: Susceptance
+        multivalued: false
+        required: true
+        description: Positive sequence shunt (charging) susceptance, uniformly distributed,
+          of the entire line section.  This value represents the full charging over
+          the full length of the line.
+      gch:
+        slot_uri: cim:ACLineSegment.gch
+        range: Conductance
+        multivalued: false
+        required: false
+        description: Positive sequence shunt (charging) conductance, uniformly distributed,
+          of the entire line section.
+      r:
+        slot_uri: cim:ACLineSegment.r
+        range: Resistance
+        multivalued: false
+        required: true
+        description: Positive sequence series resistance of the entire line section.
+      x:
+        slot_uri: cim:ACLineSegment.x
+        range: Reactance
+        multivalued: false
+        required: true
+        description: Positive sequence series reactance of the entire line section.
+      Clamp:
+        slot_uri: cim:ACLineSegment.Clamp
+        range: Clamp
+        multivalued: true
+        required: false
+        description: The clamps connected to the line segment.
+      Cut:
+        slot_uri: cim:ACLineSegment.Cut
+        range: Cut
+        multivalued: true
+        required: false
+        description: Cuts applied to the line segment.
+    is_a: Conductor
+    description: 'A wire or combination of wires, with consistent electrical characteristics,
+      building a single electrical system, used to carry alternating current between
+      points in the power system.
+
+      For symmetrical, transposed three phase lines, it is sufficient to use attributes
+      of the line segment, which describe impedances and admittances for the entire
+      length of the segment.  Additionally impedances can be computed by using length
+      and associated per length impedances.
+
+      The BaseVoltage at the two ends of ACLineSegments in a Line shall have the same
+      BaseVoltage.nominalVoltage. However, boundary lines may have slightly different
+      BaseVoltage.nominalVoltages and variation is allowed. Larger voltage difference
+      in general requires use of an equivalent branch.'
+  Susceptance:
+    class_uri: cim:Susceptance
+    attributes:
+      value:
+        slot_uri: cim:Susceptance.value
+        range: float
+        multivalued: false
+        required: false
+      unit:
+        slot_uri: cim:Susceptance.unit
+        range: UnitSymbol
+        multivalued: false
+        required: false
+      multiplier:
+        slot_uri: cim:Susceptance.multiplier
+        range: UnitMultiplier
+        multivalued: false
+        required: false
+    description: Imaginary part of admittance.
+  Conductance:
+    class_uri: cim:Conductance
+    attributes:
+      value:
+        slot_uri: cim:Conductance.value
+        range: float
+        multivalued: false
+        required: false
+      unit:
+        slot_uri: cim:Conductance.unit
+        range: UnitSymbol
+        multivalued: false
+        required: false
+      multiplier:
+        slot_uri: cim:Conductance.multiplier
+        range: UnitMultiplier
+        multivalued: false
+        required: false
+    description: Factor by which voltage must be multiplied to give corresponding
+      power lost from a circuit. Real part of admittance.
+  Reactance:
+    class_uri: cim:Reactance
+    attributes:
+      value:
+        slot_uri: cim:Reactance.value
+        range: float
+        multivalued: false
+        required: false
+      unit:
+        slot_uri: cim:Reactance.unit
+        range: UnitSymbol
+        multivalued: false
+        required: false
+      multiplier:
+        slot_uri: cim:Reactance.multiplier
+        range: UnitMultiplier
+        multivalued: false
+        required: false
+    description: Reactance (imaginary part of impedance), at rated frequency.
+  ActivePowerLimit:
+    class_uri: cim:ActivePowerLimit
+    attributes:
+      normalValue:
+        slot_uri: cim:ActivePowerLimit.normalValue
+        range: ActivePower
+        multivalued: false
+        required: true
+        description: The normal value of active power limit. The attribute shall be
+          a positive value or zero.
+    is_a: OperationalLimit
+    description: Limit on active power flow.
+  ApparentPowerLimit:
+    class_uri: cim:ApparentPowerLimit
+    attributes:
+      normalValue:
+        slot_uri: cim:ApparentPowerLimit.normalValue
+        range: ApparentPower
+        multivalued: false
+        required: true
+        description: The normal apparent power limit. The attribute shall be a positive
+          value or zero.
+    is_a: OperationalLimit
+    description: Apparent power limit.
+  AsynchronousMachine:
+    class_uri: cim:AsynchronousMachine
+    attributes:
+      nominalFrequency:
+        slot_uri: cim:AsynchronousMachine.nominalFrequency
+        range: Frequency
+        multivalued: false
+        required: false
+        description: Nameplate data indicates if the machine is 50 Hz or 60 Hz.
+      nominalSpeed:
+        slot_uri: cim:AsynchronousMachine.nominalSpeed
+        range: RotationSpeed
+        multivalued: false
+        required: false
+        description: Nameplate data.  Depends on the slip and number of pole pairs.
+    is_a: RotatingMachine
+    description: A rotating machine whose shaft rotates asynchronously with the electrical
+      field.  Also known as an induction machine with no external connection to the
+      rotor windings, e.g. squirrel-cage induction machine.
+  Frequency:
+    class_uri: cim:Frequency
+    attributes:
+      value:
+        slot_uri: cim:Frequency.value
+        range: float
+        multivalued: false
+        required: false
+      unit:
+        slot_uri: cim:Frequency.unit
+        range: UnitSymbol
+        multivalued: false
+        required: false
+      multiplier:
+        slot_uri: cim:Frequency.multiplier
+        range: UnitMultiplier
+        multivalued: false
+        required: false
+    description: Cycles per second.
+  RotationSpeed:
+    class_uri: cim:RotationSpeed
+    attributes:
+      multiplier:
+        slot_uri: cim:RotationSpeed.multiplier
+        range: UnitMultiplier
+        multivalued: false
+        required: false
+      unit:
+        slot_uri: cim:RotationSpeed.unit
+        range: UnitSymbol
+        multivalued: false
+        required: false
+      value:
+        slot_uri: cim:RotationSpeed.value
+        range: float
+        multivalued: false
+        required: false
+    description: Number of revolutions per second.
+  AuxiliaryEquipment:
+    class_uri: cim:AuxiliaryEquipment
+    attributes:
+      Terminal:
+        slot_uri: cim:AuxiliaryEquipment.Terminal
+        range: Terminal
+        multivalued: false
+        required: true
+        description: The Terminal at the equipment where the AuxiliaryEquipment is
+          attached.
+    is_a: Equipment
+    description: 'AuxiliaryEquipment describe equipment that is not performing any
+      primary functions but support for the equipment performing the primary function.
+
+      AuxiliaryEquipment is attached to primary equipment via an association with
+      Terminal.'
+  BaseVoltage:
+    class_uri: cim:BaseVoltage
+    attributes:
+      nominalVoltage:
+        slot_uri: cim:BaseVoltage.nominalVoltage
+        range: Voltage
+        multivalued: false
+        required: true
+        description: The power system resource's base voltage.  Shall be a positive
+          value and not zero.
+      ConductingEquipment:
+        slot_uri: cim:BaseVoltage.ConductingEquipment
+        range: ConductingEquipment
+        multivalued: true
+        required: false
+        description: All conducting equipment with this base voltage.  Use only when
+          there is no voltage level container used and only one base voltage applies.  For
+          example, not used for transformers.
+      VoltageLevel:
+        slot_uri: cim:BaseVoltage.VoltageLevel
+        range: VoltageLevel
+        multivalued: true
+        required: false
+        description: The voltage levels having this base voltage.
+      TransformerEnds:
+        slot_uri: cim:BaseVoltage.TransformerEnds
+        range: TransformerEnd
+        multivalued: true
+        required: false
+        description: Transformer ends at the base voltage.  This is essential for
+          PU calculation.
+    is_a: IdentifiedObject
+    description: Defines a system base voltage which is referenced.
+  BasicIntervalSchedule:
+    class_uri: cim:BasicIntervalSchedule
+    attributes:
+      startTime:
+        slot_uri: cim:BasicIntervalSchedule.startTime
+        range: date
+        multivalued: false
+        required: true
+        description: The time for the first time point.  The value can be a time of
+          day, not a specific date.
+      value1Unit:
+        slot_uri: cim:BasicIntervalSchedule.value1Unit
+        range: UnitSymbol
+        multivalued: false
+        required: true
+        description: Value1 units of measure.
+      value2Unit:
+        slot_uri: cim:BasicIntervalSchedule.value2Unit
+        range: UnitSymbol
+        multivalued: false
+        required: false
+        description: Value2 units of measure.
+    is_a: IdentifiedObject
+    description: Schedule of values at points in time.
+  BatteryUnit:
+    class_uri: cim:BatteryUnit
+    attributes:
+      ratedE:
+        slot_uri: cim:BatteryUnit.ratedE
+        range: RealEnergy
+        multivalued: false
+        required: true
+        description: Full energy storage capacity of the battery. The attribute shall
+          be a positive value.
+    is_a: PowerElectronicsUnit
+    description: An electrochemical energy storage device.
+  RealEnergy:
+    class_uri: cim:RealEnergy
+    attributes:
+      multiplier:
+        slot_uri: cim:RealEnergy.multiplier
+        range: UnitMultiplier
+        multivalued: false
+        required: false
+      unit:
+        slot_uri: cim:RealEnergy.unit
+        range: UnitSymbol
+        multivalued: false
+        required: false
+      value:
+        slot_uri: cim:RealEnergy.value
+        range: float
+        multivalued: false
+        required: false
+    description: Real electrical energy.
+  Bay:
+    class_uri: cim:Bay
+    attributes:
+      VoltageLevel:
+        slot_uri: cim:Bay.VoltageLevel
+        range: VoltageLevel
+        multivalued: false
+        required: true
+        description: The voltage level containing this bay.
+    is_a: EquipmentContainer
+    description: A collection of power system resources (within a given substation)
+      including conducting equipment, protection relays, measurements, and telemetry.  A
+      bay typically represents a physical grouping related to modularization of equipment.
+  BoundaryPoint:
+    class_uri: eu:BoundaryPoint
+    attributes:
+      fromEndIsoCode:
+        slot_uri: eu:BoundaryPoint.fromEndIsoCode
+        range: string
+        multivalued: false
+        required: true
+        description: 'The ISO code of the region which the "From" side of the Boundary
+          point belongs to or it is connected to.
+
+          The ISO code is a two-character country code as defined by ISO 3166 (http://www.iso.org/iso/country_codes).
+          The length of the string is 2 characters maximum.'
+      fromEndName:
+        slot_uri: eu:BoundaryPoint.fromEndName
+        range: string
+        multivalued: false
+        required: true
+        description: 'A human readable name with length of the string 64 characters
+          maximum. It covers the following two cases:
+
+          -if the Boundary point is placed on a tie-line, it is the name (IdentifiedObject.name)
+          of the substation at which the "From" side of the tie-line is connected
+          to.
+
+          -if the Boundary point is placed in a substation, it is the name (IdentifiedObject.name)
+          of the element (e.g. PowerTransformer, ACLineSegment, Switch, etc.) at which
+          the "From" side of the Boundary point is connected to.'
+      fromEndNameTso:
+        slot_uri: eu:BoundaryPoint.fromEndNameTso
+        range: string
+        multivalued: false
+        required: true
+        description: Identifies the name of the transmission system operator, distribution
+          system operator or other entity at which the "From" side of the interconnection
+          is connected to. The length of the string is 64 characters maximum.
+      toEndIsoCode:
+        slot_uri: eu:BoundaryPoint.toEndIsoCode
+        range: string
+        multivalued: false
+        required: true
+        description: 'The ISO code of the region which the "To" side of the Boundary
+          point belongs to or is connected to.
+
+          The ISO code is a two-character country code as defined by ISO 3166 (http://www.iso.org/iso/country_codes).
+          The length of the string is 2 characters maximum.'
+      toEndName:
+        slot_uri: eu:BoundaryPoint.toEndName
+        range: string
+        multivalued: false
+        required: true
+        description: 'A human readable name with length of the string 64 characters
+          maximum. It covers the following two cases:
+
+          -if the Boundary point is placed on a tie-line, it is the name (IdentifiedObject.name)
+          of the substation at which the "To" side of the tie-line is connected to.
+
+          -if the Boundary point is placed in a substation, it is the name (IdentifiedObject.name)
+          of the element (e.g. PowerTransformer, ACLineSegment, Switch, etc.) at which
+          the "To" side of the Boundary point is connected to.'
+      toEndNameTso:
+        slot_uri: eu:BoundaryPoint.toEndNameTso
+        range: string
+        multivalued: false
+        required: true
+        description: Identifies the name of the transmission system operator, distribution
+          system operator or other entity at which the "To" side of the interconnection
+          is connected to. The length of the string is 64 characters maximum.
+      isDirectCurrent:
+        slot_uri: eu:BoundaryPoint.isDirectCurrent
+        range: boolean
+        multivalued: false
+        required: false
+        description: If true, this boundary point is a point of common coupling (PCC)
+          of a direct current (DC) interconnection, otherwise the interconnection
+          is AC (default).
+      isExcludedFromAreaInterchange:
+        slot_uri: eu:BoundaryPoint.isExcludedFromAreaInterchange
+        range: boolean
+        multivalued: false
+        required: false
+        description: If true, this boundary point is on the interconnection that is
+          excluded from control area interchange calculation and consequently has
+          no related tie flows. Otherwise, the interconnection is included in control
+          area interchange and a TieFlow is required at all sides of the boundary
+          point (default).
+      ConnectivityNode:
+        slot_uri: eu:BoundaryPoint.ConnectivityNode
+        range: ConnectivityNode
+        multivalued: false
+        required: true
+        description: The connectivity node that is designated as a boundary point.
+    is_a: PowerSystemResource
+    description: Designates a connection point at which one or more model authority
+      sets shall connect to. The location of the connection point as well as other
+      properties are agreed between organisations responsible for the interconnection,
+      hence all attributes of the class represent this agreement.  It is primarily
+      used in a boundary model authority set which can contain one or many BoundaryPoint-s
+      among other Equipment-s and their connections.
+  Breaker:
+    class_uri: cim:Breaker
+    is_a: ProtectedSwitch
+    description: A mechanical switching device capable of making, carrying, and breaking
+      currents under normal circuit conditions and also making, carrying for a specified
+      time, and breaking currents under specified abnormal circuit conditions e.g.  those
+      of short circuit.
+  BusbarSection:
+    class_uri: cim:BusbarSection
+    is_a: Connector
+    description: "A conductor, or group of conductors, with negligible impedance,\
+      \ that serve to connect other conducting equipment within a single substation.\
+      \ \nVoltage measurements are typically obtained from voltage transformers that\
+      \ are connected to busbar sections. A bus bar section may have many physical\
+      \ terminals but for analysis is modelled with exactly one logical terminal."
+  BusNameMarker:
+    class_uri: cim:BusNameMarker
+    attributes:
+      Terminal:
+        slot_uri: cim:BusNameMarker.Terminal
+        range: ACDCTerminal
+        multivalued: true
+        required: true
+        description: The terminals associated with this bus name marker.
+      priority:
+        slot_uri: cim:BusNameMarker.priority
+        range: integer
+        multivalued: false
+        required: false
+        description: Priority of bus name marker for use as topology bus name.  Use
+          0 for do not care.  Use 1 for highest priority.  Use 2 as priority is less
+          than 1 and so on.
+      ReportingGroup:
+        slot_uri: cim:BusNameMarker.ReportingGroup
+        range: ReportingGroup
+        multivalued: false
+        required: false
+        description: The reporting group to which this bus name marker belongs.
+    is_a: IdentifiedObject
+    description: Used to apply user standard names to TopologicalNodes. Associated
+      with one or more terminals that are normally connected with the bus name.    The
+      associated terminals are normally connected by non-retained switches. For a
+      ring bus station configuration, all BusbarSection terminals in the ring are
+      typically associated.   For a breaker and a half scheme, both BusbarSections
+      would normally be associated.  For a ring bus, all BusbarSections would normally
+      be associated.  For a "straight" busbar configuration, normally only the main
+      terminal at the BusbarSection would be associated.
+  CAESPlant:
+    class_uri: cim:CAESPlant
+    attributes:
+      ThermalGeneratingUnit:
+        slot_uri: cim:CAESPlant.ThermalGeneratingUnit
+        range: ThermalGeneratingUnit
+        multivalued: false
+        required: false
+        description: A thermal generating unit may be a member of a compressed air
+          energy storage plant.
+    is_a: PowerSystemResource
+    description: Compressed air energy storage plant.
+  Clamp:
+    class_uri: cim:Clamp
+    attributes:
+      ACLineSegment:
+        slot_uri: cim:Clamp.ACLineSegment
+        range: ACLineSegment
+        multivalued: false
+        required: true
+        description: The line segment to which the clamp is connected.
+      lengthFromTerminal1:
+        slot_uri: cim:Clamp.lengthFromTerminal1
+        range: Length
+        multivalued: false
+        required: false
+        description: The length to the place where the clamp is located starting from
+          side one of the line segment, i.e. the line segment terminal with sequence
+          number equal to 1.
+    is_a: ConductingEquipment
+    description: "A Clamp is a galvanic connection at a line segment where other equipment\
+      \ is connected. A Clamp does not cut the line segment. \nA Clamp is ConductingEquipment\
+      \ and has one Terminal with an associated ConnectivityNode. Any other ConductingEquipment\
+      \ can be connected to the Clamp ConnectivityNode."
+  Length:
+    class_uri: cim:Length
+    attributes:
+      value:
+        slot_uri: cim:Length.value
+        range: float
+        multivalued: false
+        required: false
+      unit:
+        slot_uri: cim:Length.unit
+        range: UnitSymbol
+        multivalued: false
+        required: false
+      multiplier:
+        slot_uri: cim:Length.multiplier
+        range: UnitMultiplier
+        multivalued: false
+        required: false
+    description: Unit of length. It shall be a positive value or zero.
+  ConformLoadSchedule:
+    class_uri: cim:ConformLoadSchedule
+    attributes:
+      ConformLoadGroup:
+        slot_uri: cim:ConformLoadSchedule.ConformLoadGroup
+        range: ConformLoadGroup
+        multivalued: false
+        required: true
+        description: The ConformLoadGroup where the ConformLoadSchedule belongs.
+    is_a: SeasonDayTypeSchedule
+    description: A curve of load  versus time (X-axis) showing the active power values
+      (Y1-axis) and reactive power (Y2-axis) for each unit of the period covered.
+      This curve represents a typical pattern of load over the time period for a given
+      day type and season.
+  CogenerationPlant:
+    class_uri: cim:CogenerationPlant
+    attributes:
+      ThermalGeneratingUnits:
+        slot_uri: cim:CogenerationPlant.ThermalGeneratingUnits
+        range: ThermalGeneratingUnit
+        multivalued: true
+        required: false
+        description: A thermal generating unit may be a member of a cogeneration plant.
+    is_a: PowerSystemResource
+    description: A set of thermal generating units for the production of electrical
+      energy and process steam (usually from the output of the steam turbines). The
+      steam sendout is typically used for industrial purposes or for municipal heating
+      and cooling.
+  CombinedCyclePlant:
+    class_uri: cim:CombinedCyclePlant
+    attributes:
+      ThermalGeneratingUnits:
+        slot_uri: cim:CombinedCyclePlant.ThermalGeneratingUnits
+        range: ThermalGeneratingUnit
+        multivalued: true
+        required: false
+        description: A thermal generating unit may be a member of a combined cycle
+          plant.
+    is_a: PowerSystemResource
+    description: A set of combustion turbines and steam turbines where the exhaust
+      heat from the combustion turbines is recovered to make steam for the steam turbines,
+      resulting in greater overall plant efficiency.
+  ConductingEquipment:
+    class_uri: cim:ConductingEquipment
+    attributes:
+      BaseVoltage:
+        slot_uri: cim:ConductingEquipment.BaseVoltage
+        range: BaseVoltage
+        multivalued: false
+        required: false
+        description: Base voltage of this conducting equipment.  Use only when there
+          is no voltage level container used and only one base voltage applies.  For
+          example, not used for transformers.
+      Terminals:
+        slot_uri: cim:ConductingEquipment.Terminals
+        range: Terminal
+        multivalued: true
+        required: false
+        description: Conducting equipment have terminals that may be connected to
+          other conducting equipment terminals via connectivity nodes or topological
+          nodes.
+    is_a: Equipment
+    description: The parts of the AC power system that are designed to carry current
+      or that are conductively connected through terminals.
+  Conductor:
+    class_uri: cim:Conductor
+    attributes:
+      length:
+        slot_uri: cim:Conductor.length
+        range: Length
+        multivalued: false
+        required: false
+        description: Segment length for calculating line section capabilities.
+    is_a: ConductingEquipment
+    description: Combination of conducting material with consistent electrical characteristics,
+      building a single electrical system, used to carry current between points in
+      the power system.
+  ConformLoad:
+    class_uri: cim:ConformLoad
+    attributes:
+      LoadGroup:
+        slot_uri: cim:ConformLoad.LoadGroup
+        range: ConformLoadGroup
+        multivalued: false
+        required: true
+        description: Group of this ConformLoad.
+    is_a: EnergyConsumer
+    description: ConformLoad represent loads that follow a daily load change pattern
+      where the pattern can be used to scale the load with a system load.
+  ConformLoadGroup:
+    class_uri: cim:ConformLoadGroup
+    attributes:
+      ConformLoadSchedules:
+        slot_uri: cim:ConformLoadGroup.ConformLoadSchedules
+        range: ConformLoadSchedule
+        multivalued: true
+        required: false
+        description: The ConformLoadSchedules in the ConformLoadGroup.
+      EnergyConsumers:
+        slot_uri: cim:ConformLoadGroup.EnergyConsumers
+        range: ConformLoad
+        multivalued: true
+        required: true
+        description: Conform loads assigned to this ConformLoadGroup.
+    is_a: LoadGroup
+    description: A group of loads conforming to an allocation pattern.
+  ConnectivityNode:
+    class_uri: cim:ConnectivityNode
+    attributes:
+      BoundaryPoint:
+        slot_uri: eu:ConnectivityNode.BoundaryPoint
+        range: BoundaryPoint
+        multivalued: false
+        required: false
+        description: The boundary point associated with the connectivity node.
+      Terminals:
+        slot_uri: cim:ConnectivityNode.Terminals
+        range: Terminal
+        multivalued: true
+        required: false
+        description: Terminals interconnected with zero impedance at a this connectivity
+          node.
+      ConnectivityNodeContainer:
+        slot_uri: cim:ConnectivityNode.ConnectivityNodeContainer
+        range: ConnectivityNodeContainer
+        multivalued: false
+        required: true
+        description: Container of this connectivity node.
+    is_a: IdentifiedObject
+    description: Connectivity nodes are points where terminals of AC conducting equipment
+      are connected together with zero impedance.
+  ConnectivityNodeContainer:
+    class_uri: cim:ConnectivityNodeContainer
+    attributes:
+      ConnectivityNodes:
+        slot_uri: cim:ConnectivityNodeContainer.ConnectivityNodes
+        range: ConnectivityNode
+        multivalued: true
+        required: false
+        description: Connectivity nodes which belong to this connectivity node container.
+    is_a: PowerSystemResource
+    description: A base class for all objects that may contain connectivity nodes
+      or topological nodes.
+  Connector:
+    class_uri: cim:Connector
+    is_a: ConductingEquipment
+    description: A conductor, or group of conductors, with negligible impedance, that
+      serve to connect other conducting equipment within a single substation and are
+      modelled with a single logical terminal.
+  ControlArea:
+    class_uri: cim:ControlArea
+    attributes:
+      type:
+        slot_uri: cim:ControlArea.type
+        range: ControlAreaTypeKind
+        multivalued: false
+        required: true
+        description: The primary type of control area definition used to determine
+          if this is used for automatic generation control, for planning interchange
+          control, or other purposes.   A control area specified with primary type
+          of automatic generation control could still be forecast and used as an interchange
+          area in power flow analysis.
+      TieFlow:
+        slot_uri: cim:ControlArea.TieFlow
+        range: TieFlow
+        multivalued: true
+        required: false
+        description: The tie flows associated with the control area.
+      ControlAreaGeneratingUnit:
+        slot_uri: cim:ControlArea.ControlAreaGeneratingUnit
+        range: ControlAreaGeneratingUnit
+        multivalued: true
+        required: false
+        description: The generating unit specifications for the control area.
+      EnergyArea:
+        slot_uri: cim:ControlArea.EnergyArea
+        range: EnergyArea
+        multivalued: false
+        required: true
+        description: The energy area that is forecast from this control area specification.
+    is_a: PowerSystemResource
+    description: 'A control area is a grouping of generating units and/or loads and
+      a cutset of tie lines (as terminals) which may be used for a variety of purposes
+      including automatic generation control, power flow solution area interchange
+      control specification, and input to load forecasting. All generation and load
+      within the area defined by the terminals on the border are considered in the
+      area interchange control. Note that any number of overlapping control area specifications
+      can be superimposed on the physical model. The following general principles
+      apply to ControlArea:
+
+      1.  The control area orientation for net interchange is positive for an import,
+      negative for an export.
+
+      2.  The control area net interchange is determined by summing flows in Terminals.
+      The Terminals are identified by creating a set of TieFlow objects associated
+      with a ControlArea object. Each TieFlow object identifies one Terminal.
+
+      3.  In a single network model, a tie between two control areas must be modelled
+      in both control area specifications, such that the two representations of the
+      tie flow sum to zero.
+
+      4.  The normal orientation of Terminal flow is positive for flow into the conducting
+      equipment that owns the Terminal. (i.e. flow from a bus into a device is positive.)
+      However, the orientation of each flow in the control area specification must
+      align with the control area convention, i.e. import is positive. If the orientation
+      of the Terminal flow referenced by a TieFlow is positive into the control area,
+      then this is confirmed by setting TieFlow.positiveFlowIn flag TRUE. If not,
+      the orientation must be reversed by setting the TieFlow.positiveFlowIn flag
+      FALSE.'
+  ControlAreaGeneratingUnit:
+    class_uri: cim:ControlAreaGeneratingUnit
+    attributes:
+      ControlArea:
+        slot_uri: cim:ControlAreaGeneratingUnit.ControlArea
+        range: ControlArea
+        multivalued: false
+        required: true
+        description: The parent control area for the generating unit specifications.
+      GeneratingUnit:
+        slot_uri: cim:ControlAreaGeneratingUnit.GeneratingUnit
+        range: GeneratingUnit
+        multivalued: false
+        required: true
+        description: The generating unit specified for this control area.  Note that
+          a control area should include a GeneratingUnit only once.
+    is_a: IdentifiedObject
+    description: A control area generating unit. This class is needed so that alternate
+      control area definitions may include the same generating unit.   It should be
+      noted that only one instance within a control area should reference a specific
+      generating unit.
+  CsConverter:
+    class_uri: cim:CsConverter
+    attributes:
+      maxAlpha:
+        slot_uri: cim:CsConverter.maxAlpha
+        range: AngleDegrees
+        multivalued: false
+        required: false
+        description: "Maximum firing angle. It is converter\u2019s configuration data\
+          \ used in power flow. The attribute shall be a positive value."
+      maxGamma:
+        slot_uri: cim:CsConverter.maxGamma
+        range: AngleDegrees
+        multivalued: false
+        required: false
+        description: "Maximum extinction angle. It is converter\u2019s configuration\
+          \ data used in power flow. The attribute shall be a positive value."
+      maxIdc:
+        slot_uri: cim:CsConverter.maxIdc
+        range: CurrentFlow
+        multivalued: false
+        required: false
+        description: "The maximum direct current (Id) on the DC side at which the\
+          \ converter should operate. It is converter\u2019s configuration data use\
+          \ in power flow. The attribute shall be a positive value."
+      minAlpha:
+        slot_uri: cim:CsConverter.minAlpha
+        range: AngleDegrees
+        multivalued: false
+        required: false
+        description: "Minimum firing angle. It is converter\u2019s configuration data\
+          \ used in power flow. The attribute shall be a positive value."
+      minGamma:
+        slot_uri: cim:CsConverter.minGamma
+        range: AngleDegrees
+        multivalued: false
+        required: false
+        description: "Minimum extinction angle. It is converter\u2019s configuration\
+          \ data used in power flow. The attribute shall be a positive value."
+      minIdc:
+        slot_uri: cim:CsConverter.minIdc
+        range: CurrentFlow
+        multivalued: false
+        required: false
+        description: "The minimum direct current (Id) on the DC side at which the\
+          \ converter should operate. It is converter\u2019s configuration data used\
+          \ in power flow. The attribute shall be a positive value."
+      ratedIdc:
+        slot_uri: cim:CsConverter.ratedIdc
+        range: CurrentFlow
+        multivalued: false
+        required: false
+        description: "Rated converter DC current, also called IdN. The attribute shall\
+          \ be a positive value. It is converter\u2019s configuration data used in\
+          \ power flow."
+    is_a: ACDCConverter
+    description: 'DC side of the current source converter (CSC).
+
+      The firing angle controls the dc voltage at the converter, both for rectifier
+      and inverter. The difference between the dc voltages of the rectifier and inverter
+      determines the dc current. The extinction angle is used to limit the dc voltage
+      at the inverter, if needed, and is not used in active power control. The firing
+      angle, transformer tap position and number of connected filters are the primary
+      means to control a current source dc line. Higher level controls are built on
+      top, e.g. dc voltage, dc current and active power. From a steady state perspective
+      it is sufficient to specify the wanted active power transfer (ACDCConverter.targetPpcc)
+      and the control functions will set the dc voltage, dc current, firing angle,
+      transformer tap position and number of connected filters to meet this. Therefore
+      attributes targetAlpha and targetGamma are not applicable in this case.
+
+      The reactive power consumed by the converter is a function of the firing angle,
+      transformer tap position and number of connected filter, which can be approximated
+      with half of the active power. The losses is a function of the dc voltage and
+      dc current.
+
+      The attributes minAlpha and maxAlpha define the range of firing angles for rectifier
+      operation between which no discrete tap changer action takes place. The range
+      is typically 10-18 degrees.
+
+      The attributes minGamma and maxGamma define the range of extinction angles for
+      inverter operation between which no discrete tap changer action takes place.
+      The range is typically 17-20 degrees.'
+  AngleDegrees:
+    class_uri: cim:AngleDegrees
+    attributes:
+      value:
+        slot_uri: cim:AngleDegrees.value
+        range: float
+        multivalued: false
+        required: false
+      unit:
+        slot_uri: cim:AngleDegrees.unit
+        range: UnitSymbol
+        multivalued: false
+        required: false
+      multiplier:
+        slot_uri: cim:AngleDegrees.multiplier
+        range: UnitMultiplier
+        multivalued: false
+        required: false
+    description: Measurement of angle in degrees.
+  CurrentFlow:
+    class_uri: cim:CurrentFlow
+    attributes:
+      value:
+        slot_uri: cim:CurrentFlow.value
+        range: float
+        multivalued: false
+        required: false
+      multiplier:
+        slot_uri: cim:CurrentFlow.multiplier
+        range: UnitMultiplier
+        multivalued: false
+        required: false
+      unit:
+        slot_uri: cim:CurrentFlow.unit
+        range: UnitSymbol
+        multivalued: false
+        required: false
+    description: 'Electrical current with sign convention: positive flow is out of
+      the conducting equipment into the connectivity node. Can be both AC and DC.'
+  CurrentLimit:
+    class_uri: cim:CurrentLimit
+    attributes:
+      normalValue:
+        slot_uri: cim:CurrentLimit.normalValue
+        range: CurrentFlow
+        multivalued: false
+        required: true
+        description: The normal value for limit on current flow. The attribute shall
+          be a positive value or zero.
+    is_a: OperationalLimit
+    description: Operational limit on current.
+  CurrentTransformer:
+    class_uri: cim:CurrentTransformer
+    is_a: Sensor
+    description: Instrument transformer used to measure electrical qualities of the
+      circuit that is being protected and/or monitored. Typically used as current
+      transducer for the purpose of metering or protection. A typical secondary current
+      rating would be 5A.
+  Curve:
+    class_uri: cim:Curve
+    attributes:
+      curveStyle:
+        slot_uri: cim:Curve.curveStyle
+        range: CurveStyle
+        multivalued: false
+        required: true
+        description: The style or shape of the curve.
+      xUnit:
+        slot_uri: cim:Curve.xUnit
+        range: UnitSymbol
+        multivalued: false
+        required: true
+        description: The X-axis units of measure.
+      y1Unit:
+        slot_uri: cim:Curve.y1Unit
+        range: UnitSymbol
+        multivalued: false
+        required: true
+        description: The Y1-axis units of measure.
+      y2Unit:
+        slot_uri: cim:Curve.y2Unit
+        range: UnitSymbol
+        multivalued: false
+        required: false
+        description: The Y2-axis units of measure.
+      CurveDatas:
+        slot_uri: cim:Curve.CurveDatas
+        range: CurveData
+        multivalued: true
+        required: true
+        description: The point data values that define this curve.
+    is_a: IdentifiedObject
+    description: A multi-purpose curve or functional relationship between an independent
+      variable (X-axis) and dependent (Y-axis) variables.
+  CurveData:
+    class_uri: cim:CurveData
+    attributes:
+      Curve:
+        slot_uri: cim:CurveData.Curve
+        range: Curve
+        multivalued: false
+        required: true
+        description: The curve of  this curve data point.
+      xvalue:
+        slot_uri: cim:CurveData.xvalue
+        range: float
+        multivalued: false
+        required: true
+        description: The data value of the X-axis variable,  depending on the X-axis
+          units.
+      y1value:
+        slot_uri: cim:CurveData.y1value
+        range: float
+        multivalued: false
+        required: true
+        description: The data value of the  first Y-axis variable, depending on the
+          Y-axis units.
+      y2value:
+        slot_uri: cim:CurveData.y2value
+        range: float
+        multivalued: false
+        required: false
+        description: The data value of the second Y-axis variable (if present), depending
+          on the Y-axis units.
+    description: Multi-purpose data points for defining a curve.  The use of this
+      generic class is discouraged if a more specific class can be used to specify
+      the X and Y axis values along with their specific data types.
+  Cut:
+    class_uri: cim:Cut
+    attributes:
+      ACLineSegment:
+        slot_uri: cim:Cut.ACLineSegment
+        range: ACLineSegment
+        multivalued: false
+        required: true
+        description: The line segment to which the cut is applied.
+      lengthFromTerminal1:
+        slot_uri: cim:Cut.lengthFromTerminal1
+        range: Length
+        multivalued: false
+        required: false
+        description: The length to the place where the cut is located starting from
+          side one of the cut line segment, i.e. the line segment Terminal with sequenceNumber
+          equal to 1.
+    is_a: Switch
+    description: 'A cut separates a line segment into two parts. The cut appears as
+      a switch inserted between these two parts and connects them together. As the
+      cut is normally open there is no galvanic connection between the two line segment
+      parts. But it is possible to close the cut to get galvanic connection.
+
+      The cut terminals are oriented towards the line segment terminals with the same
+      sequence number. Hence the cut terminal with sequence number equal to 1 is oriented
+      to the line segment''s terminal with sequence number equal to 1.
+
+      The cut terminals also act as connection points for jumpers and other equipment,
+      e.g. a mobile generator. To enable this, connectivity nodes are placed at the
+      cut terminals. Once the connectivity nodes are in place any conducting equipment
+      can be connected at them.'
+  DayType:
+    class_uri: cim:DayType
+    attributes:
+      SeasonDayTypeSchedules:
+        slot_uri: cim:DayType.SeasonDayTypeSchedules
+        range: SeasonDayTypeSchedule
+        multivalued: true
+        required: false
+        description: Schedules that use this DayType.
+    is_a: IdentifiedObject
+    description: Group of similar days.   For example it could be used to represent
+      weekdays, weekend, or holidays.
+  DCBaseTerminal:
+    class_uri: cim:DCBaseTerminal
+    attributes:
+      DCNode:
+        slot_uri: cim:DCBaseTerminal.DCNode
+        range: DCNode
+        multivalued: false
+        required: false
+        description: The DC connectivity node to which this DC base terminal connects
+          with zero impedance.
+    is_a: ACDCTerminal
+    description: An electrical connection point at a piece of DC conducting equipment.
+      DC terminals are connected at one physical DC node that may have multiple DC
+      terminals connected. A DC node is similar to an AC connectivity node. The model
+      requires that DC connections are distinct from AC connections.
+  DCBreaker:
+    class_uri: cim:DCBreaker
+    is_a: DCSwitch
+    description: A breaker within a DC system.
+  DCBusbar:
+    class_uri: cim:DCBusbar
+    is_a: DCConductingEquipment
+    description: A busbar within a DC system.
+  DCChopper:
+    class_uri: cim:DCChopper
+    is_a: DCConductingEquipment
+    description: Low resistance equipment used in the internal DC circuit to balance
+      voltages. It has typically positive and negative pole terminals and a ground.
+  DCConductingEquipment:
+    class_uri: cim:DCConductingEquipment
+    attributes:
+      ratedUdc:
+        slot_uri: cim:DCConductingEquipment.ratedUdc
+        range: Voltage
+        multivalued: false
+        required: true
+        description: Rated DC device voltage. The attribute shall be a positive value.
+          It is configuration data used in power flow.
+      DCTerminals:
+        slot_uri: cim:DCConductingEquipment.DCTerminals
+        range: DCTerminal
+        multivalued: true
+        required: false
+        description: A DC conducting equipment has DC terminals.
+    is_a: Equipment
+    description: The parts of the DC power system that are designed to carry current
+      or that are conductively connected through DC terminals.
+  DCConverterUnit:
+    class_uri: cim:DCConverterUnit
+    attributes:
+      operationMode:
+        slot_uri: cim:DCConverterUnit.operationMode
+        range: DCConverterOperatingModeKind
+        multivalued: false
+        required: true
+        description: The operating mode of an HVDC bipole (bipolar, monopolar metallic
+          return, etc).
+      Substation:
+        slot_uri: cim:DCConverterUnit.Substation
+        range: Substation
+        multivalued: false
+        required: false
+        description: The containing substation of the DC converter unit.
+    is_a: DCEquipmentContainer
+    description: "Indivisible operative unit comprising all equipment between the\
+      \ point of common coupling on the AC side and the point of common coupling \u2013\
+      \ DC side, essentially one or more converters, together with one or more converter\
+      \ transformers, converter control equipment, essential protective and switching\
+      \ devices and auxiliaries, if any, used for conversion."
+  DCDisconnector:
+    class_uri: cim:DCDisconnector
+    is_a: DCSwitch
+    description: A disconnector within a DC system.
+  DCEquipmentContainer:
+    class_uri: cim:DCEquipmentContainer
+    attributes:
+      DCNodes:
+        slot_uri: cim:DCEquipmentContainer.DCNodes
+        range: DCNode
+        multivalued: true
+        required: false
+        description: The DC nodes contained in the DC equipment container.
+    is_a: EquipmentContainer
+    description: A modelling construct to provide a root class for containment of
+      DC as well as AC equipment. The class differ from the EquipmentContaner for
+      AC in that it may also contain DCNode-s. Hence it can contain both AC and DC
+      equipment.
+  DCGround:
+    class_uri: cim:DCGround
+    attributes:
+      inductance:
+        slot_uri: cim:DCGround.inductance
+        range: Inductance
+        multivalued: false
+        required: false
+        description: Inductance to ground.
+      r:
+        slot_uri: cim:DCGround.r
+        range: Resistance
+        multivalued: false
+        required: false
+        description: Resistance to ground.
+    is_a: DCConductingEquipment
+    description: A ground within a DC system.
+  Inductance:
+    class_uri: cim:Inductance
+    attributes:
+      value:
+        slot_uri: cim:Inductance.value
+        range: float
+        multivalued: false
+        required: false
+      unit:
+        slot_uri: cim:Inductance.unit
+        range: UnitSymbol
+        multivalued: false
+        required: false
+      multiplier:
+        slot_uri: cim:Inductance.multiplier
+        range: UnitMultiplier
+        multivalued: false
+        required: false
+    description: Inductive part of reactance (imaginary part of impedance), at rated
+      frequency.
+  DCLine:
+    class_uri: cim:DCLine
+    attributes:
+      Region:
+        slot_uri: cim:DCLine.Region
+        range: SubGeographicalRegion
+        multivalued: false
+        required: false
+        description: The SubGeographicalRegion containing the DC line.
+    is_a: DCEquipmentContainer
+    description: Overhead lines and/or cables connecting two or more HVDC substations.
+  DCLineSegment:
+    class_uri: cim:DCLineSegment
+    attributes:
+      capacitance:
+        slot_uri: cim:DCLineSegment.capacitance
+        range: Capacitance
+        multivalued: false
+        required: true
+        description: Capacitance of the DC line segment. Significant for cables only.
+      inductance:
+        slot_uri: cim:DCLineSegment.inductance
+        range: Inductance
+        multivalued: false
+        required: true
+        description: Inductance of the DC line segment. Negligible compared with DCSeriesDevice
+          used for smoothing.
+      resistance:
+        slot_uri: cim:DCLineSegment.resistance
+        range: Resistance
+        multivalued: false
+        required: true
+        description: Resistance of the DC line segment.
+      length:
+        slot_uri: cim:DCLineSegment.length
+        range: Length
+        multivalued: false
+        required: false
+        description: Segment length for calculating line section capabilities.
+    is_a: DCConductingEquipment
+    description: A wire or combination of wires not insulated from one another, with
+      consistent electrical characteristics, used to carry direct current between
+      points in the DC region of the power system.
+  Capacitance:
+    class_uri: cim:Capacitance
+    attributes:
+      value:
+        slot_uri: cim:Capacitance.value
+        range: float
+        multivalued: false
+        required: false
+      unit:
+        slot_uri: cim:Capacitance.unit
+        range: UnitSymbol
+        multivalued: false
+        required: false
+      multiplier:
+        slot_uri: cim:Capacitance.multiplier
+        range: UnitMultiplier
+        multivalued: false
+        required: false
+    description: Capacitive part of reactance (imaginary part of impedance), at rated
+      frequency.
+  DCNode:
+    class_uri: cim:DCNode
+    attributes:
+      DCTerminals:
+        slot_uri: cim:DCNode.DCTerminals
+        range: DCBaseTerminal
+        multivalued: true
+        required: false
+        description: DC base terminals interconnected with zero impedance at a this
+          DC connectivity node.
+      DCEquipmentContainer:
+        slot_uri: cim:DCNode.DCEquipmentContainer
+        range: DCEquipmentContainer
+        multivalued: false
+        required: true
+        description: The DC container for the DC nodes.
+    is_a: IdentifiedObject
+    description: DC nodes are points where terminals of DC conducting equipment are
+      connected together with zero impedance.
+  RegulationSchedule:
+    class_uri: cim:RegulationSchedule
+    attributes:
+      RegulatingControl:
+        slot_uri: cim:RegulationSchedule.RegulatingControl
+        range: RegulatingControl
+        multivalued: false
+        required: true
+        description: Regulating controls that have this schedule.
+    is_a: SeasonDayTypeSchedule
+    description: A pre-established pattern over time for a controlled variable, e.g.,
+      busbar voltage.
+  DCSeriesDevice:
+    class_uri: cim:DCSeriesDevice
+    attributes:
+      inductance:
+        slot_uri: cim:DCSeriesDevice.inductance
+        range: Inductance
+        multivalued: false
+        required: true
+        description: Inductance of the device.
+      resistance:
+        slot_uri: cim:DCSeriesDevice.resistance
+        range: Resistance
+        multivalued: false
+        required: true
+        description: Resistance of the DC device.
+    is_a: DCConductingEquipment
+    description: A series device within the DC system, typically a reactor used for
+      filtering or smoothing.  Needed for transient and short circuit studies.
+  DCShunt:
+    class_uri: cim:DCShunt
+    attributes:
+      capacitance:
+        slot_uri: cim:DCShunt.capacitance
+        range: Capacitance
+        multivalued: false
+        required: true
+        description: Capacitance of the DC shunt.
+      resistance:
+        slot_uri: cim:DCShunt.resistance
+        range: Resistance
+        multivalued: false
+        required: true
+        description: Resistance of the DC device.
+    is_a: DCConductingEquipment
+    description: A shunt device within the DC system, typically used for filtering.  Needed
+      for transient and short circuit studies.
+  DCSwitch:
+    class_uri: cim:DCSwitch
+    is_a: DCConductingEquipment
+    description: A switch within the DC system.
+  DCTerminal:
+    class_uri: cim:DCTerminal
+    attributes:
+      DCConductingEquipment:
+        slot_uri: cim:DCTerminal.DCConductingEquipment
+        range: DCConductingEquipment
+        multivalued: false
+        required: true
+        description: An DC  terminal belong to a DC conducting equipment.
+    is_a: DCBaseTerminal
+    description: An electrical connection point to generic DC conducting equipment.
+  Disconnector:
+    class_uri: cim:Disconnector
+    is_a: Switch
+    description: A manually operated or motor operated mechanical switching device
+      used for changing the connections in a circuit, or for isolating a circuit or
+      equipment from a source of power. It is required to open or close circuits when
+      negligible current is broken or made.
+  DisconnectingCircuitBreaker:
+    class_uri: cim:DisconnectingCircuitBreaker
+    is_a: Breaker
+    description: A circuit breaking device including disconnecting function, eliminating
+      the need for separate disconnectors.
+  EarthFaultCompensator:
+    class_uri: cim:EarthFaultCompensator
+    is_a: ConductingEquipment
+    description: A conducting equipment used to represent a connection to ground which
+      is typically used to compensate earth faults.   An earth fault compensator device
+      modelled with a single terminal implies a second terminal solidly connected
+      to ground.  If two terminals are modelled, the ground is not assumed and normal
+      connection rules apply.
+  EnergyArea:
+    class_uri: cim:EnergyArea
+    attributes:
+      ControlArea:
+        slot_uri: cim:EnergyArea.ControlArea
+        range: ControlArea
+        multivalued: false
+        required: false
+        description: The control area specification that is used for the load forecast.
+    is_a: IdentifiedObject
+    description: Describes an area having energy production or consumption.  Specializations
+      are intended to support the load allocation function as typically required in
+      energy management systems or planning studies to allocate hypothesized load
+      levels to individual load points for power flow analysis.  Often the energy
+      area can be linked to both measured and forecast load levels.
+  EnergyConnection:
+    class_uri: cim:EnergyConnection
+    is_a: ConductingEquipment
+    description: A connection of energy generation or consumption on the power system
+      model.
+  EnergyConsumer:
+    class_uri: cim:EnergyConsumer
+    attributes:
+      pfixed:
+        slot_uri: cim:EnergyConsumer.pfixed
+        range: ActivePower
+        multivalued: false
+        required: false
+        description: Active power of the load that is a fixed quantity and does not
+          vary as load group value varies. Load sign convention is used, i.e. positive
+          sign means flow out from a node.
+      pfixedPct:
+        slot_uri: cim:EnergyConsumer.pfixedPct
+        range: PerCent
+        multivalued: false
+        required: false
+        description: Fixed active power as a percentage of load group fixed active
+          power. Used to represent the time-varying components.  Load sign convention
+          is used, i.e. positive sign means flow out from a node.
+      qfixed:
+        slot_uri: cim:EnergyConsumer.qfixed
+        range: ReactivePower
+        multivalued: false
+        required: false
+        description: Reactive power of the load that is a fixed quantity and does
+          not vary as load group value varies. Load sign convention is used, i.e.
+          positive sign means flow out from a node.
+      qfixedPct:
+        slot_uri: cim:EnergyConsumer.qfixedPct
+        range: PerCent
+        multivalued: false
+        required: false
+        description: Fixed reactive power as a percentage of load group fixed reactive
+          power. Used to represent the time-varying components.  Load sign convention
+          is used, i.e. positive sign means flow out from a node.
+      LoadResponse:
+        slot_uri: cim:EnergyConsumer.LoadResponse
+        range: LoadResponseCharacteristic
+        multivalued: false
+        required: false
+        description: The load response characteristic of this load.  If missing, this
+          load is assumed to be constant power.
+    is_a: EnergyConnection
+    description: 'Generic user of energy - a  point of consumption on the power system
+      model.
+
+      EnergyConsumer.pfixed, .qfixed, .pfixedPct and .qfixedPct have meaning only
+      if there is no LoadResponseCharacteristic associated with EnergyConsumer or
+      if LoadResponseCharacteristic.exponentModel is set to False.'
+  PerCent:
+    class_uri: cim:PerCent
+    attributes:
+      value:
+        slot_uri: cim:PerCent.value
+        range: float
+        multivalued: false
+        required: false
+        description: Normally 0 to 100 on a defined base.
+      unit:
+        slot_uri: cim:PerCent.unit
+        range: UnitSymbol
+        multivalued: false
+        required: false
+      multiplier:
+        slot_uri: cim:PerCent.multiplier
+        range: UnitMultiplier
+        multivalued: false
+        required: false
+    description: Percentage on a defined base.   For example, specify as 100 to indicate
+      at the defined base.
+  ReactivePower:
+    class_uri: cim:ReactivePower
+    attributes:
+      value:
+        slot_uri: cim:ReactivePower.value
+        range: float
+        multivalued: false
+        required: false
+      unit:
+        slot_uri: cim:ReactivePower.unit
+        range: UnitSymbol
+        multivalued: false
+        required: false
+      multiplier:
+        slot_uri: cim:ReactivePower.multiplier
+        range: UnitMultiplier
+        multivalued: false
+        required: false
+    description: Product of RMS value of the voltage and the RMS value of the quadrature
+      component of the current.
+  EnergySchedulingType:
+    class_uri: cim:EnergySchedulingType
+    attributes:
+      EnergySource:
+        slot_uri: cim:EnergySchedulingType.EnergySource
+        range: EnergySource
+        multivalued: true
+        required: false
+        description: Energy Source of a particular Energy Scheduling Type.
+    is_a: IdentifiedObject
+    description: Used to define the type of generation for scheduling purposes.
+  TapSchedule:
+    class_uri: cim:TapSchedule
+    attributes:
+      TapChanger:
+        slot_uri: cim:TapSchedule.TapChanger
+        range: TapChanger
+        multivalued: false
+        required: true
+        description: A TapSchedule is associated with a TapChanger.
+    is_a: SeasonDayTypeSchedule
+    description: A pre-established pattern over time for a tap step.
+  EnergySource:
+    class_uri: cim:EnergySource
+    attributes:
+      EnergySchedulingType:
+        slot_uri: cim:EnergySource.EnergySchedulingType
+        range: EnergySchedulingType
+        multivalued: false
+        required: false
+        description: Energy Scheduling Type of an Energy Source.
+      nominalVoltage:
+        slot_uri: cim:EnergySource.nominalVoltage
+        range: Voltage
+        multivalued: false
+        required: false
+        description: Phase-to-phase nominal voltage.
+      pMin:
+        slot_uri: cim:EnergySource.pMin
+        range: ActivePower
+        multivalued: false
+        required: false
+        description: This is the minimum active power that can be produced by the
+          source. Load sign convention is used, i.e. positive sign means flow out
+          from a TopologicalNode (bus) into the conducting equipment.
+      pMax:
+        slot_uri: cim:EnergySource.pMax
+        range: ActivePower
+        multivalued: false
+        required: false
+        description: This is the maximum active power that can be produced by the
+          source. Load sign convention is used, i.e. positive sign means flow out
+          from a TopologicalNode (bus) into the conducting equipment.
+    is_a: EnergyConnection
+    description: A generic equivalent for an energy supplier on a transmission or
+      distribution voltage level.
+  Equipment:
+    class_uri: cim:Equipment
+    attributes:
+      aggregate:
+        slot_uri: cim:Equipment.aggregate
+        range: boolean
+        multivalued: false
+        required: false
+        description: "The aggregate flag provides an alternative way of representing\
+          \ an aggregated (equivalent) element. It is applicable in cases when the\
+          \ dedicated classes for equivalent equipment do not have all of the attributes\
+          \ necessary to represent the required level of detail.  In case the flag\
+          \ is set to \u201Ctrue\u201D the single instance of equipment represents\
+          \ multiple pieces of equipment that have been modelled together as an aggregate\
+          \ equivalent obtained by a network reduction procedure. Examples would be\
+          \ power transformers or synchronous machines operating in parallel modelled\
+          \ as a single aggregate power transformer or aggregate synchronous machine.\
+          \  \nThe attribute is not used for EquivalentBranch, EquivalentShunt and\
+          \ EquivalentInjection."
+      normallyInService:
+        slot_uri: cim:Equipment.normallyInService
+        range: boolean
+        multivalued: false
+        required: false
+        description: Specifies the availability of the equipment under normal operating
+          conditions. True means the equipment is available for topology processing,
+          which determines if the equipment is energized or not. False means that
+          the equipment is treated by network applications as if it is not in the
+          model.
+      EquipmentContainer:
+        slot_uri: cim:Equipment.EquipmentContainer
+        range: EquipmentContainer
+        multivalued: false
+        required: false
+        description: Container of this equipment.
+      OperationalLimitSet:
+        slot_uri: cim:Equipment.OperationalLimitSet
+        range: OperationalLimitSet
+        multivalued: true
+        required: false
+        description: The operational limit sets associated with this equipment.
+    is_a: PowerSystemResource
+    description: The parts of a power system that are physical devices, electronic
+      or mechanical.
+  EquipmentContainer:
+    class_uri: cim:EquipmentContainer
+    attributes:
+      Equipments:
+        slot_uri: cim:EquipmentContainer.Equipments
+        range: Equipment
+        multivalued: true
+        required: false
+        description: Contained equipment.
+    is_a: ConnectivityNodeContainer
+    description: A modelling construct to provide a root class for containing equipment.
+  EquivalentBranch:
+    class_uri: cim:EquivalentBranch
+    attributes:
+      r:
+        slot_uri: cim:EquivalentBranch.r
+        range: Resistance
+        multivalued: false
+        required: true
+        description: Positive sequence series resistance of the reduced branch.
+      r21:
+        slot_uri: cim:EquivalentBranch.r21
+        range: Resistance
+        multivalued: false
+        required: false
+        description: 'Resistance from terminal sequence 2 to terminal sequence 1 .Used
+          for steady state power flow. This attribute is optional and represent unbalanced
+          network such as off-nominal phase shifter. If only EquivalentBranch.r is
+          given, then EquivalentBranch.r21 is assumed equal to EquivalentBranch.r.
+
+          Usage rule : EquivalentBranch is a result of network reduction prior to
+          the data exchange.'
+      x:
+        slot_uri: cim:EquivalentBranch.x
+        range: Reactance
+        multivalued: false
+        required: true
+        description: Positive sequence series reactance of the reduced branch.
+      x21:
+        slot_uri: cim:EquivalentBranch.x21
+        range: Reactance
+        multivalued: false
+        required: false
+        description: 'Reactance from terminal sequence 2 to terminal sequence 1. Used
+          for steady state power flow. This attribute is optional and represents an
+          unbalanced network such as off-nominal phase shifter. If only EquivalentBranch.x
+          is given, then EquivalentBranch.x21 is assumed equal to EquivalentBranch.x.
+
+          Usage rule: EquivalentBranch is a result of network reduction prior to the
+          data exchange.'
+    is_a: EquivalentEquipment
+    description: The class represents equivalent branches. In cases where a transformer
+      phase shift is modelled and the EquivalentBranch is spanning the same nodes,
+      the impedance quantities for the EquivalentBranch shall consider the needed
+      phase shift.
+  EquivalentEquipment:
+    class_uri: cim:EquivalentEquipment
+    attributes:
+      EquivalentNetwork:
+        slot_uri: cim:EquivalentEquipment.EquivalentNetwork
+        range: EquivalentNetwork
+        multivalued: false
+        required: false
+        description: The equivalent where the reduced model belongs.
+    is_a: ConductingEquipment
+    description: The class represents equivalent objects that are the result of a
+      network reduction. The class is the base for equivalent objects of different
+      types.
+  EquivalentInjection:
+    class_uri: cim:EquivalentInjection
+    attributes:
+      maxP:
+        slot_uri: cim:EquivalentInjection.maxP
+        range: ActivePower
+        multivalued: false
+        required: false
+        description: Maximum active power of the injection.
+      maxQ:
+        slot_uri: cim:EquivalentInjection.maxQ
+        range: ReactivePower
+        multivalued: false
+        required: false
+        description: Maximum reactive power of the injection.  Used for modelling
+          of infeed for load flow exchange. Not used for short circuit modelling.  If
+          maxQ and minQ are not used ReactiveCapabilityCurve can be used.
+      minP:
+        slot_uri: cim:EquivalentInjection.minP
+        range: ActivePower
+        multivalued: false
+        required: false
+        description: Minimum active power of the injection.
+      minQ:
+        slot_uri: cim:EquivalentInjection.minQ
+        range: ReactivePower
+        multivalued: false
+        required: false
+        description: Minimum reactive power of the injection.  Used for modelling
+          of infeed for load flow exchange. Not used for short circuit modelling.  If
+          maxQ and minQ are not used ReactiveCapabilityCurve can be used.
+      regulationCapability:
+        slot_uri: cim:EquivalentInjection.regulationCapability
+        range: boolean
+        multivalued: false
+        required: true
+        description: Specifies whether or not the EquivalentInjection has the capability
+          to regulate the local voltage. If true the EquivalentInjection can regulate.
+          If false the EquivalentInjection cannot regulate. ReactiveCapabilityCurve
+          can only be associated with EquivalentInjection  if the flag is true.
+      ReactiveCapabilityCurve:
+        slot_uri: cim:EquivalentInjection.ReactiveCapabilityCurve
+        range: ReactiveCapabilityCurve
+        multivalued: false
+        required: false
+        description: The reactive capability curve used by this equivalent injection.
+    is_a: EquivalentEquipment
+    description: This class represents equivalent injections (generation or load).  Voltage
+      regulation is allowed only at the point of connection.
+  EquivalentNetwork:
+    class_uri: cim:EquivalentNetwork
+    attributes:
+      EquivalentEquipments:
+        slot_uri: cim:EquivalentNetwork.EquivalentEquipments
+        range: EquivalentEquipment
+        multivalued: true
+        required: false
+        description: The associated reduced equivalents.
+    is_a: ConnectivityNodeContainer
+    description: A class that groups electrical equivalents, including internal nodes,
+      of a network that has been reduced. The ConnectivityNodes contained in the equivalent
+      are intended to reflect internal nodes of the equivalent. The boundary Connectivity
+      nodes where the equivalent connects outside itself are not contained by the
+      equivalent.
+  EquivalentShunt:
+    class_uri: cim:EquivalentShunt
+    attributes:
+      b:
+        slot_uri: cim:EquivalentShunt.b
+        range: Susceptance
+        multivalued: false
+        required: true
+        description: Positive sequence shunt susceptance.
+      g:
+        slot_uri: cim:EquivalentShunt.g
+        range: Conductance
+        multivalued: false
+        required: true
+        description: Positive sequence shunt conductance.
+    is_a: EquivalentEquipment
+    description: The class represents equivalent shunts.
+  ExternalNetworkInjection:
+    class_uri: cim:ExternalNetworkInjection
+    attributes:
+      governorSCD:
+        slot_uri: cim:ExternalNetworkInjection.governorSCD
+        range: ActivePowerPerFrequency
+        multivalued: false
+        required: true
+        description: Power Frequency Bias. This is the change in power injection divided
+          by the change in frequency and negated.  A positive value of the power frequency
+          bias provides additional power injection upon a drop in frequency.
+      maxP:
+        slot_uri: cim:ExternalNetworkInjection.maxP
+        range: ActivePower
+        multivalued: false
+        required: true
+        description: Maximum active power of the injection.
+      maxQ:
+        slot_uri: cim:ExternalNetworkInjection.maxQ
+        range: ReactivePower
+        multivalued: false
+        required: true
+        description: Maximum reactive power limit. It is used for modelling of infeed
+          for load flow exchange and not for short circuit modelling.
+      minP:
+        slot_uri: cim:ExternalNetworkInjection.minP
+        range: ActivePower
+        multivalued: false
+        required: true
+        description: Minimum active power of the injection.
+      minQ:
+        slot_uri: cim:ExternalNetworkInjection.minQ
+        range: ReactivePower
+        multivalued: false
+        required: true
+        description: Minimum reactive power limit. It is used for modelling of infeed
+          for load flow exchange and not for short circuit modelling.
+    is_a: RegulatingCondEq
+    description: This class represents the external network and it is used for IEC
+      60909 calculations.
+  ActivePowerPerFrequency:
+    class_uri: cim:ActivePowerPerFrequency
+    attributes:
+      multiplier:
+        slot_uri: cim:ActivePowerPerFrequency.multiplier
+        range: UnitMultiplier
+        multivalued: false
+        required: false
+      unit:
+        slot_uri: cim:ActivePowerPerFrequency.unit
+        range: UnitSymbol
+        multivalued: false
+        required: false
+      value:
+        slot_uri: cim:ActivePowerPerFrequency.value
+        range: float
+        multivalued: false
+        required: false
+    description: Active power variation with frequency.
+  FaultIndicator:
+    class_uri: cim:FaultIndicator
+    is_a: AuxiliaryEquipment
+    description: A FaultIndicator is typically only an indicator (which may or may
+      not be remotely monitored), and not a piece of equipment that actually initiates
+      a protection event. It is used for FLISR (Fault Location, Isolation and Restoration)
+      purposes, assisting with the dispatch of crews to "most likely" part of the
+      network (i.e. assists with determining circuit section where the fault most
+      likely happened).
+  FossilFuel:
+    class_uri: cim:FossilFuel
+    attributes:
+      fossilFuelType:
+        slot_uri: cim:FossilFuel.fossilFuelType
+        range: FuelType
+        multivalued: false
+        required: true
+        description: The type of fossil fuel, such as coal, oil, or gas.
+      ThermalGeneratingUnit:
+        slot_uri: cim:FossilFuel.ThermalGeneratingUnit
+        range: ThermalGeneratingUnit
+        multivalued: false
+        required: true
+        description: A thermal generating unit may have one or more fossil fuels.
+    is_a: IdentifiedObject
+    description: The fossil fuel consumed by the non-nuclear thermal generating unit.   For
+      example, coal, oil, gas, etc.   These are the specific fuels that the generating
+      unit can consume.
+  Fuse:
+    class_uri: cim:Fuse
+    is_a: Switch
+    description: An overcurrent protective device with a circuit opening fusible part
+      that is heated and severed by the passage of overcurrent through it. A fuse
+      is considered a switching device because it breaks current.
+  GeneratingUnit:
+    class_uri: cim:GeneratingUnit
+    attributes:
+      ControlAreaGeneratingUnit:
+        slot_uri: cim:GeneratingUnit.ControlAreaGeneratingUnit
+        range: ControlAreaGeneratingUnit
+        multivalued: true
+        required: false
+        description: ControlArea specifications for this generating unit.
+      genControlSource:
+        slot_uri: cim:GeneratingUnit.genControlSource
+        range: GeneratorControlSource
+        multivalued: false
+        required: false
+        description: The source of controls for a generating unit.  Defines the control
+          status of the generating unit.
+      governorSCD:
+        slot_uri: cim:GeneratingUnit.governorSCD
+        range: PerCent
+        multivalued: false
+        required: false
+        description: Governor Speed Changer Droop.   This is the change in generator
+          power output divided by the change in frequency normalized by the nominal
+          power of the generator and the nominal frequency and expressed in percent
+          and negated. A positive value of speed change droop provides additional
+          generator output upon a drop in frequency.
+      longPF:
+        slot_uri: cim:GeneratingUnit.longPF
+        range: float
+        multivalued: false
+        required: false
+        description: Generating unit long term economic participation factor.
+      maximumAllowableSpinningReserve:
+        slot_uri: cim:GeneratingUnit.maximumAllowableSpinningReserve
+        range: ActivePower
+        multivalued: false
+        required: false
+        description: Maximum allowable spinning reserve. Spinning reserve will never
+          be considered greater than this value regardless of the current operating
+          point.
+      maxOperatingP:
+        slot_uri: cim:GeneratingUnit.maxOperatingP
+        range: ActivePower
+        multivalued: false
+        required: true
+        description: This is the maximum operating active power limit the dispatcher
+          can enter for this unit.
+      minOperatingP:
+        slot_uri: cim:GeneratingUnit.minOperatingP
+        range: ActivePower
+        multivalued: false
+        required: true
+        description: This is the minimum operating active power limit the dispatcher
+          can enter for this unit.
+      nominalP:
+        slot_uri: cim:GeneratingUnit.nominalP
+        range: ActivePower
+        multivalued: false
+        required: false
+        description: 'The nominal power of the generating unit.  Used to give precise
+          meaning to percentage based attributes such as the governor speed change
+          droop (governorSCD attribute).
+
+          The attribute shall be a positive value equal to or less than RotatingMachine.ratedS.'
+      ratedGrossMaxP:
+        slot_uri: cim:GeneratingUnit.ratedGrossMaxP
+        range: ActivePower
+        multivalued: false
+        required: false
+        description: 'The unit''s gross rated maximum capacity (book value).
+
+          The attribute shall be a positive value.'
+      ratedGrossMinP:
+        slot_uri: cim:GeneratingUnit.ratedGrossMinP
+        range: ActivePower
+        multivalued: false
+        required: false
+        description: 'The gross rated minimum generation level which the unit can
+          safely operate at while delivering power to the transmission grid.
+
+          The attribute shall be a positive value.'
+      ratedNetMaxP:
+        slot_uri: cim:GeneratingUnit.ratedNetMaxP
+        range: ActivePower
+        multivalued: false
+        required: false
+        description: 'The net rated maximum capacity determined by subtracting the
+          auxiliary power used to operate the internal plant machinery from the rated
+          gross maximum capacity.
+
+          The attribute shall be a positive value.'
+      shortPF:
+        slot_uri: cim:GeneratingUnit.shortPF
+        range: float
+        multivalued: false
+        required: false
+        description: Generating unit short term economic participation factor.
+      startupCost:
+        slot_uri: cim:GeneratingUnit.startupCost
+        range: Money
+        multivalued: false
+        required: false
+        description: The initial startup cost incurred for each start of the GeneratingUnit.
+      variableCost:
+        slot_uri: cim:GeneratingUnit.variableCost
+        range: Money
+        multivalued: false
+        required: false
+        description: The variable cost component of production per unit of ActivePower.
+      startupTime:
+        slot_uri: cim:GeneratingUnit.startupTime
+        range: Seconds
+        multivalued: false
+        required: false
+        description: Time it takes to get the unit on-line, from the time that the
+          prime mover mechanical power is applied.
+      totalEfficiency:
+        slot_uri: cim:GeneratingUnit.totalEfficiency
+        range: PerCent
+        multivalued: false
+        required: false
+        description: The efficiency of the unit in converting the fuel into electrical
+          energy.
+      GrossToNetActivePowerCurves:
+        slot_uri: cim:GeneratingUnit.GrossToNetActivePowerCurves
+        range: GrossToNetActivePowerCurve
+        multivalued: true
+        required: false
+        description: A generating unit may have a gross active power to net active
+          power curve, describing the losses and auxiliary power requirements of the
+          unit.
+      RotatingMachine:
+        slot_uri: cim:GeneratingUnit.RotatingMachine
+        range: RotatingMachine
+        multivalued: true
+        required: true
+        description: A synchronous machine may operate as a generator and as such
+          becomes a member of a generating unit.
+    is_a: Equipment
+    description: A single or set of synchronous machines for converting mechanical
+      power into alternating-current power. For example, individual machines within
+      a set may be defined for scheduling purposes while a single control signal is
+      derived for the set. In this case there would be a GeneratingUnit for each member
+      of the set and an additional GeneratingUnit corresponding to the set.
+  Money:
+    class_uri: cim:Money
+    attributes:
+      unit:
+        slot_uri: cim:Money.unit
+        range: Currency
+        multivalued: false
+        required: false
+      multiplier:
+        slot_uri: cim:Money.multiplier
+        range: UnitMultiplier
+        multivalued: false
+        required: false
+      value:
+        slot_uri: cim:Money.value
+        range: double
+        multivalued: false
+        required: false
+    description: Amount of money.
+  Seconds:
+    class_uri: cim:Seconds
+    attributes:
+      value:
+        slot_uri: cim:Seconds.value
+        range: float
+        multivalued: false
+        required: false
+        description: Time, in seconds
+      unit:
+        slot_uri: cim:Seconds.unit
+        range: UnitSymbol
+        multivalued: false
+        required: false
+      multiplier:
+        slot_uri: cim:Seconds.multiplier
+        range: UnitMultiplier
+        multivalued: false
+        required: false
+    description: Time, in seconds.
+  GeographicalRegion:
+    class_uri: cim:GeographicalRegion
+    attributes:
+      Regions:
+        slot_uri: cim:GeographicalRegion.Regions
+        range: SubGeographicalRegion
+        multivalued: true
+        required: false
+        description: All sub-geographical regions within this geographical region.
+    is_a: IdentifiedObject
+    description: A geographical region of a power system network model.
+  GrossToNetActivePowerCurve:
+    class_uri: cim:GrossToNetActivePowerCurve
+    attributes:
+      GeneratingUnit:
+        slot_uri: cim:GrossToNetActivePowerCurve.GeneratingUnit
+        range: GeneratingUnit
+        multivalued: false
+        required: true
+        description: A generating unit may have a gross active power to net active
+          power curve, describing the losses and auxiliary power requirements of the
+          unit.
+    is_a: Curve
+    description: Relationship between the generating unit's gross active power output
+      on the X-axis (measured at the terminals of the machine(s)) and the generating
+      unit's net active power output on the Y-axis (based on utility-defined measurements
+      at the power station). Station service loads, when modelled, should be treated
+      as non-conforming bus loads. There may be more than one curve, depending on
+      the auxiliary equipment that is in service.
+  Ground:
+    class_uri: cim:Ground
+    is_a: ConductingEquipment
+    description: A point where the system is grounded used for connecting conducting
+      equipment to ground. The power system model can have any number of grounds.
+  GroundDisconnector:
+    class_uri: cim:GroundDisconnector
+    is_a: Switch
+    description: A manually operated or motor operated mechanical switching device
+      used for isolating a circuit or equipment from ground.
+  GroundingImpedance:
+    class_uri: cim:GroundingImpedance
+    is_a: EarthFaultCompensator
+    description: A fixed impedance device used for grounding.
+  HydroGeneratingUnit:
+    class_uri: cim:HydroGeneratingUnit
+    attributes:
+      energyConversionCapability:
+        slot_uri: cim:HydroGeneratingUnit.energyConversionCapability
+        range: HydroEnergyConversionKind
+        multivalued: false
+        required: false
+        description: Energy conversion capability for generating.
+      dropHeight:
+        slot_uri: cim:HydroGeneratingUnit.dropHeight
+        range: Length
+        multivalued: false
+        required: false
+        description: The height water drops from the reservoir mid-point to the turbine.
+      turbineType:
+        slot_uri: cim:HydroGeneratingUnit.turbineType
+        range: HydroTurbineKind
+        multivalued: false
+        required: false
+        description: Type of turbine.
+      HydroPowerPlant:
+        slot_uri: cim:HydroGeneratingUnit.HydroPowerPlant
+        range: HydroPowerPlant
+        multivalued: false
+        required: false
+        description: The hydro generating unit belongs to a hydro power plant.
+    is_a: GeneratingUnit
+    description: A generating unit whose prime mover is a hydraulic turbine (e.g.,
+      Francis, Pelton, Kaplan).
+  HydroPowerPlant:
+    class_uri: cim:HydroPowerPlant
+    attributes:
+      HydroGeneratingUnits:
+        slot_uri: cim:HydroPowerPlant.HydroGeneratingUnits
+        range: HydroGeneratingUnit
+        multivalued: true
+        required: false
+        description: The hydro generating unit belongs to a hydro power plant.
+      hydroPlantStorageType:
+        slot_uri: cim:HydroPowerPlant.hydroPlantStorageType
+        range: HydroPlantStorageKind
+        multivalued: false
+        required: true
+        description: The type of hydro power plant water storage.
+      HydroPumps:
+        slot_uri: cim:HydroPowerPlant.HydroPumps
+        range: HydroPump
+        multivalued: true
+        required: false
+        description: The hydro pump may be a member of a pumped storage plant or a
+          pump for distributing water.
+    is_a: PowerSystemResource
+    description: A hydro power station which can generate or pump. When generating,
+      the generator turbines receive water from an upper reservoir. When pumping,
+      the pumps receive their water from a lower reservoir.
+  HydroPump:
+    class_uri: cim:HydroPump
+    attributes:
+      HydroPowerPlant:
+        slot_uri: cim:HydroPump.HydroPowerPlant
+        range: HydroPowerPlant
+        multivalued: false
+        required: false
+        description: The hydro pump may be a member of a pumped storage plant or a
+          pump for distributing water.
+      RotatingMachine:
+        slot_uri: cim:HydroPump.RotatingMachine
+        range: RotatingMachine
+        multivalued: false
+        required: true
+        description: The synchronous machine drives the turbine which moves the water
+          from a low elevation to a higher elevation. The direction of machine rotation
+          for pumping may or may not be the same as for generating.
+    is_a: Equipment
+    description: A synchronous motor-driven pump, typically associated with a pumped
+      storage plant.
+  IdentifiedObject:
+    class_uri: cim:IdentifiedObject
+    attributes:
+      description:
+        slot_uri: cim:IdentifiedObject.description
+        range: string
+        multivalued: false
+        required: false
+        description: The description is a free human readable text describing or naming
+          the object. It may be non unique and may not correlate to a naming hierarchy.
+      energyIdentCodeEic:
+        slot_uri: eu:IdentifiedObject.energyIdentCodeEic
+        range: string
+        multivalued: false
+        required: false
+        description: The attribute is used for an exchange of the EIC code (Energy
+          identification Code). The length of the string is 16 characters as defined
+          by the EIC code. For details on EIC scheme please refer to ENTSO-E web site.
+      mRID:
+        slot_uri: cim:IdentifiedObject.mRID
+        range: string
+        multivalued: false
+        required: true
+        description: 'Master resource identifier issued by a model authority. The
+          mRID is unique within an exchange context. Global uniqueness is easily achieved
+          by using a UUID, as specified in RFC 4122, for the mRID. The use of UUID
+          is strongly recommended.
+
+          For CIMXML data files in RDF syntax conforming to IEC 61970-552, the mRID
+          is mapped to rdf:ID or rdf:about attributes that identify CIM object elements.'
+      name:
+        slot_uri: cim:IdentifiedObject.name
+        range: string
+        multivalued: false
+        required: true
+        description: The name is any free human readable and possibly non unique text
+          naming the object.
+      shortName:
+        slot_uri: eu:IdentifiedObject.shortName
+        range: string
+        multivalued: false
+        required: false
+        description: The attribute is used for an exchange of a human readable short
+          name with length of the string 12 characters maximum.
+    description: This is a root class to provide common identification for all classes
+      needing identification and naming attributes.
+  Jumper:
+    class_uri: cim:Jumper
+    is_a: Switch
+    description: A short section of conductor with negligible impedance which can
+      be manually removed and replaced if the circuit is de-energized. Note that zero-impedance
+      branches can potentially be modelled by other equipment types.
+  Junction:
+    class_uri: cim:Junction
+    is_a: Connector
+    description: A point where one or more conducting equipments are connected with
+      zero resistance.
+  Line:
+    class_uri: cim:Line
+    attributes:
+      Region:
+        slot_uri: cim:Line.Region
+        range: SubGeographicalRegion
+        multivalued: false
+        required: false
+        description: The sub-geographical region of the line.
+    is_a: EquipmentContainer
+    description: Contains equipment beyond a substation belonging to a power transmission
+      line.
+  LinearShuntCompensator:
+    class_uri: cim:LinearShuntCompensator
+    attributes:
+      bPerSection:
+        slot_uri: cim:LinearShuntCompensator.bPerSection
+        range: Susceptance
+        multivalued: false
+        required: true
+        description: Positive sequence shunt (charging) susceptance per section.
+      gPerSection:
+        slot_uri: cim:LinearShuntCompensator.gPerSection
+        range: Conductance
+        multivalued: false
+        required: true
+        description: Positive sequence shunt (charging) conductance per section.
+    is_a: ShuntCompensator
+    description: A linear shunt compensator has banks or sections with equal admittance
+      values.
+  LoadArea:
+    class_uri: cim:LoadArea
+    attributes:
+      SubLoadAreas:
+        slot_uri: cim:LoadArea.SubLoadAreas
+        range: SubLoadArea
+        multivalued: true
+        required: true
+        description: The SubLoadAreas in the LoadArea.
+    is_a: EnergyArea
+    description: The class is the root or first level in a hierarchical structure
+      for grouping of loads for the purpose of load flow load scaling.
+  LoadBreakSwitch:
+    class_uri: cim:LoadBreakSwitch
+    is_a: ProtectedSwitch
+    description: A mechanical switching device capable of making, carrying, and breaking
+      currents under normal operating conditions.
+  LoadGroup:
+    class_uri: cim:LoadGroup
+    attributes:
+      SubLoadArea:
+        slot_uri: cim:LoadGroup.SubLoadArea
+        range: SubLoadArea
+        multivalued: false
+        required: true
+        description: The SubLoadArea where the Loadgroup belongs.
+    is_a: IdentifiedObject
+    description: The class is the third level in a hierarchical structure for grouping
+      of loads for the purpose of load flow load scaling.
+  LoadResponseCharacteristic:
+    class_uri: cim:LoadResponseCharacteristic
+    attributes:
+      EnergyConsumer:
+        slot_uri: cim:LoadResponseCharacteristic.EnergyConsumer
+        range: EnergyConsumer
+        multivalued: true
+        required: false
+        description: The set of loads that have the response characteristics.
+      exponentModel:
+        slot_uri: cim:LoadResponseCharacteristic.exponentModel
+        range: boolean
+        multivalued: false
+        required: true
+        description: 'Indicates the exponential voltage dependency model is to be
+          used. If false, the coefficient model is to be used.
+
+          The exponential voltage dependency model consist of the attributes:
+
+          - pVoltageExponent
+
+          - qVoltageExponent
+
+          - pFrequencyExponent
+
+          - qFrequencyExponent.
+
+          The coefficient model consist of the attributes:
+
+          - pConstantImpedance
+
+          - pConstantCurrent
+
+          - pConstantPower
+
+          - qConstantImpedance
+
+          - qConstantCurrent
+
+          - qConstantPower.
+
+          The sum of pConstantImpedance, pConstantCurrent and pConstantPower shall
+          equal 1.
+
+          The sum of qConstantImpedance, qConstantCurrent and qConstantPower shall
+          equal 1.'
+      pConstantCurrent:
+        slot_uri: cim:LoadResponseCharacteristic.pConstantCurrent
+        range: float
+        multivalued: false
+        required: false
+        description: Portion of active power load modelled as constant current.
+      pConstantImpedance:
+        slot_uri: cim:LoadResponseCharacteristic.pConstantImpedance
+        range: float
+        multivalued: false
+        required: false
+        description: Portion of active power load modelled as constant impedance.
+      pConstantPower:
+        slot_uri: cim:LoadResponseCharacteristic.pConstantPower
+        range: float
+        multivalued: false
+        required: false
+        description: Portion of active power load modelled as constant power.
+      pFrequencyExponent:
+        slot_uri: cim:LoadResponseCharacteristic.pFrequencyExponent
+        range: float
+        multivalued: false
+        required: false
+        description: Exponent of per unit frequency effecting active power.
+      pVoltageExponent:
+        slot_uri: cim:LoadResponseCharacteristic.pVoltageExponent
+        range: float
+        multivalued: false
+        required: false
+        description: Exponent of per unit voltage effecting real power.
+      qConstantCurrent:
+        slot_uri: cim:LoadResponseCharacteristic.qConstantCurrent
+        range: float
+        multivalued: false
+        required: false
+        description: Portion of reactive power load modelled as constant current.
+      qConstantImpedance:
+        slot_uri: cim:LoadResponseCharacteristic.qConstantImpedance
+        range: float
+        multivalued: false
+        required: false
+        description: Portion of reactive power load modelled as constant impedance.
+      qConstantPower:
+        slot_uri: cim:LoadResponseCharacteristic.qConstantPower
+        range: float
+        multivalued: false
+        required: false
+        description: Portion of reactive power load modelled as constant power.
+      qFrequencyExponent:
+        slot_uri: cim:LoadResponseCharacteristic.qFrequencyExponent
+        range: float
+        multivalued: false
+        required: false
+        description: Exponent of per unit frequency effecting reactive power.
+      qVoltageExponent:
+        slot_uri: cim:LoadResponseCharacteristic.qVoltageExponent
+        range: float
+        multivalued: false
+        required: false
+        description: Exponent of per unit voltage effecting reactive power.
+    is_a: IdentifiedObject
+    description: "Models the characteristic response of the load demand due to changes\
+      \ in system conditions such as voltage and frequency. It is not related to demand\
+      \ response.\nIf LoadResponseCharacteristic.exponentModel is True, the exponential\
+      \ voltage or frequency dependent models are specified and used as to calculate\
+      \ active and reactive power components of the load model.\nThe equations to\
+      \ calculate active and reactive power components of the load model are internal\
+      \ to the power flow calculation, hence they use different quantities depending\
+      \ on the use case of the data exchange. \nThe equations for exponential voltage\
+      \ dependent load model injected power are: \npInjection= Pnominal* (Voltage/cim:BaseVoltage.nominalVoltage)\
+      \ ** cim:LoadResponseCharacteristic.pVoltageExponent\nqInjection= Qnominal*\
+      \ (Voltage/cim:BaseVoltage.nominalVoltage) ** cim:LoadResponseCharacteristic.qVoltageExponent\n\
+      Where: \n1) * means \"multiply\" and ** is \"raised to power of\";\n2) Pnominal\
+      \ and Qnominal represent the active power and reactive power at nominal voltage\
+      \ as any load described by the voltage exponential model shall be given at nominal\
+      \ voltage.  This means that EnergyConsumer.p and EnergyConsumer.q  are at nominal\
+      \ voltage.\n3) After power flow is solved: \n-pInjection and qInjection correspond\
+      \ to SvPowerflow.p and SvPowerflow.q respectively.  \n- Voltage corresponds\
+      \ to SvVoltage.v at the TopologicalNode where the load is connected."
+  NonConformLoad:
+    class_uri: cim:NonConformLoad
+    attributes:
+      LoadGroup:
+        slot_uri: cim:NonConformLoad.LoadGroup
+        range: NonConformLoadGroup
+        multivalued: false
+        required: true
+        description: Group of this ConformLoad.
+    is_a: EnergyConsumer
+    description: NonConformLoad represents loads that do not follow a daily load change
+      pattern and whose changes are not correlated with the daily load change pattern.
+  NonConformLoadGroup:
+    class_uri: cim:NonConformLoadGroup
+    attributes:
+      EnergyConsumers:
+        slot_uri: cim:NonConformLoadGroup.EnergyConsumers
+        range: NonConformLoad
+        multivalued: true
+        required: true
+        description: Conform loads assigned to this ConformLoadGroup.
+      NonConformLoadSchedules:
+        slot_uri: cim:NonConformLoadGroup.NonConformLoadSchedules
+        range: NonConformLoadSchedule
+        multivalued: true
+        required: false
+        description: The NonConformLoadSchedules in the NonConformLoadGroup.
+    is_a: LoadGroup
+    description: Loads that do not follow a daily and seasonal load variation pattern.
+  NonConformLoadSchedule:
+    class_uri: cim:NonConformLoadSchedule
+    attributes:
+      NonConformLoadGroup:
+        slot_uri: cim:NonConformLoadSchedule.NonConformLoadGroup
+        range: NonConformLoadGroup
+        multivalued: false
+        required: true
+        description: The NonConformLoadGroup where the NonConformLoadSchedule belongs.
+    is_a: SeasonDayTypeSchedule
+    description: An active power (Y1-axis) and reactive power (Y2-axis) schedule (curves)
+      versus time (X-axis) for non-conforming loads, e.g., large industrial load or
+      power station service (where modelled).
+  NonlinearShuntCompensator:
+    class_uri: cim:NonlinearShuntCompensator
+    attributes:
+      NonlinearShuntCompensatorPoints:
+        slot_uri: cim:NonlinearShuntCompensator.NonlinearShuntCompensatorPoints
+        range: NonlinearShuntCompensatorPoint
+        multivalued: true
+        required: true
+        description: All points of the non-linear shunt compensator.
+    is_a: ShuntCompensator
+    description: A non linear shunt compensator has bank or section admittance values
+      that differ. The attributes g, b, g0 and b0 of the associated NonlinearShuntCompensatorPoint
+      describe the total conductance and admittance of a NonlinearShuntCompensatorPoint
+      at a section number specified by NonlinearShuntCompensatorPoint.sectionNumber.
+  NonlinearShuntCompensatorPoint:
+    class_uri: cim:NonlinearShuntCompensatorPoint
+    attributes:
+      NonlinearShuntCompensator:
+        slot_uri: cim:NonlinearShuntCompensatorPoint.NonlinearShuntCompensator
+        range: NonlinearShuntCompensator
+        multivalued: false
+        required: true
+        description: Non-linear shunt compensator owning this point.
+      b:
+        slot_uri: cim:NonlinearShuntCompensatorPoint.b
+        range: Susceptance
+        multivalued: false
+        required: true
+        description: Positive sequence shunt (charging) susceptance per section.
+      g:
+        slot_uri: cim:NonlinearShuntCompensatorPoint.g
+        range: Conductance
+        multivalued: false
+        required: true
+        description: Positive sequence shunt (charging) conductance per section.
+      sectionNumber:
+        slot_uri: cim:NonlinearShuntCompensatorPoint.sectionNumber
+        range: integer
+        multivalued: false
+        required: true
+        description: The number of the section.
+    description: A non linear shunt compensator bank or section admittance value.
+      The number of NonlinearShuntCompenstorPoint instances associated with a NonlinearShuntCompensator
+      shall be equal to ShuntCompensator.maximumSections. ShuntCompensator.sections
+      shall only be set to one of the NonlinearShuntCompenstorPoint.sectionNumber.
+      There is no interpolation between NonlinearShuntCompenstorPoint-s.
+  NuclearGeneratingUnit:
+    class_uri: cim:NuclearGeneratingUnit
+    is_a: GeneratingUnit
+    description: A nuclear generating unit.
+  OperationalLimit:
+    class_uri: cim:OperationalLimit
+    attributes:
+      OperationalLimitSet:
+        slot_uri: cim:OperationalLimit.OperationalLimitSet
+        range: OperationalLimitSet
+        multivalued: false
+        required: true
+        description: The limit set to which the limit values belong.
+      OperationalLimitType:
+        slot_uri: cim:OperationalLimit.OperationalLimitType
+        range: OperationalLimitType
+        multivalued: false
+        required: true
+        description: The limit type associated with this limit.
+    is_a: IdentifiedObject
+    description: "A value and normal value associated with a specific kind of limit.\
+      \ \nThe sub class value and normalValue attributes vary inversely to the associated\
+      \ OperationalLimitType.acceptableDuration (acceptableDuration for short).  \n\
+      If a particular piece of equipment has multiple operational limits of the same\
+      \ kind (apparent power, current, etc.), the limit with the greatest acceptableDuration\
+      \ shall have the smallest limit value and the limit with the smallest acceptableDuration\
+      \ shall have the largest limit value.  Note: A large current can only be allowed\
+      \ to flow through a piece of equipment for a short duration without causing\
+      \ damage, but a lesser current can be allowed to flow for a longer duration."
+  OperationalLimitSet:
+    class_uri: cim:OperationalLimitSet
+    attributes:
+      Terminal:
+        slot_uri: cim:OperationalLimitSet.Terminal
+        range: ACDCTerminal
+        multivalued: false
+        required: true
+        description: The terminal where the operational limit set apply.
+      Equipment:
+        slot_uri: cim:OperationalLimitSet.Equipment
+        range: Equipment
+        multivalued: false
+        required: false
+        description: The equipment to which the limit set applies.
+      OperationalLimitValue:
+        slot_uri: cim:OperationalLimitSet.OperationalLimitValue
+        range: OperationalLimit
+        multivalued: true
+        required: false
+        description: Values of equipment limits.
+    is_a: IdentifiedObject
+    description: A set of limits associated with equipment.  Sets of limits might
+      apply to a specific temperature, or season for example. A set of limits may
+      contain different severities of limit levels that would apply to the same equipment.
+      The set may contain limits of different types such as apparent power and current
+      limits or high and low voltage limits  that are logically applied together as
+      a set.
+  OperationalLimitType:
+    class_uri: cim:OperationalLimitType
+    attributes:
+      OperationalLimit:
+        slot_uri: cim:OperationalLimitType.OperationalLimit
+        range: OperationalLimit
+        multivalued: true
+        required: false
+        description: The operational limits associated with this type of limit.
+      acceptableDuration:
+        slot_uri: cim:OperationalLimitType.acceptableDuration
+        range: Seconds
+        multivalued: false
+        required: false
+        description: The nominal acceptable duration of the limit. Limits are commonly
+          expressed in terms of the time limit for which the limit is normally acceptable.
+          The actual acceptable duration of a specific limit may depend on other local
+          factors such as temperature or wind speed. The attribute has meaning only
+          if the flag isInfiniteDuration is set to false, hence it shall not be exchanged
+          when isInfiniteDuration is set to true.
+      direction:
+        slot_uri: cim:OperationalLimitType.direction
+        range: OperationalLimitDirectionKind
+        multivalued: false
+        required: true
+        description: The direction of the limit.
+      isInfiniteDuration:
+        slot_uri: cim:OperationalLimitType.isInfiniteDuration
+        range: boolean
+        multivalued: false
+        required: true
+        description: Defines if the operational limit type has infinite duration.
+          If true, the limit has infinite duration. If false, the limit has definite
+          duration which is defined by the attribute acceptableDuration.
+      kind:
+        slot_uri: eu:OperationalLimitType.kind
+        range: LimitKind
+        multivalued: false
+        required: true
+        description: Types of limits defined in the ENTSO-E Operational Handbook Policy
+          3.
+    is_a: IdentifiedObject
+    description: The operational meaning of a category of limits.
+  PetersenCoil:
+    class_uri: cim:PetersenCoil
+    is_a: EarthFaultCompensator
+    description: A variable impedance device normally used to offset line charging
+      during single line faults in an ungrounded section of network.
+  PhaseTapChanger:
+    class_uri: cim:PhaseTapChanger
+    attributes:
+      TransformerEnd:
+        slot_uri: cim:PhaseTapChanger.TransformerEnd
+        range: TransformerEnd
+        multivalued: false
+        required: true
+        description: Transformer end to which this phase tap changer belongs.
+    is_a: TapChanger
+    description: A transformer phase shifting tap model that controls the phase angle
+      difference across the power transformer and potentially the active power flow
+      through the power transformer.  This phase tap model may also impact the voltage
+      magnitude.
+  PhaseTapChangerAsymmetrical:
+    class_uri: cim:PhaseTapChangerAsymmetrical
+    attributes:
+      windingConnectionAngle:
+        slot_uri: cim:PhaseTapChangerAsymmetrical.windingConnectionAngle
+        range: AngleDegrees
+        multivalued: false
+        required: true
+        description: The phase angle between the in-phase winding and the out-of -phase
+          winding used for creating phase shift. The out-of-phase winding produces
+          what is known as the difference voltage.  Setting this angle to 90 degrees
+          is not the same as a symmetrical transformer. The attribute can only be
+          multiples of 30 degrees.  The allowed range is -150 degrees to 150 degrees
+          excluding 0.
+    is_a: PhaseTapChangerNonLinear
+    description: Describes the tap model for an asymmetrical phase shifting transformer
+      in which the difference voltage vector adds to the in-phase winding. The out-of-phase
+      winding is the transformer end where the tap changer is located.  The angle
+      between the in-phase and out-of-phase windings is named the winding connection
+      angle. The phase shift depends on both the difference voltage magnitude and
+      the winding connection angle.
+  PhaseTapChangerLinear:
+    class_uri: cim:PhaseTapChangerLinear
+    attributes:
+      stepPhaseShiftIncrement:
+        slot_uri: cim:PhaseTapChangerLinear.stepPhaseShiftIncrement
+        range: AngleDegrees
+        multivalued: false
+        required: true
+        description: 'Phase shift per step position. A positive value indicates a
+          positive angle variation from the Terminal at the  PowerTransformerEnd,  where
+          the TapChanger is located, into the transformer.
+
+          The actual phase shift increment might be more accurately computed from
+          the symmetrical or asymmetrical models or a tap step table lookup if those
+          are available.'
+      xMax:
+        slot_uri: cim:PhaseTapChangerLinear.xMax
+        range: Reactance
+        multivalued: false
+        required: true
+        description: "The reactance depends on the tap position according to a \"\
+          u\" shaped curve. The maximum reactance (xMax) appears at the low and high\
+          \ tap positions. Depending on the \u201Cu\u201D curve the attribute can\
+          \ be either higher or lower than PowerTransformerEnd.x."
+      xMin:
+        slot_uri: cim:PhaseTapChangerLinear.xMin
+        range: Reactance
+        multivalued: false
+        required: true
+        description: The reactance depends on the tap position according to a "u"
+          shaped curve. The minimum reactance (xMin) appears at the mid tap position.  PowerTransformerEnd.x
+          shall be consistent with PhaseTapChangerLinear.xMin and PhaseTapChangerNonLinear.xMin.
+          In case of inconsistency, PowerTransformerEnd.x shall be used.
+    is_a: PhaseTapChanger
+    description: 'Describes a tap changer with a linear relation between the tap step
+      and the phase angle difference across the transformer. This is a mathematical
+      model that is an approximation of a real phase tap changer.
+
+      The phase angle is computed as stepPhaseShiftIncrement times the tap position.
+
+      The voltage magnitude of both sides is the same.'
+  PhaseTapChangerNonLinear:
+    class_uri: cim:PhaseTapChangerNonLinear
+    attributes:
+      voltageStepIncrement:
+        slot_uri: cim:PhaseTapChangerNonLinear.voltageStepIncrement
+        range: PerCent
+        multivalued: false
+        required: true
+        description: 'The voltage step increment on the out of phase winding (the
+          PowerTransformerEnd where the TapChanger is located) specified in percent
+          of rated voltage of the PowerTransformerEnd. A positive value means a positive
+          voltage variation from the Terminal at the PowerTransformerEnd, where the
+          TapChanger is located, into the transformer.
+
+          When the increment is negative, the voltage decreases when the tap step
+          increases.'
+      xMax:
+        slot_uri: cim:PhaseTapChangerNonLinear.xMax
+        range: Reactance
+        multivalued: false
+        required: true
+        description: "The reactance depends on the tap position according to a \"\
+          u\" shaped curve. The maximum reactance (xMax) appears at the low and high\
+          \ tap positions. Depending on the \u201Cu\u201D curve the attribute can\
+          \ be either higher or lower than PowerTransformerEnd.x."
+      xMin:
+        slot_uri: cim:PhaseTapChangerNonLinear.xMin
+        range: Reactance
+        multivalued: false
+        required: true
+        description: The reactance depend on the tap position according to a "u" shaped
+          curve. The minimum reactance (xMin) appear at the mid tap position.   PowerTransformerEnd.x
+          shall be consistent with PhaseTapChangerLinear.xMin and PhaseTapChangerNonLinear.xMin.
+          In case of inconsistency, PowerTransformerEnd.x shall be used.
+    is_a: PhaseTapChanger
+    description: The non-linear phase tap changer describes the non-linear behaviour
+      of a phase tap changer. This is a base class for the symmetrical and asymmetrical
+      phase tap changer models. The details of these models can be found in IEC 61970-301.
+  PhaseTapChangerSymmetrical:
+    class_uri: cim:PhaseTapChangerSymmetrical
+    is_a: PhaseTapChangerNonLinear
+    description: Describes a symmetrical phase shifting transformer tap model in which
+      the voltage magnitude of both sides is the same. The difference voltage magnitude
+      is the base in an equal-sided triangle where the sides corresponds to the primary
+      and secondary voltages. The phase angle difference corresponds to the top angle
+      and can be expressed as twice the arctangent of half the total difference voltage.
+  PhaseTapChangerTable:
+    class_uri: cim:PhaseTapChangerTable
+    attributes:
+      PhaseTapChangerTablePoint:
+        slot_uri: cim:PhaseTapChangerTable.PhaseTapChangerTablePoint
+        range: PhaseTapChangerTablePoint
+        multivalued: true
+        required: true
+        description: The points of this table.
+      PhaseTapChangerTabular:
+        slot_uri: cim:PhaseTapChangerTable.PhaseTapChangerTabular
+        range: PhaseTapChangerTabular
+        multivalued: true
+        required: false
+        description: The phase tap changers to which this phase tap table applies.
+    is_a: IdentifiedObject
+    description: Describes a tabular curve for how the phase angle difference and
+      impedance varies with the tap step.
+  PhaseTapChangerTablePoint:
+    class_uri: cim:PhaseTapChangerTablePoint
+    attributes:
+      PhaseTapChangerTable:
+        slot_uri: cim:PhaseTapChangerTablePoint.PhaseTapChangerTable
+        range: PhaseTapChangerTable
+        multivalued: false
+        required: true
+        description: The table of this point.
+      angle:
+        slot_uri: cim:PhaseTapChangerTablePoint.angle
+        range: AngleDegrees
+        multivalued: false
+        required: true
+        description: The angle difference in degrees. A positive value indicates a
+          positive angle variation from the Terminal at the  PowerTransformerEnd,  where
+          the TapChanger is located, into the transformer.
+    is_a: TapChangerTablePoint
+    description: Describes each tap step in the phase tap changer tabular curve.
+  PhaseTapChangerTabular:
+    class_uri: cim:PhaseTapChangerTabular
+    attributes:
+      PhaseTapChangerTable:
+        slot_uri: cim:PhaseTapChangerTabular.PhaseTapChangerTable
+        range: PhaseTapChangerTable
+        multivalued: false
+        required: true
+        description: The phase tap changer table for this phase tap changer.
+    is_a: PhaseTapChanger
+    description: Describes a tap changer with a table defining the relation between
+      the tap step and the phase angle difference across the transformer.
+  PhotoVoltaicUnit:
+    class_uri: cim:PhotoVoltaicUnit
+    is_a: PowerElectronicsUnit
+    description: A photovoltaic device or an aggregation of such devices.
+  PostLineSensor:
+    class_uri: cim:PostLineSensor
+    is_a: Sensor
+    description: A sensor used mainly in overhead distribution networks as the source
+      of both current and voltage measurements.
+  PotentialTransformer:
+    class_uri: cim:PotentialTransformer
+    is_a: Sensor
+    description: Instrument transformer (also known as Voltage Transformer) used to
+      measure electrical qualities of the circuit that is being protected and/or monitored.
+      Typically used as voltage transducer for the purpose of metering, protection,
+      or sometimes auxiliary substation supply. A typical secondary voltage rating
+      would be 120V.
+  PowerElectronicsConnection:
+    class_uri: cim:PowerElectronicsConnection
+    attributes:
+      maxQ:
+        slot_uri: cim:PowerElectronicsConnection.maxQ
+        range: ReactivePower
+        multivalued: false
+        required: false
+        description: Maximum reactive power limit. This is the maximum (nameplate)
+          limit for the unit.
+      minQ:
+        slot_uri: cim:PowerElectronicsConnection.minQ
+        range: ReactivePower
+        multivalued: false
+        required: false
+        description: Minimum reactive power limit for the unit. This is the minimum
+          (nameplate) limit for the unit.
+      ratedS:
+        slot_uri: cim:PowerElectronicsConnection.ratedS
+        range: ApparentPower
+        multivalued: false
+        required: false
+        description: 'Nameplate apparent power rating for the unit.
+
+          The attribute shall have a positive value.'
+      ratedU:
+        slot_uri: cim:PowerElectronicsConnection.ratedU
+        range: Voltage
+        multivalued: false
+        required: false
+        description: 'Rated voltage (nameplate data, Ur in IEC 60909-0). It is primarily
+          used for short circuit data exchange according to IEC 60909.
+
+          The attribute shall be a positive value.'
+      PowerElectronicsUnit:
+        slot_uri: cim:PowerElectronicsConnection.PowerElectronicsUnit
+        range: PowerElectronicsUnit
+        multivalued: false
+        required: false
+        description: An AC network connection may have several power electronics units
+          connecting through it.
+    is_a: RegulatingCondEq
+    description: A connection to the AC network for energy production or consumption
+      that uses power electronics rather than rotating machines.
+  PowerElectronicsUnit:
+    class_uri: cim:PowerElectronicsUnit
+    attributes:
+      PowerElectronicsConnection:
+        slot_uri: cim:PowerElectronicsUnit.PowerElectronicsConnection
+        range: PowerElectronicsConnection
+        multivalued: false
+        required: true
+        description: A power electronics unit has a connection to the AC network.
+      maxP:
+        slot_uri: cim:PowerElectronicsUnit.maxP
+        range: ActivePower
+        multivalued: false
+        required: false
+        description: Maximum active power limit. This is the maximum (nameplate) limit
+          for the unit.
+      minP:
+        slot_uri: cim:PowerElectronicsUnit.minP
+        range: ActivePower
+        multivalued: false
+        required: false
+        description: Minimum active power limit. This is the minimum (nameplate) limit
+          for the unit.
+    is_a: Equipment
+    description: A generating unit or battery or aggregation that connects to the
+      AC network using power electronics rather than rotating machines.
+  PowerElectronicsWindUnit:
+    class_uri: cim:PowerElectronicsWindUnit
+    is_a: PowerElectronicsUnit
+    description: A wind generating unit that connects to the AC network with power
+      electronics rather than rotating machines or an aggregation of such units.
+  PowerSystemResource:
+    class_uri: cim:PowerSystemResource
+    is_a: IdentifiedObject
+    description: A power system resource (PSR) can be an item of equipment such as
+      a switch, an equipment container containing many individual items of equipment
+      such as a substation, or an organisational entity such as sub-control area.
+      Power system resources can have measurements associated.
+  PowerTransformer:
+    class_uri: cim:PowerTransformer
+    attributes:
+      PowerTransformerEnd:
+        slot_uri: cim:PowerTransformer.PowerTransformerEnd
+        range: PowerTransformerEnd
+        multivalued: true
+        required: false
+        description: The ends of this power transformer.
+    is_a: ConductingEquipment
+    description: 'An electrical device consisting of  two or more coupled windings,
+      with or without a magnetic core, for introducing mutual coupling between electric
+      circuits. Transformers can be used to control voltage and phase shift (active
+      power flow).
+
+      A power transformer may be composed of separate transformer tanks that need
+      not be identical.
+
+      A power transformer can be modelled with or without tanks and is intended for
+      use in both balanced and unbalanced representations.   A power transformer typically
+      has two terminals, but may have one (grounding), three or more terminals.
+
+      The inherited association ConductingEquipment.BaseVoltage should not be used.  The
+      association from TransformerEnd to BaseVoltage should be used instead.'
+  PowerTransformerEnd:
+    class_uri: cim:PowerTransformerEnd
+    attributes:
+      PowerTransformer:
+        slot_uri: cim:PowerTransformerEnd.PowerTransformer
+        range: PowerTransformer
+        multivalued: false
+        required: true
+        description: The power transformer of this power transformer end.
+      b:
+        slot_uri: cim:PowerTransformerEnd.b
+        range: Susceptance
+        multivalued: false
+        required: true
+        description: Magnetizing branch susceptance (B mag).  The value can be positive
+          or negative.
+      connectionKind:
+        slot_uri: cim:PowerTransformerEnd.connectionKind
+        range: WindingConnection
+        multivalued: false
+        required: false
+        description: Kind of connection.
+      ratedS:
+        slot_uri: cim:PowerTransformerEnd.ratedS
+        range: ApparentPower
+        multivalued: false
+        required: false
+        description: 'Normal apparent power rating.
+
+          The attribute shall be a positive value. For a two-winding transformer the
+          values for the high and low voltage sides shall be identical.'
+      g:
+        slot_uri: cim:PowerTransformerEnd.g
+        range: Conductance
+        multivalued: false
+        required: false
+        description: Magnetizing branch conductance.
+      ratedU:
+        slot_uri: cim:PowerTransformerEnd.ratedU
+        range: Voltage
+        multivalued: false
+        required: true
+        description: 'Rated voltage: phase-phase for three-phase windings, and either
+          phase-phase or phase-neutral for single-phase windings.
+
+          A high voltage side, as given by TransformerEnd.endNumber, shall have a
+          ratedU that is greater than or equal to ratedU for the lower voltage sides.
+
+          The attribute shall be a positive value.'
+      r:
+        slot_uri: cim:PowerTransformerEnd.r
+        range: Resistance
+        multivalued: false
+        required: true
+        description: 'Resistance (star-model) of the transformer end.
+
+          The attribute shall be equal to or greater than zero for non-equivalent
+          transformers.'
+      x:
+        slot_uri: cim:PowerTransformerEnd.x
+        range: Reactance
+        multivalued: false
+        required: true
+        description: Positive sequence series reactance (star-model) of the transformer
+          end.
+    is_a: TransformerEnd
+    description: 'A PowerTransformerEnd is associated with each Terminal of a PowerTransformer.
+
+      The impedance values r, r0, x, and x0 of a PowerTransformerEnd represents a
+      star equivalent as follows.
+
+      1) for a two Terminal PowerTransformer the high voltage (TransformerEnd.endNumber=1)
+      PowerTransformerEnd has non zero values on r, r0, x, and x0 while the low voltage
+      (TransformerEnd.endNumber=2) PowerTransformerEnd has zero values for r, r0,
+      x, and x0.  Parameters are always provided, even if the PowerTransformerEnds
+      have the same rated voltage.  In this case, the parameters are provided at the
+      PowerTransformerEnd which has TransformerEnd.endNumber equal to 1.
+
+      2) for a three Terminal PowerTransformer the three PowerTransformerEnds represent
+      a star equivalent with each leg in the star represented by r, r0, x, and x0
+      values.
+
+      3) For a three Terminal transformer each PowerTransformerEnd shall have g, g0,
+      b and b0 values corresponding to the no load losses distributed on the three
+      PowerTransformerEnds. The total no load loss shunt impedances may also be placed
+      at one of the PowerTransformerEnds, preferably the end numbered 1, having the
+      shunt values on end 1.  This is the preferred way.
+
+      4) for a PowerTransformer with more than three Terminals the PowerTransformerEnd
+      impedance values cannot be used. Instead use the TransformerMeshImpedance or
+      split the transformer into multiple PowerTransformers.
+
+      Each PowerTransformerEnd must be contained by a PowerTransformer. Because a
+      PowerTransformerEnd (or any other object) can not be contained by more than
+      one parent, a PowerTransformerEnd can not have an association to an EquipmentContainer
+      (Substation, VoltageLevel, etc).'
+  ProtectedSwitch:
+    class_uri: cim:ProtectedSwitch
+    is_a: Switch
+    description: A ProtectedSwitch is a switching device that can be operated by ProtectionEquipment.
+  RatioTapChanger:
+    class_uri: cim:RatioTapChanger
+    attributes:
+      stepVoltageIncrement:
+        slot_uri: cim:RatioTapChanger.stepVoltageIncrement
+        range: PerCent
+        multivalued: false
+        required: true
+        description: 'Tap step increment, in per cent of rated voltage of the power
+          transformer end, per step position.
+
+          When the increment is negative, the voltage decreases when the tap step
+          increases.'
+      RatioTapChangerTable:
+        slot_uri: cim:RatioTapChanger.RatioTapChangerTable
+        range: RatioTapChangerTable
+        multivalued: false
+        required: false
+        description: The tap ratio table for this ratio  tap changer.
+      TransformerEnd:
+        slot_uri: cim:RatioTapChanger.TransformerEnd
+        range: TransformerEnd
+        multivalued: false
+        required: true
+        description: Transformer end to which this ratio tap changer belongs.
+    is_a: TapChanger
+    description: 'A tap changer that changes the voltage ratio impacting the voltage
+      magnitude but not the phase angle across the transformer.
+
+
+      Angle sign convention (general): Positive value indicates a positive phase shift
+      from the winding where the tap is located to the other winding (for a two-winding
+      transformer).'
+  RatioTapChangerTable:
+    class_uri: cim:RatioTapChangerTable
+    attributes:
+      RatioTapChanger:
+        slot_uri: cim:RatioTapChangerTable.RatioTapChanger
+        range: RatioTapChanger
+        multivalued: true
+        required: false
+        description: The ratio tap changer of this tap ratio table.
+      RatioTapChangerTablePoint:
+        slot_uri: cim:RatioTapChangerTable.RatioTapChangerTablePoint
+        range: RatioTapChangerTablePoint
+        multivalued: true
+        required: true
+        description: Points of this table.
+    is_a: IdentifiedObject
+    description: Describes a curve for how the voltage magnitude and impedance varies
+      with the tap step.
+  RatioTapChangerTablePoint:
+    class_uri: cim:RatioTapChangerTablePoint
+    attributes:
+      RatioTapChangerTable:
+        slot_uri: cim:RatioTapChangerTablePoint.RatioTapChangerTable
+        range: RatioTapChangerTable
+        multivalued: false
+        required: true
+        description: Table of this point.
+    is_a: TapChangerTablePoint
+    description: Describes each tap step in the ratio tap changer tabular curve.
+  ReactiveCapabilityCurve:
+    class_uri: cim:ReactiveCapabilityCurve
+    attributes:
+      EquivalentInjection:
+        slot_uri: cim:ReactiveCapabilityCurve.EquivalentInjection
+        range: EquivalentInjection
+        multivalued: true
+        required: false
+        description: The equivalent injection using this reactive capability curve.
+      InitiallyUsedBySynchronousMachines:
+        slot_uri: cim:ReactiveCapabilityCurve.InitiallyUsedBySynchronousMachines
+        range: SynchronousMachine
+        multivalued: true
+        required: true
+        description: Synchronous machines using this curve as default.
+    is_a: Curve
+    description: Reactive power rating envelope versus the synchronous machine's active
+      power, in both the generating and motoring modes. For each active power value
+      there is a corresponding high and low reactive power limit  value. Typically
+      there will be a separate curve for each coolant condition, such as hydrogen
+      pressure.  The Y1 axis values represent reactive minimum and the Y2 axis values
+      represent reactive maximum.
+  RegulatingCondEq:
+    class_uri: cim:RegulatingCondEq
+    attributes:
+      RegulatingControl:
+        slot_uri: cim:RegulatingCondEq.RegulatingControl
+        range: RegulatingControl
+        multivalued: false
+        required: false
+        description: The regulating control scheme in which this equipment participates.
+    is_a: EnergyConnection
+    description: A type of conducting equipment that can regulate a quantity (i.e.
+      voltage or flow) at a specific point in the network.
+  RegulatingControl:
+    class_uri: cim:RegulatingControl
+    attributes:
+      RegulationSchedule:
+        slot_uri: cim:RegulatingControl.RegulationSchedule
+        range: RegulationSchedule
+        multivalued: true
+        required: false
+        description: Schedule for this regulating control.
+      RegulatingCondEq:
+        slot_uri: cim:RegulatingControl.RegulatingCondEq
+        range: RegulatingCondEq
+        multivalued: true
+        required: false
+        description: The equipment that participates in this regulating control scheme.
+      mode:
+        slot_uri: cim:RegulatingControl.mode
+        range: RegulatingControlModeKind
+        multivalued: false
+        required: true
+        description: The regulating control mode presently available.  This specification
+          allows for determining the kind of regulation without need for obtaining
+          the units from a schedule.
+      Terminal:
+        slot_uri: cim:RegulatingControl.Terminal
+        range: Terminal
+        multivalued: false
+        required: true
+        description: The terminal associated with this regulating control.  The terminal
+          is associated instead of a node, since the terminal could connect into either
+          a topological node or a connectivity node.  Sometimes it is useful to model
+          regulation at a terminal of a bus bar object.
+    is_a: PowerSystemResource
+    description: "Specifies a set of equipment that works together to control a power\
+      \ system quantity such as voltage or flow. \nRemote bus voltage control is possible\
+      \ by specifying the controlled terminal located at some place remote from the\
+      \ controlling equipment.\nThe specified terminal shall be associated with the\
+      \ connectivity node of the controlled point.  The most specific subtype of RegulatingControl\
+      \ shall be used in case such equipment participate in the control, e.g. TapChangerControl\
+      \ for tap changers.\nFor flow control, load sign convention is used, i.e. positive\
+      \ sign means flow out from a TopologicalNode (bus) into the conducting equipment.\n\
+      The attribute minAllowedTargetValue and maxAllowedTargetValue are required in\
+      \ the following cases:\n- For a power generating module operated in power factor\
+      \ control mode to specify maximum and minimum power factor values;\n- Whenever\
+      \ it is necessary to have an off center target voltage for the tap changer regulator.\
+      \ For instance, due to long cables to off shore wind farms and the need to have\
+      \ a simpler setup at the off shore transformer platform, the voltage is controlled\
+      \ from the land at the connection point for the off shore wind farm. Since there\
+      \ usually is a voltage rise along the cable, there is typical and overvoltage\
+      \ of up 3-4 kV compared to the on shore station. Thus in normal operation the\
+      \ tap changer on the on shore station is operated with a target set point, which\
+      \ is in the lower parts of the dead band.\nThe attributes minAllowedTargetValue\
+      \ and maxAllowedTargetValue are not related to the attribute targetDeadband\
+      \ and thus they are not treated as an alternative of the targetDeadband. They\
+      \ are needed due to limitations in the local substation controller. The attribute\
+      \ targetDeadband is used to prevent the power flow from move the tap position\
+      \ in circles (hunting) that is to be used regardless of the attributes minAllowedTargetValue\
+      \ and maxAllowedTargetValue."
+  RegularTimePoint:
+    class_uri: cim:RegularTimePoint
+    attributes:
+      sequenceNumber:
+        slot_uri: cim:RegularTimePoint.sequenceNumber
+        range: integer
+        multivalued: false
+        required: true
+        description: The position of the regular time point in the sequence. Note
+          that time points don't have to be sequential, i.e. time points may be omitted.
+          The actual time for a RegularTimePoint is computed by multiplying the associated
+          regular interval schedule's time step with the regular time point sequence
+          number and adding the associated schedules start time. To specify values
+          for the start time, use sequence number 0.  The sequence number cannot be
+          negative.
+      value1:
+        slot_uri: cim:RegularTimePoint.value1
+        range: float
+        multivalued: false
+        required: true
+        description: The first value at the time. The meaning of the value is defined
+          by the derived type of the associated schedule.
+      value2:
+        slot_uri: cim:RegularTimePoint.value2
+        range: float
+        multivalued: false
+        required: false
+        description: The second value at the time. The meaning of the value is defined
+          by the derived type of the associated schedule.
+      IntervalSchedule:
+        slot_uri: cim:RegularTimePoint.IntervalSchedule
+        range: RegularIntervalSchedule
+        multivalued: false
+        required: true
+        description: Regular interval schedule containing this time point.
+    description: Time point for a schedule where the time between the consecutive
+      points is constant.
+  RegularIntervalSchedule:
+    class_uri: cim:RegularIntervalSchedule
+    attributes:
+      TimePoints:
+        slot_uri: cim:RegularIntervalSchedule.TimePoints
+        range: RegularTimePoint
+        multivalued: true
+        required: true
+        description: The regular interval time point data values that define this
+          schedule.
+      timeStep:
+        slot_uri: cim:RegularIntervalSchedule.timeStep
+        range: Seconds
+        multivalued: false
+        required: true
+        description: The time between each pair of subsequent regular time points
+          in sequence order.
+      endTime:
+        slot_uri: cim:RegularIntervalSchedule.endTime
+        range: date
+        multivalued: false
+        required: true
+        description: The time for the last time point.  The value can be a time of
+          day, not a specific date.
+    is_a: BasicIntervalSchedule
+    description: The schedule has time points where the time between them is constant.
+  ReportingGroup:
+    class_uri: cim:ReportingGroup
+    attributes:
+      BusNameMarker:
+        slot_uri: cim:ReportingGroup.BusNameMarker
+        range: BusNameMarker
+        multivalued: true
+        required: false
+        description: The bus name markers that belong to this reporting group.
+    is_a: IdentifiedObject
+    description: A reporting group is used for various ad-hoc groupings used for reporting.
+  RotatingMachine:
+    class_uri: cim:RotatingMachine
+    attributes:
+      GeneratingUnit:
+        slot_uri: cim:RotatingMachine.GeneratingUnit
+        range: GeneratingUnit
+        multivalued: false
+        required: false
+        description: A synchronous machine may operate as a generator and as such
+          becomes a member of a generating unit.
+      HydroPump:
+        slot_uri: cim:RotatingMachine.HydroPump
+        range: HydroPump
+        multivalued: false
+        required: false
+        description: The synchronous machine drives the turbine which moves the water
+          from a low elevation to a higher elevation. The direction of machine rotation
+          for pumping may or may not be the same as for generating.
+      ratedPowerFactor:
+        slot_uri: cim:RotatingMachine.ratedPowerFactor
+        range: float
+        multivalued: false
+        required: false
+        description: Power factor (nameplate data). It is primarily used for short
+          circuit data exchange according to IEC 60909. The attribute cannot be a
+          negative value.
+      ratedS:
+        slot_uri: cim:RotatingMachine.ratedS
+        range: ApparentPower
+        multivalued: false
+        required: false
+        description: 'Nameplate apparent power rating for the unit.
+
+          The attribute shall have a positive value.'
+      ratedU:
+        slot_uri: cim:RotatingMachine.ratedU
+        range: Voltage
+        multivalued: false
+        required: false
+        description: 'Rated voltage (nameplate data, Ur in IEC 60909-0). It is primarily
+          used for short circuit data exchange according to IEC 60909.
+
+          The attribute shall be a positive value.'
+    is_a: RegulatingCondEq
+    description: A rotating machine which may be used as a generator or motor.
+  Season:
+    class_uri: cim:Season
+    attributes:
+      endDate:
+        slot_uri: cim:Season.endDate
+        range: date
+        multivalued: false
+        required: true
+        description: Date season ends.
+      startDate:
+        slot_uri: cim:Season.startDate
+        range: date
+        multivalued: false
+        required: true
+        description: Date season starts.
+      SeasonDayTypeSchedules:
+        slot_uri: cim:Season.SeasonDayTypeSchedules
+        range: SeasonDayTypeSchedule
+        multivalued: true
+        required: false
+        description: Schedules that use this Season.
+    is_a: IdentifiedObject
+    description: A specified time period of the year.
+  Sensor:
+    class_uri: cim:Sensor
+    is_a: AuxiliaryEquipment
+    description: This class describe devices that transform a measured quantity into
+      signals that can be presented at displays, used in control or be recorded.
+  SeasonDayTypeSchedule:
+    class_uri: cim:SeasonDayTypeSchedule
+    attributes:
+      DayType:
+        slot_uri: cim:SeasonDayTypeSchedule.DayType
+        range: DayType
+        multivalued: false
+        required: true
+        description: DayType for the Schedule.
+      Season:
+        slot_uri: cim:SeasonDayTypeSchedule.Season
+        range: Season
+        multivalued: false
+        required: true
+        description: Season for the Schedule.
+    is_a: RegularIntervalSchedule
+    description: A time schedule covering a 24 hour period, with curve data for a
+      specific type of season and day.
+  SeriesCompensator:
+    class_uri: cim:SeriesCompensator
+    attributes:
+      r:
+        slot_uri: cim:SeriesCompensator.r
+        range: Resistance
+        multivalued: false
+        required: true
+        description: Positive sequence resistance.
+      x:
+        slot_uri: cim:SeriesCompensator.x
+        range: Reactance
+        multivalued: false
+        required: true
+        description: Positive sequence reactance.
+    is_a: ConductingEquipment
+    description: A Series Compensator is a series capacitor or reactor or an AC transmission
+      line without charging susceptance.  It is a two terminal device.
+  ShuntCompensator:
+    class_uri: cim:ShuntCompensator
+    attributes:
+      aVRDelay:
+        slot_uri: cim:ShuntCompensator.aVRDelay
+        range: Seconds
+        multivalued: false
+        required: false
+        description: An automatic voltage regulation delay (AVRDelay) which is the
+          time delay from a change in voltage to when the capacitor is allowed to
+          change state. This filters out temporary changes in voltage.
+      grounded:
+        slot_uri: cim:ShuntCompensator.grounded
+        range: boolean
+        multivalued: false
+        required: false
+        description: Used for Yn and Zn connections. True if the neutral is solidly
+          grounded.
+      maximumSections:
+        slot_uri: cim:ShuntCompensator.maximumSections
+        range: integer
+        multivalued: false
+        required: true
+        description: The maximum number of sections that may be switched in.
+      nomU:
+        slot_uri: cim:ShuntCompensator.nomU
+        range: Voltage
+        multivalued: false
+        required: true
+        description: The voltage at which the nominal reactive power may be calculated.
+          This should normally be within 10% of the voltage at which the capacitor
+          is connected to the network.
+      normalSections:
+        slot_uri: cim:ShuntCompensator.normalSections
+        range: integer
+        multivalued: false
+        required: true
+        description: The normal number of sections switched in. The value shall be
+          between zero and ShuntCompensator.maximumSections.
+      voltageSensitivity:
+        slot_uri: cim:ShuntCompensator.voltageSensitivity
+        range: VoltagePerReactivePower
+        multivalued: false
+        required: false
+        description: Voltage sensitivity required for the device to regulate the bus
+          voltage, in voltage/reactive power.
+    is_a: RegulatingCondEq
+    description: A shunt capacitor or reactor or switchable bank of shunt capacitors
+      or reactors. A section of a shunt compensator is an individual capacitor or
+      reactor. A negative value for bPerSection indicates that the compensator is
+      a reactor. ShuntCompensator is a single terminal device.  Ground is implied.
+  VoltagePerReactivePower:
+    class_uri: cim:VoltagePerReactivePower
+    attributes:
+      value:
+        slot_uri: cim:VoltagePerReactivePower.value
+        range: float
+        multivalued: false
+        required: false
+      unit:
+        slot_uri: cim:VoltagePerReactivePower.unit
+        range: UnitSymbol
+        multivalued: false
+        required: false
+      multiplier:
+        slot_uri: cim:VoltagePerReactivePower.multiplier
+        range: UnitMultiplier
+        multivalued: false
+        required: false
+    description: Voltage variation with reactive power.
+  SolarGeneratingUnit:
+    class_uri: cim:SolarGeneratingUnit
+    attributes:
+      SolarPowerPlant:
+        slot_uri: eu:SolarGeneratingUnit.SolarPowerPlant
+        range: SolarPowerPlant
+        multivalued: false
+        required: false
+        description: A solar power plant may have solar generating units.
+    is_a: GeneratingUnit
+    description: A solar thermal generating unit, connected to the grid by means of
+      a rotating machine.  This class does not represent photovoltaic (PV) generation.
+  SolarPowerPlant:
+    class_uri: eu:SolarPowerPlant
+    attributes:
+      SolarGeneratingUnits:
+        slot_uri: eu:SolarPowerPlant.SolarGeneratingUnits
+        range: SolarGeneratingUnit
+        multivalued: true
+        required: false
+        description: A solar generating unit or units may be a member of a solar power
+          plant.
+    is_a: PowerSystemResource
+    description: Solar power plant.
+  StaticVarCompensator:
+    class_uri: cim:StaticVarCompensator
+    attributes:
+      capacitiveRating:
+        slot_uri: cim:StaticVarCompensator.capacitiveRating
+        range: Reactance
+        multivalued: false
+        required: true
+        description: Capacitive reactance at maximum capacitive reactive power.  Shall
+          always be positive.
+      inductiveRating:
+        slot_uri: cim:StaticVarCompensator.inductiveRating
+        range: Reactance
+        multivalued: false
+        required: true
+        description: Inductive reactance at maximum inductive reactive power.  Shall
+          always be negative.
+      slope:
+        slot_uri: cim:StaticVarCompensator.slope
+        range: VoltagePerReactivePower
+        multivalued: false
+        required: true
+        description: 'The characteristics slope of an SVC defines how the reactive
+          power output changes in proportion to the difference between the regulated
+          bus voltage and the voltage setpoint.
+
+          The attribute shall be a positive value or zero.'
+      sVCControlMode:
+        slot_uri: cim:StaticVarCompensator.sVCControlMode
+        range: SVCControlMode
+        multivalued: false
+        required: false
+        description: SVC control mode.
+      voltageSetPoint:
+        slot_uri: cim:StaticVarCompensator.voltageSetPoint
+        range: Voltage
+        multivalued: false
+        required: false
+        description: The reactive power output of the SVC is proportional to the difference
+          between the voltage at the regulated bus and the voltage setpoint.  When
+          the regulated bus voltage is equal to the voltage setpoint, the reactive
+          power output is zero.
+    is_a: RegulatingCondEq
+    description: 'A facility for providing variable and controllable shunt reactive
+      power. The SVC typically consists of a stepdown transformer, filter, thyristor-controlled
+      reactor, and thyristor-switched capacitor arms.
+
+
+      The SVC may operate in fixed MVar output mode or in voltage control mode. When
+      in voltage control mode, the output of the SVC will be proportional to the deviation
+      of voltage at the controlled bus from the voltage setpoint.  The SVC characteristic
+      slope defines the proportion.  If the voltage at the controlled bus is equal
+      to the voltage setpoint, the SVC MVar output is zero.'
+  StationSupply:
+    class_uri: cim:StationSupply
+    is_a: EnergyConsumer
+    description: Station supply with load derived from the station output.
+  SubGeographicalRegion:
+    class_uri: cim:SubGeographicalRegion
+    attributes:
+      DCLines:
+        slot_uri: cim:SubGeographicalRegion.DCLines
+        range: DCLine
+        multivalued: true
+        required: false
+        description: The DC lines in this sub-geographical region.
+      Region:
+        slot_uri: cim:SubGeographicalRegion.Region
+        range: GeographicalRegion
+        multivalued: false
+        required: true
+        description: The geographical region which this sub-geographical region is
+          within.
+      Lines:
+        slot_uri: cim:SubGeographicalRegion.Lines
+        range: Line
+        multivalued: true
+        required: false
+        description: The lines within the sub-geographical region.
+      Substations:
+        slot_uri: cim:SubGeographicalRegion.Substations
+        range: Substation
+        multivalued: true
+        required: false
+        description: The substations in this sub-geographical region.
+    is_a: IdentifiedObject
+    description: A subset of a geographical region of a power system network model.
+  SubLoadArea:
+    class_uri: cim:SubLoadArea
+    attributes:
+      LoadArea:
+        slot_uri: cim:SubLoadArea.LoadArea
+        range: LoadArea
+        multivalued: false
+        required: true
+        description: The LoadArea where the SubLoadArea belongs.
+      LoadGroups:
+        slot_uri: cim:SubLoadArea.LoadGroups
+        range: LoadGroup
+        multivalued: true
+        required: true
+        description: The Loadgroups in the SubLoadArea.
+    is_a: EnergyArea
+    description: The class is the second level in a hierarchical structure for grouping
+      of loads for the purpose of load flow load scaling.
+  Substation:
+    class_uri: cim:Substation
+    attributes:
+      DCConverterUnit:
+        slot_uri: cim:Substation.DCConverterUnit
+        range: DCConverterUnit
+        multivalued: true
+        required: false
+        description: The DC converter unit belonging of the substation.
+      Region:
+        slot_uri: cim:Substation.Region
+        range: SubGeographicalRegion
+        multivalued: false
+        required: true
+        description: The SubGeographicalRegion containing the substation.
+      VoltageLevels:
+        slot_uri: cim:Substation.VoltageLevels
+        range: VoltageLevel
+        multivalued: true
+        required: false
+        description: The voltage levels within this substation.
+    is_a: EquipmentContainer
+    description: A collection of equipment for purposes other than generation or utilization,
+      through which electric energy in bulk is passed for the purposes of switching
+      or modifying its characteristics.
+  SurgeArrester:
+    class_uri: cim:SurgeArrester
+    is_a: AuxiliaryEquipment
+    description: Shunt device, installed on the network, usually in the proximity
+      of electrical equipment in order to protect the said equipment against transient
+      voltage transients caused by lightning or switching activity.
+  Switch:
+    class_uri: cim:Switch
+    attributes:
+      normalOpen:
+        slot_uri: cim:Switch.normalOpen
+        range: boolean
+        multivalued: false
+        required: true
+        description: The attribute is used in cases when no Measurement for the status
+          value is present. If the Switch has a status measurement the Discrete.normalValue
+          is expected to match with the Switch.normalOpen.
+      ratedCurrent:
+        slot_uri: cim:Switch.ratedCurrent
+        range: CurrentFlow
+        multivalued: false
+        required: false
+        description: 'The maximum continuous current carrying capacity in amps governed
+          by the device material and construction.
+
+          The attribute shall be a positive value.'
+      retained:
+        slot_uri: cim:Switch.retained
+        range: boolean
+        multivalued: false
+        required: true
+        description: Branch is retained in the topological solution.  The flow through
+          retained switches will normally be calculated in power flow.
+      SwitchSchedules:
+        slot_uri: cim:Switch.SwitchSchedules
+        range: SwitchSchedule
+        multivalued: true
+        required: false
+        description: A Switch can be associated with SwitchSchedules.
+    is_a: ConductingEquipment
+    description: A generic device designed to close, or open, or both, one or more
+      electric circuits.  All switches are two terminal devices including grounding
+      switches. The ACDCTerminal.connected at the two sides of the switch shall not
+      be considered for assessing switch connectivity, i.e. only Switch.open, .normalOpen
+      and .locked are relevant.
+  SwitchSchedule:
+    class_uri: cim:SwitchSchedule
+    attributes:
+      Switch:
+        slot_uri: cim:SwitchSchedule.Switch
+        range: Switch
+        multivalued: false
+        required: true
+        description: A SwitchSchedule is associated with a Switch.
+    is_a: SeasonDayTypeSchedule
+    description: A schedule of switch positions.  If RegularTimePoint.value1 is 0,
+      the switch is open.  If 1, the switch is closed.
+  SynchronousMachine:
+    class_uri: cim:SynchronousMachine
+    attributes:
+      InitialReactiveCapabilityCurve:
+        slot_uri: cim:SynchronousMachine.InitialReactiveCapabilityCurve
+        range: ReactiveCapabilityCurve
+        multivalued: false
+        required: false
+        description: The default reactive capability curve for use by a synchronous
+          machine.
+      maxQ:
+        slot_uri: cim:SynchronousMachine.maxQ
+        range: ReactivePower
+        multivalued: false
+        required: false
+        description: Maximum reactive power limit. This is the maximum (nameplate)
+          limit for the unit.
+      minQ:
+        slot_uri: cim:SynchronousMachine.minQ
+        range: ReactivePower
+        multivalued: false
+        required: false
+        description: Minimum reactive power limit for the unit.
+      qPercent:
+        slot_uri: cim:SynchronousMachine.qPercent
+        range: PerCent
+        multivalued: false
+        required: false
+        description: Part of the coordinated reactive control that comes from this
+          machine. The attribute is used as a participation factor not necessarily
+          summing up to 100% for the participating devices in the control.
+      type:
+        slot_uri: cim:SynchronousMachine.type
+        range: SynchronousMachineKind
+        multivalued: false
+        required: true
+        description: Modes that this synchronous machine can operate in.
+    is_a: RotatingMachine
+    description: An electromechanical device that operates with shaft rotating synchronously
+      with the network. It is a single machine operating either as a generator or
+      synchronous condenser or pump.
+  TapChanger:
+    class_uri: cim:TapChanger
+    attributes:
+      TapSchedules:
+        slot_uri: cim:TapChanger.TapSchedules
+        range: TapSchedule
+        multivalued: true
+        required: false
+        description: A TapChanger can have TapSchedules.
+      highStep:
+        slot_uri: cim:TapChanger.highStep
+        range: integer
+        multivalued: false
+        required: true
+        description: 'Highest possible tap step position, advance from neutral.
+
+          The attribute shall be greater than lowStep.'
+      lowStep:
+        slot_uri: cim:TapChanger.lowStep
+        range: integer
+        multivalued: false
+        required: true
+        description: Lowest possible tap step position, retard from neutral.
+      ltcFlag:
+        slot_uri: cim:TapChanger.ltcFlag
+        range: boolean
+        multivalued: false
+        required: true
+        description: Specifies whether or not a TapChanger has load tap changing capabilities.
+      neutralStep:
+        slot_uri: cim:TapChanger.neutralStep
+        range: integer
+        multivalued: false
+        required: true
+        description: 'The neutral tap step position for this winding.
+
+          The attribute shall be equal to or greater than lowStep and equal or less
+          than highStep.
+
+          It is the step position where the voltage is neutralU when the other terminals
+          of the transformer are at the ratedU.  If there are other tap changers on
+          the transformer those taps are kept constant at their neutralStep.'
+      neutralU:
+        slot_uri: cim:TapChanger.neutralU
+        range: Voltage
+        multivalued: false
+        required: true
+        description: 'Voltage at which the winding operates at the neutral tap setting.
+          It is the voltage at the terminal of the PowerTransformerEnd associated
+          with the tap changer when all tap changers on the transformer are at their
+          neutralStep position.  Normally neutralU of the tap changer is the same
+          as ratedU of the PowerTransformerEnd, but it can differ in special cases
+          such as when the tapping mechanism is separate from the winding more common
+          on lower voltage transformers.
+
+          This attribute is not relevant for PhaseTapChangerAsymmetrical, PhaseTapChangerSymmetrical
+          and PhaseTapChangerLinear.'
+      normalStep:
+        slot_uri: cim:TapChanger.normalStep
+        range: integer
+        multivalued: false
+        required: true
+        description: 'The tap step position used in "normal" network operation for
+          this winding. For a "Fixed" tap changer indicates the current physical tap
+          setting.
+
+          The attribute shall be equal to or greater than lowStep and equal to or
+          less than highStep.'
+      TapChangerControl:
+        slot_uri: cim:TapChanger.TapChangerControl
+        range: TapChangerControl
+        multivalued: false
+        required: false
+        description: The regulating control scheme in which this tap changer participates.
+    is_a: PowerSystemResource
+    description: Mechanism for changing transformer winding tap positions.
+  TapChangerControl:
+    class_uri: cim:TapChangerControl
+    attributes:
+      TapChanger:
+        slot_uri: cim:TapChangerControl.TapChanger
+        range: TapChanger
+        multivalued: true
+        required: true
+        description: The tap changers that participates in this regulating tap control
+          scheme.
+    is_a: RegulatingControl
+    description: Describes behaviour specific to tap changers, e.g. how the voltage
+      at the end of a line varies with the load level and compensation of the voltage
+      drop by tap adjustment.
+  TapChangerTablePoint:
+    class_uri: cim:TapChangerTablePoint
+    attributes:
+      b:
+        slot_uri: cim:TapChangerTablePoint.b
+        range: PerCent
+        multivalued: false
+        required: false
+        description: 'The magnetizing branch susceptance deviation as a percentage
+          of nominal value. The actual susceptance is calculated as follows:
+
+          calculated magnetizing susceptance = b(nominal) * (1 + b(from this class)/100).   The
+          b(nominal) is defined as the static magnetizing susceptance on the associated
+          power transformer end or ends.  This model assumes the star impedance (pi
+          model) form.'
+      g:
+        slot_uri: cim:TapChangerTablePoint.g
+        range: PerCent
+        multivalued: false
+        required: false
+        description: 'The magnetizing branch conductance deviation as a percentage
+          of nominal value. The actual conductance is calculated as follows:
+
+          calculated magnetizing conductance = g(nominal) * (1 + g(from this class)/100).   The
+          g(nominal) is defined as the static magnetizing conductance on the associated
+          power transformer end or ends.  This model assumes the star impedance (pi
+          model) form.'
+      r:
+        slot_uri: cim:TapChangerTablePoint.r
+        range: PerCent
+        multivalued: false
+        required: false
+        description: 'The resistance deviation as a percentage of nominal value. The
+          actual reactance is calculated as follows:
+
+          calculated resistance = r(nominal) * (1 + r(from this class)/100).   The
+          r(nominal) is defined as the static resistance on the associated power transformer
+          end or ends.  This model assumes the star impedance (pi model) form.'
+      ratio:
+        slot_uri: cim:TapChangerTablePoint.ratio
+        range: float
+        multivalued: false
+        required: false
+        description: 'The voltage at the tap step divided by rated voltage of the
+          transformer end having the tap changer. Hence this is a value close to one.
+
+          For example, if the ratio at step 1 is 1.01, and the rated voltage of the
+          transformer end is 110kV, then the voltage obtained by setting the tap changer
+          to step 1 to is 111.1kV.'
+      step:
+        slot_uri: cim:TapChangerTablePoint.step
+        range: integer
+        multivalued: false
+        required: true
+        description: The tap step.
+      x:
+        slot_uri: cim:TapChangerTablePoint.x
+        range: PerCent
+        multivalued: false
+        required: false
+        description: 'The series reactance deviation as a percentage of nominal value.
+          The actual reactance is calculated as follows:
+
+          calculated reactance = x(nominal) * (1 + x(from this class)/100).   The
+          x(nominal) is defined as the static series reactance on the associated power
+          transformer end or ends.  This model assumes the star impedance (pi model)
+          form.'
+    description: Describes each tap step in the tabular curve.
+  Terminal:
+    class_uri: cim:Terminal
+    attributes:
+      ConverterDCSides:
+        slot_uri: cim:Terminal.ConverterDCSides
+        range: ACDCConverter
+        multivalued: true
+        required: false
+        description: All converters' DC sides linked to this point of common coupling
+          terminal.
+      AuxiliaryEquipment:
+        slot_uri: cim:Terminal.AuxiliaryEquipment
+        range: AuxiliaryEquipment
+        multivalued: true
+        required: false
+        description: The auxiliary equipment connected to the terminal.
+      ConductingEquipment:
+        slot_uri: cim:Terminal.ConductingEquipment
+        range: ConductingEquipment
+        multivalued: false
+        required: true
+        description: The conducting equipment of the terminal.  Conducting equipment
+          have  terminals that may be connected to other conducting equipment terminals
+          via connectivity nodes or topological nodes.
+      ConnectivityNode:
+        slot_uri: cim:Terminal.ConnectivityNode
+        range: ConnectivityNode
+        multivalued: false
+        required: false
+        description: The connectivity node to which this terminal connects with zero
+          impedance.
+      RegulatingControl:
+        slot_uri: cim:Terminal.RegulatingControl
+        range: RegulatingControl
+        multivalued: true
+        required: false
+        description: The controls regulating this terminal.
+      phases:
+        slot_uri: cim:Terminal.phases
+        range: PhaseCode
+        multivalued: false
+        required: false
+        description: 'Represents the normal network phasing condition. If the attribute
+          is missing, three phases (ABC) shall be assumed, except for terminals of
+          grounding classes (specializations of EarthFaultCompensator, GroundDisconnector,
+          and Ground) which will be assumed to be N. Therefore, phase code ABCN is
+          explicitly declared when needed, e.g. for star point grounding equipment.
+
+          The phase code on terminals connecting same ConnectivityNode or same TopologicalNode
+          as well as for equipment between two terminals shall be consistent.'
+      TransformerEnd:
+        slot_uri: cim:Terminal.TransformerEnd
+        range: TransformerEnd
+        multivalued: true
+        required: false
+        description: All transformer ends connected at this terminal.
+      TieFlow:
+        slot_uri: cim:Terminal.TieFlow
+        range: TieFlow
+        multivalued: true
+        required: false
+        description: The control area tie flows to which this terminal associates.
+    is_a: ACDCTerminal
+    description: An AC electrical connection point to a piece of conducting equipment.
+      Terminals are connected at physical connection points called connectivity nodes.
+  ThermalGeneratingUnit:
+    class_uri: cim:ThermalGeneratingUnit
+    attributes:
+      CAESPlant:
+        slot_uri: cim:ThermalGeneratingUnit.CAESPlant
+        range: CAESPlant
+        multivalued: false
+        required: false
+        description: A thermal generating unit may be a member of a compressed air
+          energy storage plant.
+      CogenerationPlant:
+        slot_uri: cim:ThermalGeneratingUnit.CogenerationPlant
+        range: CogenerationPlant
+        multivalued: false
+        required: false
+        description: A thermal generating unit may be a member of a cogeneration plant.
+      CombinedCyclePlant:
+        slot_uri: cim:ThermalGeneratingUnit.CombinedCyclePlant
+        range: CombinedCyclePlant
+        multivalued: false
+        required: false
+        description: A thermal generating unit may be a member of a combined cycle
+          plant.
+      FossilFuels:
+        slot_uri: cim:ThermalGeneratingUnit.FossilFuels
+        range: FossilFuel
+        multivalued: true
+        required: false
+        description: A thermal generating unit may have one or more fossil fuels.
+    is_a: GeneratingUnit
+    description: A generating unit whose prime mover could be a steam turbine, combustion
+      turbine, or diesel engine.
+  TieFlow:
+    class_uri: cim:TieFlow
+    attributes:
+      ControlArea:
+        slot_uri: cim:TieFlow.ControlArea
+        range: ControlArea
+        multivalued: false
+        required: true
+        description: The control area of the tie flows.
+      Terminal:
+        slot_uri: cim:TieFlow.Terminal
+        range: Terminal
+        multivalued: false
+        required: true
+        description: The terminal to which this tie flow belongs.
+      positiveFlowIn:
+        slot_uri: cim:TieFlow.positiveFlowIn
+        range: boolean
+        multivalued: false
+        required: true
+        description: Specifies the sign of the tie flow associated with a control
+          area. True if positive flow into the terminal (load convention) is also
+          positive flow into the control area.  See the description of ControlArea
+          for further explanation of how TieFlow.positiveFlowIn is used.
+    is_a: IdentifiedObject
+    description: Defines the structure (in terms of location and direction) of the
+      net interchange constraint for a control area. This constraint may be used by
+      either AGC or power flow.
+  TransformerEnd:
+    class_uri: cim:TransformerEnd
+    attributes:
+      BaseVoltage:
+        slot_uri: cim:TransformerEnd.BaseVoltage
+        range: BaseVoltage
+        multivalued: false
+        required: true
+        description: Base voltage of the transformer end.  This is essential for PU
+          calculation.
+      PhaseTapChanger:
+        slot_uri: cim:TransformerEnd.PhaseTapChanger
+        range: PhaseTapChanger
+        multivalued: false
+        required: false
+        description: Phase tap changer associated with this transformer end.
+      RatioTapChanger:
+        slot_uri: cim:TransformerEnd.RatioTapChanger
+        range: RatioTapChanger
+        multivalued: false
+        required: false
+        description: Ratio tap changer associated with this transformer end.
+      Terminal:
+        slot_uri: cim:TransformerEnd.Terminal
+        range: Terminal
+        multivalued: false
+        required: true
+        description: Terminal of the power transformer to which this transformer end
+          belongs.
+      endNumber:
+        slot_uri: cim:TransformerEnd.endNumber
+        range: integer
+        multivalued: false
+        required: true
+        description: Number for this transformer end, corresponding to the end's order
+          in the power transformer vector group or phase angle clock number.  Highest
+          voltage winding should be 1.  Each end within a power transformer should
+          have a unique subsequent end number.   Note the transformer end number need
+          not match the terminal sequence number.
+    is_a: IdentifiedObject
+    description: A conducting connection point of a power transformer. It corresponds
+      to a physical transformer winding terminal.  In earlier CIM versions, the TransformerWinding
+      class served a similar purpose, but this class is more flexible because it associates
+      to terminal but is not a specialization of ConductingEquipment.
+  VoltageLevel:
+    class_uri: cim:VoltageLevel
+    attributes:
+      BaseVoltage:
+        slot_uri: cim:VoltageLevel.BaseVoltage
+        range: BaseVoltage
+        multivalued: false
+        required: true
+        description: The base voltage used for all equipment within the voltage level.
+      Bays:
+        slot_uri: cim:VoltageLevel.Bays
+        range: Bay
+        multivalued: true
+        required: false
+        description: The bays within this voltage level.
+      Substation:
+        slot_uri: cim:VoltageLevel.Substation
+        range: Substation
+        multivalued: false
+        required: true
+        description: The substation of the voltage level.
+      highVoltageLimit:
+        slot_uri: cim:VoltageLevel.highVoltageLimit
+        range: Voltage
+        multivalued: false
+        required: false
+        description: 'The bus bar''s high voltage limit.
+
+          The limit applies to all equipment and nodes contained in a given VoltageLevel.
+          It is not required that it is exchanged in pair with lowVoltageLimit. It
+          is preferable to use operational VoltageLimit, which prevails, if present.'
+      lowVoltageLimit:
+        slot_uri: cim:VoltageLevel.lowVoltageLimit
+        range: Voltage
+        multivalued: false
+        required: false
+        description: 'The bus bar''s low voltage limit.
+
+          The limit applies to all equipment and nodes contained in a given VoltageLevel.
+          It is not required that it is exchanged in pair with highVoltageLimit. It
+          is preferable to use operational VoltageLimit, which prevails, if present.'
+    is_a: EquipmentContainer
+    description: A collection of equipment at one common system voltage forming a
+      switchgear. The equipment typically consists of breakers, busbars, instrumentation,
+      control, regulation and protection devices as well as assemblies of all these.
+  VoltageLimit:
+    class_uri: cim:VoltageLimit
+    attributes:
+      normalValue:
+        slot_uri: cim:VoltageLimit.normalValue
+        range: Voltage
+        multivalued: false
+        required: true
+        description: The normal limit on voltage. High or low limit nature of the
+          limit depends upon the properties of the operational limit type. The attribute
+          shall be a positive value or zero.
+    is_a: OperationalLimit
+    description: 'Operational limit applied to voltage.
+
+      The use of operational VoltageLimit is preferred instead of limits defined at
+      VoltageLevel. The operational VoltageLimits are used, if present.'
+  VsCapabilityCurve:
+    class_uri: cim:VsCapabilityCurve
+    attributes:
+      VsConverterDCSides:
+        slot_uri: cim:VsCapabilityCurve.VsConverterDCSides
+        range: VsConverter
+        multivalued: true
+        required: false
+        description: All converters with this capability curve.
+    is_a: Curve
+    description: The P-Q capability curve for a voltage source converter, with P on
+      X-axis and Qmin and Qmax on Y1-axis and Y2-axis.
+  VsConverter:
+    class_uri: cim:VsConverter
+    attributes:
+      CapabilityCurve:
+        slot_uri: cim:VsConverter.CapabilityCurve
+        range: VsCapabilityCurve
+        multivalued: false
+        required: false
+        description: Capability curve of this converter.
+      maxModulationIndex:
+        slot_uri: cim:VsConverter.maxModulationIndex
+        range: float
+        multivalued: false
+        required: false
+        description: "The maximum quotient between the AC converter voltage (Uc) and\
+          \ DC voltage (Ud). A factor typically less than 1. It is converter\u2019\
+          s configuration data used in power flow."
+    is_a: ACDCConverter
+    description: DC side of the voltage source converter (VSC).
+  WaveTrap:
+    class_uri: cim:WaveTrap
+    is_a: AuxiliaryEquipment
+    description: Line traps are devices that impede high frequency power line carrier
+      signals yet present a negligible impedance at the main power frequency.
+  WindGeneratingUnit:
+    class_uri: cim:WindGeneratingUnit
+    attributes:
+      windGenUnitType:
+        slot_uri: cim:WindGeneratingUnit.windGenUnitType
+        range: WindGenUnitKind
+        multivalued: false
+        required: true
+        description: The kind of wind generating unit.
+      WindPowerPlant:
+        slot_uri: eu:WindGeneratingUnit.WindPowerPlant
+        range: WindPowerPlant
+        multivalued: false
+        required: false
+        description: A wind power plant may have wind generating units.
+    is_a: GeneratingUnit
+    description: A wind driven generating unit, connected to the grid by means of
+      a rotating machine.  May be used to represent a single turbine or an aggregation.
+  WindPowerPlant:
+    class_uri: eu:WindPowerPlant
+    attributes:
+      WindGeneratingUnits:
+        slot_uri: eu:WindPowerPlant.WindGeneratingUnits
+        range: WindGeneratingUnit
+        multivalued: true
+        required: false
+        description: A wind generating unit or units may be a member of a wind power
+          plant.
+    is_a: PowerSystemResource
+    description: Wind power plant.
+enums:
+  UnitMultiplier:
+    permissible_values:
+      y:
+        meaning: cim:UnitMultiplier.y
+      z:
+        meaning: cim:UnitMultiplier.z
+      a:
+        meaning: cim:UnitMultiplier.a
+      f:
+        meaning: cim:UnitMultiplier.f
+      p:
+        meaning: cim:UnitMultiplier.p
+      n:
+        meaning: cim:UnitMultiplier.n
+      micro:
+        meaning: cim:UnitMultiplier.micro
+      m:
+        meaning: cim:UnitMultiplier.m
+      c:
+        meaning: cim:UnitMultiplier.c
+      d:
+        meaning: cim:UnitMultiplier.d
+      none:
+        meaning: cim:UnitMultiplier.none
+      da:
+        meaning: cim:UnitMultiplier.da
+      h:
+        meaning: cim:UnitMultiplier.h
+      k:
+        meaning: cim:UnitMultiplier.k
+      M:
+        meaning: cim:UnitMultiplier.M
+      G:
+        meaning: cim:UnitMultiplier.G
+      T:
+        meaning: cim:UnitMultiplier.T
+      P:
+        meaning: cim:UnitMultiplier.P
+      E:
+        meaning: cim:UnitMultiplier.E
+      Z:
+        meaning: cim:UnitMultiplier.Z
+      Y:
+        meaning: cim:UnitMultiplier.Y
+    enum_uri: http://iec.ch/TC57/CIM100#UnitMultiplier
+  UnitSymbol:
+    permissible_values:
+      none:
+        meaning: cim:UnitSymbol.none
+      m:
+        meaning: cim:UnitSymbol.m
+      kg:
+        meaning: cim:UnitSymbol.kg
+      s:
+        meaning: cim:UnitSymbol.s
+      A:
+        meaning: cim:UnitSymbol.A
+      K:
+        meaning: cim:UnitSymbol.K
+      mol:
+        meaning: cim:UnitSymbol.mol
+      cd:
+        meaning: cim:UnitSymbol.cd
+      deg:
+        meaning: cim:UnitSymbol.deg
+      rad:
+        meaning: cim:UnitSymbol.rad
+      sr:
+        meaning: cim:UnitSymbol.sr
+      Gy:
+        meaning: cim:UnitSymbol.Gy
+      Bq:
+        meaning: cim:UnitSymbol.Bq
+      degC:
+        meaning: cim:UnitSymbol.degC
+      Sv:
+        meaning: cim:UnitSymbol.Sv
+      F:
+        meaning: cim:UnitSymbol.F
+      C:
+        meaning: cim:UnitSymbol.C
+      S:
+        meaning: cim:UnitSymbol.S
+      H:
+        meaning: cim:UnitSymbol.H
+      V:
+        meaning: cim:UnitSymbol.V
+      ohm:
+        meaning: cim:UnitSymbol.ohm
+      J:
+        meaning: cim:UnitSymbol.J
+      N:
+        meaning: cim:UnitSymbol.N
+      Hz:
+        meaning: cim:UnitSymbol.Hz
+      lx:
+        meaning: cim:UnitSymbol.lx
+      lm:
+        meaning: cim:UnitSymbol.lm
+      Wb:
+        meaning: cim:UnitSymbol.Wb
+      T:
+        meaning: cim:UnitSymbol.T
+      W:
+        meaning: cim:UnitSymbol.W
+      Pa:
+        meaning: cim:UnitSymbol.Pa
+      m2:
+        meaning: cim:UnitSymbol.m2
+      m3:
+        meaning: cim:UnitSymbol.m3
+      mPers:
+        meaning: cim:UnitSymbol.mPers
+      mPers2:
+        meaning: cim:UnitSymbol.mPers2
+      m3Pers:
+        meaning: cim:UnitSymbol.m3Pers
+      mPerm3:
+        meaning: cim:UnitSymbol.mPerm3
+      kgm:
+        meaning: cim:UnitSymbol.kgm
+      kgPerm3:
+        meaning: cim:UnitSymbol.kgPerm3
+      m2Pers:
+        meaning: cim:UnitSymbol.m2Pers
+      WPermK:
+        meaning: cim:UnitSymbol.WPermK
+      JPerK:
+        meaning: cim:UnitSymbol.JPerK
+      ppm:
+        meaning: cim:UnitSymbol.ppm
+      rotPers:
+        meaning: cim:UnitSymbol.rotPers
+      radPers:
+        meaning: cim:UnitSymbol.radPers
+      WPerm2:
+        meaning: cim:UnitSymbol.WPerm2
+      JPerm2:
+        meaning: cim:UnitSymbol.JPerm2
+      SPerm:
+        meaning: cim:UnitSymbol.SPerm
+      KPers:
+        meaning: cim:UnitSymbol.KPers
+      PaPers:
+        meaning: cim:UnitSymbol.PaPers
+      JPerkgK:
+        meaning: cim:UnitSymbol.JPerkgK
+      VA:
+        meaning: cim:UnitSymbol.VA
+      VAr:
+        meaning: cim:UnitSymbol.VAr
+      cosPhi:
+        meaning: cim:UnitSymbol.cosPhi
+      Vs:
+        meaning: cim:UnitSymbol.Vs
+      V2:
+        meaning: cim:UnitSymbol.V2
+      As:
+        meaning: cim:UnitSymbol.As
+      A2:
+        meaning: cim:UnitSymbol.A2
+      A2s:
+        meaning: cim:UnitSymbol.A2s
+      VAh:
+        meaning: cim:UnitSymbol.VAh
+      Wh:
+        meaning: cim:UnitSymbol.Wh
+      VArh:
+        meaning: cim:UnitSymbol.VArh
+      VPerHz:
+        meaning: cim:UnitSymbol.VPerHz
+      HzPers:
+        meaning: cim:UnitSymbol.HzPers
+      character:
+        meaning: cim:UnitSymbol.character
+      charPers:
+        meaning: cim:UnitSymbol.charPers
+      kgm2:
+        meaning: cim:UnitSymbol.kgm2
+      dB:
+        meaning: cim:UnitSymbol.dB
+      WPers:
+        meaning: cim:UnitSymbol.WPers
+      lPers:
+        meaning: cim:UnitSymbol.lPers
+      dBm:
+        meaning: cim:UnitSymbol.dBm
+      h:
+        meaning: cim:UnitSymbol.h
+      min:
+        meaning: cim:UnitSymbol.min
+      Q:
+        meaning: cim:UnitSymbol.Q
+      Qh:
+        meaning: cim:UnitSymbol.Qh
+      ohmm:
+        meaning: cim:UnitSymbol.ohmm
+      APerm:
+        meaning: cim:UnitSymbol.APerm
+      V2h:
+        meaning: cim:UnitSymbol.V2h
+      A2h:
+        meaning: cim:UnitSymbol.A2h
+      Ah:
+        meaning: cim:UnitSymbol.Ah
+      count:
+        meaning: cim:UnitSymbol.count
+      ft3:
+        meaning: cim:UnitSymbol.ft3
+      m3Perh:
+        meaning: cim:UnitSymbol.m3Perh
+      gal:
+        meaning: cim:UnitSymbol.gal
+      Btu:
+        meaning: cim:UnitSymbol.Btu
+      l:
+        meaning: cim:UnitSymbol.l
+      lPerh:
+        meaning: cim:UnitSymbol.lPerh
+      lPerl:
+        meaning: cim:UnitSymbol.lPerl
+      gPerg:
+        meaning: cim:UnitSymbol.gPerg
+      molPerm3:
+        meaning: cim:UnitSymbol.molPerm3
+      molPermol:
+        meaning: cim:UnitSymbol.molPermol
+      molPerkg:
+        meaning: cim:UnitSymbol.molPerkg
+      sPers:
+        meaning: cim:UnitSymbol.sPers
+      HzPerHz:
+        meaning: cim:UnitSymbol.HzPerHz
+      VPerV:
+        meaning: cim:UnitSymbol.VPerV
+      APerA:
+        meaning: cim:UnitSymbol.APerA
+      VPerVA:
+        meaning: cim:UnitSymbol.VPerVA
+      rev:
+        meaning: cim:UnitSymbol.rev
+      kat:
+        meaning: cim:UnitSymbol.kat
+      JPerkg:
+        meaning: cim:UnitSymbol.JPerkg
+      m3Uncompensated:
+        meaning: cim:UnitSymbol.m3Uncompensated
+      m3Compensated:
+        meaning: cim:UnitSymbol.m3Compensated
+      WPerW:
+        meaning: cim:UnitSymbol.WPerW
+      therm:
+        meaning: cim:UnitSymbol.therm
+      onePerm:
+        meaning: cim:UnitSymbol.onePerm
+      m3Perkg:
+        meaning: cim:UnitSymbol.m3Perkg
+      Pas:
+        meaning: cim:UnitSymbol.Pas
+      Nm:
+        meaning: cim:UnitSymbol.Nm
+      NPerm:
+        meaning: cim:UnitSymbol.NPerm
+      radPers2:
+        meaning: cim:UnitSymbol.radPers2
+      JPerm3:
+        meaning: cim:UnitSymbol.JPerm3
+      VPerm:
+        meaning: cim:UnitSymbol.VPerm
+      CPerm3:
+        meaning: cim:UnitSymbol.CPerm3
+      CPerm2:
+        meaning: cim:UnitSymbol.CPerm2
+      FPerm:
+        meaning: cim:UnitSymbol.FPerm
+      HPerm:
+        meaning: cim:UnitSymbol.HPerm
+      JPermol:
+        meaning: cim:UnitSymbol.JPermol
+      JPermolK:
+        meaning: cim:UnitSymbol.JPermolK
+      CPerkg:
+        meaning: cim:UnitSymbol.CPerkg
+      GyPers:
+        meaning: cim:UnitSymbol.GyPers
+      WPersr:
+        meaning: cim:UnitSymbol.WPersr
+      WPerm2sr:
+        meaning: cim:UnitSymbol.WPerm2sr
+      katPerm3:
+        meaning: cim:UnitSymbol.katPerm3
+      d:
+        meaning: cim:UnitSymbol.d
+      anglemin:
+        meaning: cim:UnitSymbol.anglemin
+      anglesec:
+        meaning: cim:UnitSymbol.anglesec
+      ha:
+        meaning: cim:UnitSymbol.ha
+      tonne:
+        meaning: cim:UnitSymbol.tonne
+      bar:
+        meaning: cim:UnitSymbol.bar
+      mmHg:
+        meaning: cim:UnitSymbol.mmHg
+      M:
+        meaning: cim:UnitSymbol.M
+      kn:
+        meaning: cim:UnitSymbol.kn
+      Mx:
+        meaning: cim:UnitSymbol.Mx
+      G:
+        meaning: cim:UnitSymbol.G
+      Oe:
+        meaning: cim:UnitSymbol.Oe
+      Vh:
+        meaning: cim:UnitSymbol.Vh
+      WPerA:
+        meaning: cim:UnitSymbol.WPerA
+      onePerHz:
+        meaning: cim:UnitSymbol.onePerHz
+      VPerVAr:
+        meaning: cim:UnitSymbol.VPerVAr
+      ohmPerm:
+        meaning: cim:UnitSymbol.ohmPerm
+      kgPerJ:
+        meaning: cim:UnitSymbol.kgPerJ
+      JPers:
+        meaning: cim:UnitSymbol.JPers
+    enum_uri: http://iec.ch/TC57/CIM100#UnitSymbol
+  DCPolarityKind:
+    permissible_values:
+      positive:
+        meaning: cim:DCPolarityKind.positive
+      middle:
+        meaning: cim:DCPolarityKind.middle
+      negative:
+        meaning: cim:DCPolarityKind.negative
+    enum_uri: http://iec.ch/TC57/CIM100#DCPolarityKind
+  ControlAreaTypeKind:
+    permissible_values:
+      AGC:
+        meaning: cim:ControlAreaTypeKind.AGC
+      Forecast:
+        meaning: cim:ControlAreaTypeKind.Forecast
+      Interchange:
+        meaning: cim:ControlAreaTypeKind.Interchange
+    enum_uri: http://iec.ch/TC57/CIM100#ControlAreaTypeKind
+  CurveStyle:
+    permissible_values:
+      constantYValue:
+        meaning: cim:CurveStyle.constantYValue
+      straightLineYValues:
+        meaning: cim:CurveStyle.straightLineYValues
+    enum_uri: http://iec.ch/TC57/CIM100#CurveStyle
+  DCConverterOperatingModeKind:
+    permissible_values:
+      bipolar:
+        meaning: cim:DCConverterOperatingModeKind.bipolar
+      monopolarMetallicReturn:
+        meaning: cim:DCConverterOperatingModeKind.monopolarMetallicReturn
+      monopolarGroundReturn:
+        meaning: cim:DCConverterOperatingModeKind.monopolarGroundReturn
+    enum_uri: http://iec.ch/TC57/CIM100#DCConverterOperatingModeKind
+  FuelType:
+    permissible_values:
+      coal:
+        meaning: cim:FuelType.coal
+      oil:
+        meaning: cim:FuelType.oil
+      gas:
+        meaning: cim:FuelType.gas
+      lignite:
+        meaning: cim:FuelType.lignite
+      hardCoal:
+        meaning: cim:FuelType.hardCoal
+      oilShale:
+        meaning: cim:FuelType.oilShale
+      brownCoalLignite:
+        meaning: cim:FuelType.brownCoalLignite
+      coalDerivedGas:
+        meaning: cim:FuelType.coalDerivedGas
+      peat:
+        meaning: cim:FuelType.peat
+      other:
+        meaning: cim:FuelType.other
+    enum_uri: http://iec.ch/TC57/CIM100#FuelType
+  GeneratorControlSource:
+    permissible_values:
+      unavailable:
+        meaning: cim:GeneratorControlSource.unavailable
+      offAGC:
+        meaning: cim:GeneratorControlSource.offAGC
+      onAGC:
+        meaning: cim:GeneratorControlSource.onAGC
+      plantControl:
+        meaning: cim:GeneratorControlSource.plantControl
+    enum_uri: http://iec.ch/TC57/CIM100#GeneratorControlSource
+  Currency:
+    permissible_values:
+      AED:
+        meaning: cim:Currency.AED
+      AFN:
+        meaning: cim:Currency.AFN
+      ALL:
+        meaning: cim:Currency.ALL
+      AMD:
+        meaning: cim:Currency.AMD
+      ANG:
+        meaning: cim:Currency.ANG
+      AOA:
+        meaning: cim:Currency.AOA
+      ARS:
+        meaning: cim:Currency.ARS
+      AUD:
+        meaning: cim:Currency.AUD
+      AWG:
+        meaning: cim:Currency.AWG
+      AZN:
+        meaning: cim:Currency.AZN
+      BAM:
+        meaning: cim:Currency.BAM
+      BBD:
+        meaning: cim:Currency.BBD
+      BDT:
+        meaning: cim:Currency.BDT
+      BGN:
+        meaning: cim:Currency.BGN
+      BHD:
+        meaning: cim:Currency.BHD
+      BIF:
+        meaning: cim:Currency.BIF
+      BMD:
+        meaning: cim:Currency.BMD
+      BND:
+        meaning: cim:Currency.BND
+      BOB:
+        meaning: cim:Currency.BOB
+      BOV:
+        meaning: cim:Currency.BOV
+      BRL:
+        meaning: cim:Currency.BRL
+      BSD:
+        meaning: cim:Currency.BSD
+      BTN:
+        meaning: cim:Currency.BTN
+      BWP:
+        meaning: cim:Currency.BWP
+      BYR:
+        meaning: cim:Currency.BYR
+      BZD:
+        meaning: cim:Currency.BZD
+      CAD:
+        meaning: cim:Currency.CAD
+      CDF:
+        meaning: cim:Currency.CDF
+      CHF:
+        meaning: cim:Currency.CHF
+      CLF:
+        meaning: cim:Currency.CLF
+      CLP:
+        meaning: cim:Currency.CLP
+      CNY:
+        meaning: cim:Currency.CNY
+      COP:
+        meaning: cim:Currency.COP
+      COU:
+        meaning: cim:Currency.COU
+      CRC:
+        meaning: cim:Currency.CRC
+      CUC:
+        meaning: cim:Currency.CUC
+      CUP:
+        meaning: cim:Currency.CUP
+      CVE:
+        meaning: cim:Currency.CVE
+      CZK:
+        meaning: cim:Currency.CZK
+      DJF:
+        meaning: cim:Currency.DJF
+      DKK:
+        meaning: cim:Currency.DKK
+      DOP:
+        meaning: cim:Currency.DOP
+      DZD:
+        meaning: cim:Currency.DZD
+      EEK:
+        meaning: cim:Currency.EEK
+      EGP:
+        meaning: cim:Currency.EGP
+      ERN:
+        meaning: cim:Currency.ERN
+      ETB:
+        meaning: cim:Currency.ETB
+      EUR:
+        meaning: cim:Currency.EUR
+      FJD:
+        meaning: cim:Currency.FJD
+      FKP:
+        meaning: cim:Currency.FKP
+      GBP:
+        meaning: cim:Currency.GBP
+      GEL:
+        meaning: cim:Currency.GEL
+      GHS:
+        meaning: cim:Currency.GHS
+      GIP:
+        meaning: cim:Currency.GIP
+      GMD:
+        meaning: cim:Currency.GMD
+      GNF:
+        meaning: cim:Currency.GNF
+      GTQ:
+        meaning: cim:Currency.GTQ
+      GYD:
+        meaning: cim:Currency.GYD
+      HKD:
+        meaning: cim:Currency.HKD
+      HNL:
+        meaning: cim:Currency.HNL
+      HRK:
+        meaning: cim:Currency.HRK
+      HTG:
+        meaning: cim:Currency.HTG
+      HUF:
+        meaning: cim:Currency.HUF
+      IDR:
+        meaning: cim:Currency.IDR
+      ILS:
+        meaning: cim:Currency.ILS
+      INR:
+        meaning: cim:Currency.INR
+      IQD:
+        meaning: cim:Currency.IQD
+      IRR:
+        meaning: cim:Currency.IRR
+      ISK:
+        meaning: cim:Currency.ISK
+      JMD:
+        meaning: cim:Currency.JMD
+      JOD:
+        meaning: cim:Currency.JOD
+      JPY:
+        meaning: cim:Currency.JPY
+      KES:
+        meaning: cim:Currency.KES
+      KGS:
+        meaning: cim:Currency.KGS
+      KHR:
+        meaning: cim:Currency.KHR
+      KMF:
+        meaning: cim:Currency.KMF
+      KPW:
+        meaning: cim:Currency.KPW
+      KRW:
+        meaning: cim:Currency.KRW
+      KWD:
+        meaning: cim:Currency.KWD
+      KYD:
+        meaning: cim:Currency.KYD
+      KZT:
+        meaning: cim:Currency.KZT
+      LAK:
+        meaning: cim:Currency.LAK
+      LBP:
+        meaning: cim:Currency.LBP
+      LKR:
+        meaning: cim:Currency.LKR
+      LRD:
+        meaning: cim:Currency.LRD
+      LSL:
+        meaning: cim:Currency.LSL
+      LTL:
+        meaning: cim:Currency.LTL
+      LVL:
+        meaning: cim:Currency.LVL
+      LYD:
+        meaning: cim:Currency.LYD
+      MAD:
+        meaning: cim:Currency.MAD
+      MDL:
+        meaning: cim:Currency.MDL
+      MGA:
+        meaning: cim:Currency.MGA
+      MKD:
+        meaning: cim:Currency.MKD
+      MMK:
+        meaning: cim:Currency.MMK
+      MNT:
+        meaning: cim:Currency.MNT
+      MOP:
+        meaning: cim:Currency.MOP
+      MRO:
+        meaning: cim:Currency.MRO
+      MUR:
+        meaning: cim:Currency.MUR
+      MVR:
+        meaning: cim:Currency.MVR
+      MWK:
+        meaning: cim:Currency.MWK
+      MXN:
+        meaning: cim:Currency.MXN
+      MYR:
+        meaning: cim:Currency.MYR
+      MZN:
+        meaning: cim:Currency.MZN
+      NAD:
+        meaning: cim:Currency.NAD
+      NGN:
+        meaning: cim:Currency.NGN
+      NIO:
+        meaning: cim:Currency.NIO
+      NOK:
+        meaning: cim:Currency.NOK
+      NPR:
+        meaning: cim:Currency.NPR
+      NZD:
+        meaning: cim:Currency.NZD
+      OMR:
+        meaning: cim:Currency.OMR
+      PAB:
+        meaning: cim:Currency.PAB
+      PEN:
+        meaning: cim:Currency.PEN
+      PGK:
+        meaning: cim:Currency.PGK
+      PHP:
+        meaning: cim:Currency.PHP
+      PKR:
+        meaning: cim:Currency.PKR
+      PLN:
+        meaning: cim:Currency.PLN
+      PYG:
+        meaning: cim:Currency.PYG
+      QAR:
+        meaning: cim:Currency.QAR
+      RON:
+        meaning: cim:Currency.RON
+      RSD:
+        meaning: cim:Currency.RSD
+      RUB:
+        meaning: cim:Currency.RUB
+      RWF:
+        meaning: cim:Currency.RWF
+      SAR:
+        meaning: cim:Currency.SAR
+      SBD:
+        meaning: cim:Currency.SBD
+      SCR:
+        meaning: cim:Currency.SCR
+      SDG:
+        meaning: cim:Currency.SDG
+      SEK:
+        meaning: cim:Currency.SEK
+      SGD:
+        meaning: cim:Currency.SGD
+      SHP:
+        meaning: cim:Currency.SHP
+      SLL:
+        meaning: cim:Currency.SLL
+      SOS:
+        meaning: cim:Currency.SOS
+      SRD:
+        meaning: cim:Currency.SRD
+      STD:
+        meaning: cim:Currency.STD
+      SYP:
+        meaning: cim:Currency.SYP
+      SZL:
+        meaning: cim:Currency.SZL
+      THB:
+        meaning: cim:Currency.THB
+      TJS:
+        meaning: cim:Currency.TJS
+      TMT:
+        meaning: cim:Currency.TMT
+      TND:
+        meaning: cim:Currency.TND
+      TOP:
+        meaning: cim:Currency.TOP
+      TRY:
+        meaning: cim:Currency.TRY
+      TTD:
+        meaning: cim:Currency.TTD
+      TWD:
+        meaning: cim:Currency.TWD
+      TZS:
+        meaning: cim:Currency.TZS
+      UAH:
+        meaning: cim:Currency.UAH
+      UGX:
+        meaning: cim:Currency.UGX
+      USD:
+        meaning: cim:Currency.USD
+      UYU:
+        meaning: cim:Currency.UYU
+      UZS:
+        meaning: cim:Currency.UZS
+      VEF:
+        meaning: cim:Currency.VEF
+      VND:
+        meaning: cim:Currency.VND
+      VUV:
+        meaning: cim:Currency.VUV
+      WST:
+        meaning: cim:Currency.WST
+      XAF:
+        meaning: cim:Currency.XAF
+      XCD:
+        meaning: cim:Currency.XCD
+      XOF:
+        meaning: cim:Currency.XOF
+      XPF:
+        meaning: cim:Currency.XPF
+      YER:
+        meaning: cim:Currency.YER
+      ZAR:
+        meaning: cim:Currency.ZAR
+      ZMK:
+        meaning: cim:Currency.ZMK
+      ZWL:
+        meaning: cim:Currency.ZWL
+    enum_uri: http://iec.ch/TC57/CIM100#Currency
+  HydroEnergyConversionKind:
+    permissible_values:
+      generator:
+        meaning: cim:HydroEnergyConversionKind.generator
+      pumpAndGenerator:
+        meaning: cim:HydroEnergyConversionKind.pumpAndGenerator
+    enum_uri: http://iec.ch/TC57/CIM100#HydroEnergyConversionKind
+  HydroTurbineKind:
+    permissible_values:
+      francis:
+        meaning: cim:HydroTurbineKind.francis
+      pelton:
+        meaning: cim:HydroTurbineKind.pelton
+      kaplan:
+        meaning: cim:HydroTurbineKind.kaplan
+    enum_uri: http://iec.ch/TC57/CIM100#HydroTurbineKind
+  HydroPlantStorageKind:
+    permissible_values:
+      runOfRiver:
+        meaning: cim:HydroPlantStorageKind.runOfRiver
+      pumpedStorage:
+        meaning: cim:HydroPlantStorageKind.pumpedStorage
+      storage:
+        meaning: cim:HydroPlantStorageKind.storage
+    enum_uri: http://iec.ch/TC57/CIM100#HydroPlantStorageKind
+  OperationalLimitDirectionKind:
+    permissible_values:
+      high:
+        meaning: cim:OperationalLimitDirectionKind.high
+      low:
+        meaning: cim:OperationalLimitDirectionKind.low
+      absoluteValue:
+        meaning: cim:OperationalLimitDirectionKind.absoluteValue
+    enum_uri: http://iec.ch/TC57/CIM100#OperationalLimitDirectionKind
+  LimitKind:
+    permissible_values:
+      patl:
+        meaning: eu:LimitKind.patl
+      patlt:
+        meaning: eu:LimitKind.patlt
+      tatl:
+        meaning: eu:LimitKind.tatl
+      tc:
+        meaning: eu:LimitKind.tc
+      tct:
+        meaning: eu:LimitKind.tct
+      highVoltage:
+        meaning: eu:LimitKind.highVoltage
+      lowVoltage:
+        meaning: eu:LimitKind.lowVoltage
+      operationalVoltageLimit:
+        meaning: eu:LimitKind.operationalVoltageLimit
+      alarmVoltage:
+        meaning: eu:LimitKind.alarmVoltage
+      warningVoltage:
+        meaning: eu:LimitKind.warningVoltage
+      stability:
+        meaning: eu:LimitKind.stability
+    enum_uri: http://iec.ch/TC57/CIM100-European#LimitKind
+  WindingConnection:
+    permissible_values:
+      D:
+        meaning: cim:WindingConnection.D
+      Y:
+        meaning: cim:WindingConnection.Y
+      Z:
+        meaning: cim:WindingConnection.Z
+      Yn:
+        meaning: cim:WindingConnection.Yn
+      Zn:
+        meaning: cim:WindingConnection.Zn
+      A:
+        meaning: cim:WindingConnection.A
+      I:
+        meaning: cim:WindingConnection.I
+    enum_uri: http://iec.ch/TC57/CIM100#WindingConnection
+  RegulatingControlModeKind:
+    permissible_values:
+      voltage:
+        meaning: cim:RegulatingControlModeKind.voltage
+      activePower:
+        meaning: cim:RegulatingControlModeKind.activePower
+      reactivePower:
+        meaning: cim:RegulatingControlModeKind.reactivePower
+      currentFlow:
+        meaning: cim:RegulatingControlModeKind.currentFlow
+      admittance:
+        meaning: cim:RegulatingControlModeKind.admittance
+      timeScheduled:
+        meaning: cim:RegulatingControlModeKind.timeScheduled
+      temperature:
+        meaning: cim:RegulatingControlModeKind.temperature
+      powerFactor:
+        meaning: cim:RegulatingControlModeKind.powerFactor
+    enum_uri: http://iec.ch/TC57/CIM100#RegulatingControlModeKind
+  SVCControlMode:
+    permissible_values:
+      reactivePower:
+        meaning: cim:SVCControlMode.reactivePower
+      voltage:
+        meaning: cim:SVCControlMode.voltage
+    enum_uri: http://iec.ch/TC57/CIM100#SVCControlMode
+  SynchronousMachineKind:
+    permissible_values:
+      generator:
+        meaning: cim:SynchronousMachineKind.generator
+      condenser:
+        meaning: cim:SynchronousMachineKind.condenser
+      generatorOrCondenser:
+        meaning: cim:SynchronousMachineKind.generatorOrCondenser
+      motor:
+        meaning: cim:SynchronousMachineKind.motor
+      generatorOrMotor:
+        meaning: cim:SynchronousMachineKind.generatorOrMotor
+      motorOrCondenser:
+        meaning: cim:SynchronousMachineKind.motorOrCondenser
+      generatorOrCondenserOrMotor:
+        meaning: cim:SynchronousMachineKind.generatorOrCondenserOrMotor
+    enum_uri: http://iec.ch/TC57/CIM100#SynchronousMachineKind
+  PhaseCode:
+    permissible_values:
+      ABCN:
+        meaning: cim:PhaseCode.ABCN
+      ABC:
+        meaning: cim:PhaseCode.ABC
+      ABN:
+        meaning: cim:PhaseCode.ABN
+      ACN:
+        meaning: cim:PhaseCode.ACN
+      BCN:
+        meaning: cim:PhaseCode.BCN
+      AB:
+        meaning: cim:PhaseCode.AB
+      AC:
+        meaning: cim:PhaseCode.AC
+      BC:
+        meaning: cim:PhaseCode.BC
+      AN:
+        meaning: cim:PhaseCode.AN
+      BN:
+        meaning: cim:PhaseCode.BN
+      CN:
+        meaning: cim:PhaseCode.CN
+      A:
+        meaning: cim:PhaseCode.A
+      B:
+        meaning: cim:PhaseCode.B
+      C:
+        meaning: cim:PhaseCode.C
+      N:
+        meaning: cim:PhaseCode.N
+      s1N:
+        meaning: cim:PhaseCode.s1N
+      s2N:
+        meaning: cim:PhaseCode.s2N
+      s12N:
+        meaning: cim:PhaseCode.s12N
+      s1:
+        meaning: cim:PhaseCode.s1
+      s2:
+        meaning: cim:PhaseCode.s2
+      s12:
+        meaning: cim:PhaseCode.s12
+      none:
+        meaning: cim:PhaseCode.none
+      X:
+        meaning: cim:PhaseCode.X
+      XY:
+        meaning: cim:PhaseCode.XY
+      XN:
+        meaning: cim:PhaseCode.XN
+      XYN:
+        meaning: cim:PhaseCode.XYN
+    enum_uri: http://iec.ch/TC57/CIM100#PhaseCode
+  WindGenUnitKind:
+    permissible_values:
+      offshore:
+        meaning: cim:WindGenUnitKind.offshore
+      onshore:
+        meaning: cim:WindGenUnitKind.onshore
+    enum_uri: http://iec.ch/TC57/CIM100#WindGenUnitKind

--- a/benchmark/resources/schemas/cgmes-dynamics.yml
+++ b/benchmark/resources/schemas/cgmes-dynamics.yml
@@ -1,0 +1,22914 @@
+# Source: https://github.com/Netbeheer-Nederland/cgmes/blob/bb2763d052185579241464791344038f3ba5ffd0/schemas/dynamics.yaml
+# Original author: Netbeheer Nederland
+# Original license: Apache 2.0
+id: http://iec.ch/TC57/ns/CIM/Dynamics-EU#Package_DynamicsProfile
+name: DynamicsProfile
+description: This vocabulary is describing the dynamics profile from IEC 61970-600-2.
+title: Dynamics Vocabulary
+prefixes:
+  linkml: https://w3id.org/linkml/
+  cim: http://iec.ch/TC57/CIM100#
+  cims: http://iec.ch/TC57/1999/rdf-schema-extensions-19990926#
+  dc: http://purl.org/dc/elements/1.1/
+  dcat: http://www.w3.org/ns/dcat#
+  dct: http://purl.org/dc/terms/
+  eu: http://iec.ch/TC57/CIM100-European#
+  owl: http://www.w3.org/2002/07/owl#
+  profcim: http://iec.ch/TC57/ns/CIM/prof-cim#
+  rdf: http://www.w3.org/1999/02/22-rdf-syntax-ns#
+  rdfs: http://www.w3.org/2000/01/rdf-schema#
+  sh: http://www.w3.org/ns/shacl#
+  skos: http://www.w3.org/2004/02/skos/core#
+  xsd: http://www.w3.org/2001/XMLSchema#
+  dy: http://iec.ch/TC57/ns/CIM/Dynamics-EU#
+  this: http://iec.ch/TC57/ns/CIM/Dynamics-EU#Package_DynamicsProfile
+imports:
+  - linkml:types
+default_curi_maps:
+  - semweb_context
+default_range: string
+default_prefix: this
+classes:
+  ActivePower:
+    class_uri: cim:ActivePower
+    attributes:
+      value:
+        slot_uri: cim:ActivePower.value
+        range: float
+        multivalued: false
+        required: false
+      multiplier:
+        slot_uri: cim:ActivePower.multiplier
+        range: UnitMultiplier
+        multivalued: false
+        required: false
+      unit:
+        slot_uri: cim:ActivePower.unit
+        range: UnitSymbol
+        multivalued: false
+        required: false
+    description: Product of RMS value of the voltage and the RMS value of the in-phase
+      component of the current.
+  AngleDegrees:
+    class_uri: cim:AngleDegrees
+    attributes:
+      value:
+        slot_uri: cim:AngleDegrees.value
+        range: float
+        multivalued: false
+        required: false
+      unit:
+        slot_uri: cim:AngleDegrees.unit
+        range: UnitSymbol
+        multivalued: false
+        required: false
+      multiplier:
+        slot_uri: cim:AngleDegrees.multiplier
+        range: UnitMultiplier
+        multivalued: false
+        required: false
+    description: Measurement of angle in degrees.
+  ApparentPower:
+    class_uri: cim:ApparentPower
+    attributes:
+      value:
+        slot_uri: cim:ApparentPower.value
+        range: float
+        multivalued: false
+        required: false
+      multiplier:
+        slot_uri: cim:ApparentPower.multiplier
+        range: UnitMultiplier
+        multivalued: false
+        required: false
+      unit:
+        slot_uri: cim:ApparentPower.unit
+        range: UnitSymbol
+        multivalued: false
+        required: false
+    description: Product of the RMS value of the voltage and the RMS value of the
+      current.
+  Area:
+    class_uri: cim:Area
+    attributes:
+      value:
+        slot_uri: cim:Area.value
+        range: float
+        multivalued: false
+        required: false
+      unit:
+        slot_uri: cim:Area.unit
+        range: UnitSymbol
+        multivalued: false
+        required: false
+      multiplier:
+        slot_uri: cim:Area.multiplier
+        range: UnitMultiplier
+        multivalued: false
+        required: false
+    description: Area.
+  Frequency:
+    class_uri: cim:Frequency
+    attributes:
+      value:
+        slot_uri: cim:Frequency.value
+        range: float
+        multivalued: false
+        required: false
+      unit:
+        slot_uri: cim:Frequency.unit
+        range: UnitSymbol
+        multivalued: false
+        required: false
+      multiplier:
+        slot_uri: cim:Frequency.multiplier
+        range: UnitMultiplier
+        multivalued: false
+        required: false
+    description: Cycles per second.
+  Length:
+    class_uri: cim:Length
+    attributes:
+      value:
+        slot_uri: cim:Length.value
+        range: float
+        multivalued: false
+        required: false
+      unit:
+        slot_uri: cim:Length.unit
+        range: UnitSymbol
+        multivalued: false
+        required: false
+      multiplier:
+        slot_uri: cim:Length.multiplier
+        range: UnitMultiplier
+        multivalued: false
+        required: false
+    description: Unit of length. It shall be a positive value or zero.
+  PU:
+    class_uri: cim:PU
+    attributes:
+      value:
+        slot_uri: cim:PU.value
+        range: float
+        multivalued: false
+        required: false
+      unit:
+        slot_uri: cim:PU.unit
+        range: UnitSymbol
+        multivalued: false
+        required: false
+      multiplier:
+        slot_uri: cim:PU.multiplier
+        range: UnitMultiplier
+        multivalued: false
+        required: false
+    description: Per Unit - a positive or negative value referred to a defined base.
+      Values typically range from -10 to +10.
+  Seconds:
+    class_uri: cim:Seconds
+    attributes:
+      value:
+        slot_uri: cim:Seconds.value
+        range: float
+        multivalued: false
+        required: false
+        description: Time, in seconds
+      unit:
+        slot_uri: cim:Seconds.unit
+        range: UnitSymbol
+        multivalued: false
+        required: false
+      multiplier:
+        slot_uri: cim:Seconds.multiplier
+        range: UnitMultiplier
+        multivalued: false
+        required: false
+    description: Time, in seconds.
+  Temperature:
+    class_uri: cim:Temperature
+    attributes:
+      multiplier:
+        slot_uri: cim:Temperature.multiplier
+        range: UnitMultiplier
+        multivalued: false
+        required: false
+      unit:
+        slot_uri: cim:Temperature.unit
+        range: UnitSymbol
+        multivalued: false
+        required: false
+      value:
+        slot_uri: cim:Temperature.value
+        range: float
+        multivalued: false
+        required: false
+    description: Value of temperature in degrees Celsius.
+  VolumeFlowRate:
+    class_uri: cim:VolumeFlowRate
+    attributes:
+      multiplier:
+        slot_uri: cim:VolumeFlowRate.multiplier
+        range: UnitMultiplier
+        multivalued: false
+        required: false
+      unit:
+        slot_uri: cim:VolumeFlowRate.unit
+        range: UnitSymbol
+        multivalued: false
+        required: false
+      value:
+        slot_uri: cim:VolumeFlowRate.value
+        range: float
+        multivalued: false
+        required: false
+    description: Volume per time.
+  ACDCTerminal:
+    class_uri: cim:ACDCTerminal
+    is_a: IdentifiedObject
+    description: An electrical connection point (AC or DC) to a piece of conducting
+      equipment. Terminals are connected at physical connection points called connectivity
+      nodes.
+  ConductingEquipment:
+    class_uri: cim:ConductingEquipment
+    attributes:
+      Terminals:
+        slot_uri: cim:ConductingEquipment.Terminals
+        range: Terminal
+        multivalued: true
+        required: false
+        description: Conducting equipment have terminals that may be connected to
+          other conducting equipment terminals via connectivity nodes or topological
+          nodes.
+    is_a: Equipment
+    description: The parts of the AC power system that are designed to carry current
+      or that are conductively connected through terminals.
+  Equipment:
+    class_uri: cim:Equipment
+    is_a: PowerSystemResource
+    description: The parts of a power system that are physical devices, electronic
+      or mechanical.
+  IdentifiedObject:
+    class_uri: cim:IdentifiedObject
+    attributes:
+      description:
+        slot_uri: cim:IdentifiedObject.description
+        range: string
+        multivalued: false
+        required: false
+        description: The description is a free human readable text describing or naming
+          the object. It may be non unique and may not correlate to a naming hierarchy.
+      mRID:
+        slot_uri: cim:IdentifiedObject.mRID
+        range: string
+        multivalued: false
+        required: true
+        description: 'Master resource identifier issued by a model authority. The
+          mRID is unique within an exchange context. Global uniqueness is easily achieved
+          by using a UUID, as specified in RFC 4122, for the mRID. The use of UUID
+          is strongly recommended.
+
+          For CIMXML data files in RDF syntax conforming to IEC 61970-552, the mRID
+          is mapped to rdf:ID or rdf:about attributes that identify CIM object elements.'
+      name:
+        slot_uri: cim:IdentifiedObject.name
+        range: string
+        multivalued: false
+        required: false
+        description: The name is any free human readable and possibly non unique text
+          naming the object.
+    description: This is a root class to provide common identification for all classes
+      needing identification and naming attributes.
+  PowerSystemResource:
+    class_uri: cim:PowerSystemResource
+    is_a: IdentifiedObject
+    description: A power system resource (PSR) can be an item of equipment such as
+      a switch, an equipment container containing many individual items of equipment
+      such as a substation, or an organisational entity such as sub-control area.
+      Power system resources can have measurements associated.
+  Terminal:
+    class_uri: cim:Terminal
+    attributes:
+      ConductingEquipment:
+        slot_uri: cim:Terminal.ConductingEquipment
+        range: ConductingEquipment
+        multivalued: false
+        required: true
+        description: The conducting equipment of the terminal.  Conducting equipment
+          have  terminals that may be connected to other conducting equipment terminals
+          via connectivity nodes or topological nodes.
+      RemoteInputSignal:
+        slot_uri: cim:Terminal.RemoteInputSignal
+        range: RemoteInputSignal
+        multivalued: true
+        required: false
+        description: Input signal coming from this terminal.
+    is_a: ACDCTerminal
+    description: An AC electrical connection point to a piece of conducting equipment.
+      Terminals are connected at physical connection points called connectivity nodes.
+  AsynchronousMachine:
+    class_uri: cim:AsynchronousMachine
+    attributes:
+      AsynchronousMachineDynamics:
+        slot_uri: cim:AsynchronousMachine.AsynchronousMachineDynamics
+        range: AsynchronousMachineDynamics
+        multivalued: false
+        required: false
+        description: Asynchronous machine dynamics model used to describe dynamic
+          behaviour of this asynchronous machine.
+    is_a: RotatingMachine
+    description: A rotating machine whose shaft rotates asynchronously with the electrical
+      field.  Also known as an induction machine with no external connection to the
+      rotor windings, e.g. squirrel-cage induction machine.
+  EnergyConnection:
+    class_uri: cim:EnergyConnection
+    is_a: ConductingEquipment
+    description: A connection of energy generation or consumption on the power system
+      model.
+  EnergyConsumer:
+    class_uri: cim:EnergyConsumer
+    attributes:
+      LoadDynamics:
+        slot_uri: cim:EnergyConsumer.LoadDynamics
+        range: LoadDynamics
+        multivalued: false
+        required: false
+        description: Load dynamics model used to describe dynamic behaviour of this
+          energy consumer.
+    is_a: EnergyConnection
+    description: 'Generic user of energy - a  point of consumption on the power system
+      model.
+
+      EnergyConsumer.pfixed, .qfixed, .pfixedPct and .qfixedPct have meaning only
+      if there is no LoadResponseCharacteristic associated with EnergyConsumer or
+      if LoadResponseCharacteristic.exponentModel is set to False.'
+  PowerElectronicsConnection:
+    class_uri: cim:PowerElectronicsConnection
+    attributes:
+      WindTurbineType3or4Dynamics:
+        slot_uri: cim:PowerElectronicsConnection.WindTurbineType3or4Dynamics
+        range: WindTurbineType3or4Dynamics
+        multivalued: false
+        required: false
+        description: The wind turbine type 3 or type 4 dynamics model associated with
+          this power electronics connection.
+    is_a: RegulatingCondEq
+    description: A connection to the AC network for energy production or consumption
+      that uses power electronics rather than rotating machines.
+  RegulatingCondEq:
+    class_uri: cim:RegulatingCondEq
+    is_a: EnergyConnection
+    description: A type of conducting equipment that can regulate a quantity (i.e.
+      voltage or flow) at a specific point in the network.
+  RotatingMachine:
+    class_uri: cim:RotatingMachine
+    is_a: RegulatingCondEq
+    description: A rotating machine which may be used as a generator or motor.
+  StaticVarCompensator:
+    class_uri: cim:StaticVarCompensator
+    attributes:
+      StaticVarCompensatorDynamics:
+        slot_uri: cim:StaticVarCompensator.StaticVarCompensatorDynamics
+        range: StaticVarCompensatorDynamics
+        multivalued: false
+        required: false
+        description: Static Var Compensator dynamics model used to describe dynamic
+          behaviour of this Static Var Compensator.
+    is_a: RegulatingCondEq
+    description: 'A facility for providing variable and controllable shunt reactive
+      power. The SVC typically consists of a stepdown transformer, filter, thyristor-controlled
+      reactor, and thyristor-switched capacitor arms.
+
+
+      The SVC may operate in fixed MVar output mode or in voltage control mode. When
+      in voltage control mode, the output of the SVC will be proportional to the deviation
+      of voltage at the controlled bus from the voltage setpoint.  The SVC characteristic
+      slope defines the proportion.  If the voltage at the controlled bus is equal
+      to the voltage setpoint, the SVC MVar output is zero.'
+  SynchronousMachine:
+    class_uri: cim:SynchronousMachine
+    attributes:
+      SynchronousMachineDynamics:
+        slot_uri: cim:SynchronousMachine.SynchronousMachineDynamics
+        range: SynchronousMachineDynamics
+        multivalued: false
+        required: false
+        description: Synchronous machine dynamics model used to describe dynamic behaviour
+          of this synchronous machine.
+    is_a: RotatingMachine
+    description: An electromechanical device that operates with shaft rotating synchronously
+      with the network. It is a single machine operating either as a generator or
+      synchronous condenser or pump.
+  ACDCConverter:
+    class_uri: cim:ACDCConverter
+    is_a: ConductingEquipment
+    description: A unit with valves for three phases, together with unit control equipment,
+      essential protective and switching devices, DC storage capacitors, phase reactors
+      and auxiliaries, if any, used for conversion.
+  CsConverter:
+    class_uri: cim:CsConverter
+    attributes:
+      CSCDynamics:
+        slot_uri: cim:CsConverter.CSCDynamics
+        range: CSCDynamics
+        multivalued: false
+        required: false
+        description: Current source converter dynamics model used to describe dynamic
+          behaviour of this converter.
+    is_a: ACDCConverter
+    description: 'DC side of the current source converter (CSC).
+
+      The firing angle controls the dc voltage at the converter, both for rectifier
+      and inverter. The difference between the dc voltages of the rectifier and inverter
+      determines the dc current. The extinction angle is used to limit the dc voltage
+      at the inverter, if needed, and is not used in active power control. The firing
+      angle, transformer tap position and number of connected filters are the primary
+      means to control a current source dc line. Higher level controls are built on
+      top, e.g. dc voltage, dc current and active power. From a steady state perspective
+      it is sufficient to specify the wanted active power transfer (ACDCConverter.targetPpcc)
+      and the control functions will set the dc voltage, dc current, firing angle,
+      transformer tap position and number of connected filters to meet this. Therefore
+      attributes targetAlpha and targetGamma are not applicable in this case.
+
+      The reactive power consumed by the converter is a function of the firing angle,
+      transformer tap position and number of connected filter, which can be approximated
+      with half of the active power. The losses is a function of the dc voltage and
+      dc current.
+
+      The attributes minAlpha and maxAlpha define the range of firing angles for rectifier
+      operation between which no discrete tap changer action takes place. The range
+      is typically 10-18 degrees.
+
+      The attributes minGamma and maxGamma define the range of extinction angles for
+      inverter operation between which no discrete tap changer action takes place.
+      The range is typically 17-20 degrees.'
+  VsConverter:
+    class_uri: cim:VsConverter
+    attributes:
+      VSCDynamics:
+        slot_uri: cim:VsConverter.VSCDynamics
+        range: VSCDynamics
+        multivalued: false
+        required: false
+        description: Voltage source converter dynamics model used to describe dynamic
+          behaviour of this converter.
+    is_a: ACDCConverter
+    description: DC side of the voltage source converter (VSC).
+  RemoteInputSignal:
+    class_uri: cim:RemoteInputSignal
+    attributes:
+      Terminal:
+        slot_uri: cim:RemoteInputSignal.Terminal
+        range: Terminal
+        multivalued: false
+        required: true
+        description: Remote terminal with which this input signal is associated.
+      remoteSignalType:
+        slot_uri: cim:RemoteInputSignal.remoteSignalType
+        range: RemoteSignalKind
+        multivalued: false
+        required: true
+        description: Type of input signal.
+      DiscontinuousExcitationControlDynamics:
+        slot_uri: cim:RemoteInputSignal.DiscontinuousExcitationControlDynamics
+        range: DiscontinuousExcitationControlDynamics
+        multivalued: false
+        required: false
+        description: Discontinuous excitation control model using this remote input
+          signal.
+      WindTurbineType1or2Dynamics:
+        slot_uri: cim:RemoteInputSignal.WindTurbineType1or2Dynamics
+        range: WindTurbineType1or2Dynamics
+        multivalued: false
+        required: false
+        description: Wind generator type 1 or type 2 model using this remote input
+          signal.
+      PowerSystemStabilizerDynamics:
+        slot_uri: cim:RemoteInputSignal.PowerSystemStabilizerDynamics
+        range: PowerSystemStabilizerDynamics
+        multivalued: false
+        required: false
+        description: Power system stabilizer model using this remote input signal.
+      UnderexcitationLimiterDynamics:
+        slot_uri: cim:RemoteInputSignal.UnderexcitationLimiterDynamics
+        range: UnderexcitationLimiterDynamics
+        multivalued: false
+        required: false
+        description: Underexcitation limiter model using this remote input signal.
+      PFVArControllerType1Dynamics:
+        slot_uri: cim:RemoteInputSignal.PFVArControllerType1Dynamics
+        range: PFVArControllerType1Dynamics
+        multivalued: false
+        required: false
+        description: Power factor or VAr controller type 1 model using this remote
+          input signal.
+      VoltageCompensatorDynamics:
+        slot_uri: cim:RemoteInputSignal.VoltageCompensatorDynamics
+        range: VoltageCompensatorDynamics
+        multivalued: false
+        required: false
+        description: Voltage compensator model using this remote input signal.
+      WindPlantDynamics:
+        slot_uri: cim:RemoteInputSignal.WindPlantDynamics
+        range: WindPlantDynamics
+        multivalued: false
+        required: false
+        description: The wind plant using the remote signal.
+      WindTurbineType3or4Dynamics:
+        slot_uri: cim:RemoteInputSignal.WindTurbineType3or4Dynamics
+        range: WindTurbineType3or4Dynamics
+        multivalued: false
+        required: false
+        description: Wind turbine type 3 or type 4 models using this remote input
+          signal.
+    is_a: IdentifiedObject
+    description: Supports connection to a terminal associated with a remote bus from
+      which an input signal of a specific type is coming.
+  DynamicsFunctionBlock:
+    class_uri: cim:DynamicsFunctionBlock
+    attributes:
+      enabled:
+        slot_uri: cim:DynamicsFunctionBlock.enabled
+        range: boolean
+        multivalued: false
+        required: true
+        description: 'Function block used indicator.
+
+          true = use of function block is enabled
+
+          false = use of function block is disabled.'
+    is_a: IdentifiedObject
+    description: Abstract parent class for all Dynamics function blocks.
+  RotatingMachineDynamics:
+    class_uri: cim:RotatingMachineDynamics
+    attributes:
+      damping:
+        slot_uri: cim:RotatingMachineDynamics.damping
+        range: float
+        multivalued: false
+        required: true
+        description: Damping torque coefficient (<i>D</i>) (&gt;= 0).  A proportionality
+          constant that, when multiplied by the angular velocity of the rotor poles
+          with respect to the magnetic field (frequency), results in the damping torque.  This
+          value is often zero when the sources of damping torques (generator damper
+          windings, load damping effects, etc.) are modelled in detail.  Typical value
+          = 0.
+      inertia:
+        slot_uri: cim:RotatingMachineDynamics.inertia
+        range: Seconds
+        multivalued: false
+        required: true
+        description: Inertia constant of generator or motor and mechanical load (<i>H</i>)
+          (&gt; 0).  This is the specification for the stored energy in the rotating
+          mass when operating at rated speed.  For a generator, this includes the
+          generator plus all other elements (turbine, exciter) on the same shaft and
+          has units of MW x s.  For a motor, it includes the motor plus its mechanical
+          load. Conventional units are PU on the generator MVA base, usually expressed
+          as MW x s / MVA or just s. This value is used in the accelerating power
+          reference frame for operator training simulator solutions.  Typical value
+          = 3.
+      saturationFactor:
+        slot_uri: cim:RotatingMachineDynamics.saturationFactor
+        range: float
+        multivalued: false
+        required: false
+        description: Saturation factor at rated terminal voltage (<i>S1</i>) (&gt;=
+          0).  Not used by simplified model.  Defined by defined by <i>S</i>(<i>E1</i>)
+          in the SynchronousMachineSaturationParameters diagram.  Typical value =
+          0,02.
+      saturationFactor120:
+        slot_uri: cim:RotatingMachineDynamics.saturationFactor120
+        range: float
+        multivalued: false
+        required: false
+        description: Saturation factor at 120% of rated terminal voltage (<i>S12</i>)
+          (&gt;= RotatingMachineDynamics.saturationFactor). Not used by the simplified
+          model, defined by <i>S</i>(<i>E2</i>) in the SynchronousMachineSaturationParameters
+          diagram.  Typical value = 0,12.
+      statorLeakageReactance:
+        slot_uri: cim:RotatingMachineDynamics.statorLeakageReactance
+        range: PU
+        multivalued: false
+        required: true
+        description: Stator leakage reactance (<i>Xl</i>) (&gt;= 0). Typical value
+          = 0,15.
+      statorResistance:
+        slot_uri: cim:RotatingMachineDynamics.statorResistance
+        range: PU
+        multivalued: false
+        required: true
+        description: Stator (armature) resistance (<i>Rs</i>) (&gt;= 0). Typical value
+          = 0,005.
+    is_a: DynamicsFunctionBlock
+    description: Abstract parent class for all synchronous and asynchronous machine
+      standard models.
+  CSCUserDefined:
+    class_uri: cim:CSCUserDefined
+    attributes:
+      proprietary:
+        slot_uri: cim:CSCUserDefined.proprietary
+        range: boolean
+        multivalued: false
+        required: true
+        description: 'Behaviour is based on a proprietary model as opposed to a detailed
+          model.
+
+          true = user-defined model is proprietary with behaviour mutually understood
+          by sending and receiving applications and parameters passed as general attributes
+
+          false = user-defined model is explicitly defined in terms of control blocks
+          and their input and output signals.'
+      ProprietaryParameterDynamics:
+        slot_uri: cim:CSCUserDefined.ProprietaryParameterDynamics
+        range: ProprietaryParameterDynamics
+        multivalued: true
+        required: false
+        description: Parameter of this proprietary user-defined model.
+    is_a: CSCDynamics
+    description: Current source converter (CSC) function block whose dynamic behaviour
+      is described by <font color="#0f0f0f">a user-defined model.</font>
+  SVCUserDefined:
+    class_uri: cim:SVCUserDefined
+    attributes:
+      proprietary:
+        slot_uri: cim:SVCUserDefined.proprietary
+        range: boolean
+        multivalued: false
+        required: true
+        description: 'Behaviour is based on a proprietary model as opposed to a detailed
+          model.
+
+          true = user-defined model is proprietary with behaviour mutually understood
+          by sending and receiving applications and parameters passed as general attributes
+
+          false = user-defined model is explicitly defined in terms of control blocks
+          and their input and output signals.'
+      ProprietaryParameterDynamics:
+        slot_uri: cim:SVCUserDefined.ProprietaryParameterDynamics
+        range: ProprietaryParameterDynamics
+        multivalued: true
+        required: false
+        description: Parameter of this proprietary user-defined model.
+    is_a: StaticVarCompensatorDynamics
+    description: Static var compensator (SVC) function block whose dynamic behaviour
+      is described by <font color="#0f0f0f">a user-defined model.</font>
+  VSCUserDefined:
+    class_uri: cim:VSCUserDefined
+    attributes:
+      proprietary:
+        slot_uri: cim:VSCUserDefined.proprietary
+        range: boolean
+        multivalued: false
+        required: true
+        description: 'Behaviour is based on a proprietary model as opposed to a detailed
+          model.
+
+          true = user-defined model is proprietary with behaviour mutually understood
+          by sending and receiving applications and parameters passed as general attributes
+
+          false = user-defined model is explicitly defined in terms of control blocks
+          and their input and output signals.'
+      ProprietaryParameterDynamics:
+        slot_uri: cim:VSCUserDefined.ProprietaryParameterDynamics
+        range: ProprietaryParameterDynamics
+        multivalued: true
+        required: false
+        description: Parameter of this proprietary user-defined model.
+    is_a: VSCDynamics
+    description: Voltage source converter (VSC) function block whose dynamic behaviour
+      is described by <font color="#0f0f0f">a user-defined model.</font>
+  WindPlantUserDefined:
+    class_uri: cim:WindPlantUserDefined
+    attributes:
+      proprietary:
+        slot_uri: cim:WindPlantUserDefined.proprietary
+        range: boolean
+        multivalued: false
+        required: true
+        description: 'Behaviour is based on a proprietary model as opposed to a detailed
+          model.
+
+          true = user-defined model is proprietary with behaviour mutually understood
+          by sending and receiving applications and parameters passed as general attributes
+
+          false = user-defined model is explicitly defined in terms of control blocks
+          and their input and output signals.'
+      ProprietaryParameterDynamics:
+        slot_uri: cim:WindPlantUserDefined.ProprietaryParameterDynamics
+        range: ProprietaryParameterDynamics
+        multivalued: true
+        required: false
+        description: Parameter of this proprietary user-defined model.
+    is_a: WindPlantDynamics
+    description: Wind plant function block whose dynamic behaviour is described by
+      <font color="#0f0f0f">a user-defined model.</font>
+  WindType1or2UserDefined:
+    class_uri: cim:WindType1or2UserDefined
+    attributes:
+      proprietary:
+        slot_uri: cim:WindType1or2UserDefined.proprietary
+        range: boolean
+        multivalued: false
+        required: true
+        description: 'Behaviour is based on a proprietary model as opposed to a detailed
+          model.
+
+          true = user-defined model is proprietary with behaviour mutually understood
+          by sending and receiving applications and parameters passed as general attributes
+
+          false = user-defined model is explicitly defined in terms of control blocks
+          and their input and output signals.'
+      ProprietaryParameterDynamics:
+        slot_uri: cim:WindType1or2UserDefined.ProprietaryParameterDynamics
+        range: ProprietaryParameterDynamics
+        multivalued: true
+        required: false
+        description: Parameter of this proprietary user-defined model.
+    is_a: WindTurbineType1or2Dynamics
+    description: Wind type 1 or type 2 function block whose dynamic behaviour is described
+      by <font color="#0f0f0f">a user-defined model.</font>
+  WindType3or4UserDefined:
+    class_uri: cim:WindType3or4UserDefined
+    attributes:
+      proprietary:
+        slot_uri: cim:WindType3or4UserDefined.proprietary
+        range: boolean
+        multivalued: false
+        required: true
+        description: 'Behaviour is based on a proprietary model as opposed to a detailed
+          model.
+
+          true = user-defined model is proprietary with behaviour mutually understood
+          by sending and receiving applications and parameters passed as general attributes
+
+          false = user-defined model is explicitly defined in terms of control blocks
+          and their input and output signals.'
+      ProprietaryParameterDynamics:
+        slot_uri: cim:WindType3or4UserDefined.ProprietaryParameterDynamics
+        range: ProprietaryParameterDynamics
+        multivalued: true
+        required: false
+        description: Parameter of this proprietary user-defined model.
+    is_a: WindTurbineType3or4Dynamics
+    description: Wind type 3 or type 4 function block whose dynamic behaviour is described
+      by <font color="#0f0f0f">a user-defined model.</font>
+  SynchronousMachineUserDefined:
+    class_uri: cim:SynchronousMachineUserDefined
+    attributes:
+      proprietary:
+        slot_uri: cim:SynchronousMachineUserDefined.proprietary
+        range: boolean
+        multivalued: false
+        required: true
+        description: 'Behaviour is based on a proprietary model as opposed to a detailed
+          model.
+
+          true = user-defined model is proprietary with behaviour mutually understood
+          by sending and receiving applications and parameters passed as general attributes
+
+          false = user-defined model is explicitly defined in terms of control blocks
+          and their input and output signals.'
+      ProprietaryParameterDynamics:
+        slot_uri: cim:SynchronousMachineUserDefined.ProprietaryParameterDynamics
+        range: ProprietaryParameterDynamics
+        multivalued: true
+        required: false
+        description: Parameter of this proprietary user-defined model.
+    is_a: SynchronousMachineDynamics
+    description: Synchronous machine whose dynamic behaviour is described by a user-defined
+      model.
+  AsynchronousMachineUserDefined:
+    class_uri: cim:AsynchronousMachineUserDefined
+    attributes:
+      proprietary:
+        slot_uri: cim:AsynchronousMachineUserDefined.proprietary
+        range: boolean
+        multivalued: false
+        required: true
+        description: 'Behaviour is based on a proprietary model as opposed to a detailed
+          model.
+
+          true = user-defined model is proprietary with behaviour mutually understood
+          by sending and receiving applications and parameters passed as general attributes
+
+          false = user-defined model is explicitly defined in terms of control blocks
+          and their input and output signals.'
+      ProprietaryParameterDynamics:
+        slot_uri: cim:AsynchronousMachineUserDefined.ProprietaryParameterDynamics
+        range: ProprietaryParameterDynamics
+        multivalued: true
+        required: false
+        description: Parameter of this proprietary user-defined model.
+    is_a: AsynchronousMachineDynamics
+    description: Asynchronous machine whose dynamic behaviour is described by a user-defined
+      model.
+  TurbineGovernorUserDefined:
+    class_uri: cim:TurbineGovernorUserDefined
+    attributes:
+      proprietary:
+        slot_uri: cim:TurbineGovernorUserDefined.proprietary
+        range: boolean
+        multivalued: false
+        required: true
+        description: 'Behaviour is based on a proprietary model as opposed to a detailed
+          model.
+
+          true = user-defined model is proprietary with behaviour mutually understood
+          by sending and receiving applications and parameters passed as general attributes
+
+          false = user-defined model is explicitly defined in terms of control blocks
+          and their input and output signals.'
+      ProprietaryParameterDynamics:
+        slot_uri: cim:TurbineGovernorUserDefined.ProprietaryParameterDynamics
+        range: ProprietaryParameterDynamics
+        multivalued: true
+        required: false
+        description: Parameter of this proprietary user-defined model.
+    is_a: TurbineGovernorDynamics
+    description: Turbine-governor function block whose dynamic behaviour is described
+      by <font color="#0f0f0f">a user-defined model.</font>
+  TurbineLoadControllerUserDefined:
+    class_uri: cim:TurbineLoadControllerUserDefined
+    attributes:
+      proprietary:
+        slot_uri: cim:TurbineLoadControllerUserDefined.proprietary
+        range: boolean
+        multivalued: false
+        required: true
+        description: 'Behaviour is based on a proprietary model as opposed to a detailed
+          model.
+
+          true = user-defined model is proprietary with behaviour mutually understood
+          by sending and receiving applications and parameters passed as general attributes
+
+          false = user-defined model is explicitly defined in terms of control blocks
+          and their input and output signals.'
+      ProprietaryParameterDynamics:
+        slot_uri: cim:TurbineLoadControllerUserDefined.ProprietaryParameterDynamics
+        range: ProprietaryParameterDynamics
+        multivalued: true
+        required: false
+        description: Parameter of this proprietary user-defined model.
+    is_a: TurbineLoadControllerDynamics
+    description: Turbine load controller function block whose dynamic behaviour is
+      described by <font color="#0f0f0f">a user-defined model.</font>
+  MechanicalLoadUserDefined:
+    class_uri: cim:MechanicalLoadUserDefined
+    attributes:
+      proprietary:
+        slot_uri: cim:MechanicalLoadUserDefined.proprietary
+        range: boolean
+        multivalued: false
+        required: true
+        description: 'Behaviour is based on a proprietary model as opposed to a detailed
+          model.
+
+          true = user-defined model is proprietary with behaviour mutually understood
+          by sending and receiving applications and parameters passed as general attributes
+
+          false = user-defined model is explicitly defined in terms of control blocks
+          and their input and output signals.'
+      ProprietaryParameterDynamics:
+        slot_uri: cim:MechanicalLoadUserDefined.ProprietaryParameterDynamics
+        range: ProprietaryParameterDynamics
+        multivalued: true
+        required: false
+        description: Parameter of this proprietary user-defined model.
+    is_a: MechanicalLoadDynamics
+    description: Mechanical load function block whose dynamic behaviour is described
+      by <font color="#0f0f0f">a user-defined model.</font>
+  ExcitationSystemUserDefined:
+    class_uri: cim:ExcitationSystemUserDefined
+    attributes:
+      proprietary:
+        slot_uri: cim:ExcitationSystemUserDefined.proprietary
+        range: boolean
+        multivalued: false
+        required: true
+        description: 'Behaviour is based on a proprietary model as opposed to a detailed
+          model.
+
+          true = user-defined model is proprietary with behaviour mutually understood
+          by sending and receiving applications and parameters passed as general attributes
+
+          false = user-defined model is explicitly defined in terms of control blocks
+          and their input and output signals.'
+      ProprietaryParameterDynamics:
+        slot_uri: cim:ExcitationSystemUserDefined.ProprietaryParameterDynamics
+        range: ProprietaryParameterDynamics
+        multivalued: true
+        required: false
+        description: Parameter of this proprietary user-defined model.
+    is_a: ExcitationSystemDynamics
+    description: Excitation system function block whose dynamic behaviour is described
+      by <font color="#0f0f0f">a user-defined model.</font>
+  OverexcitationLimiterUserDefined:
+    class_uri: cim:OverexcitationLimiterUserDefined
+    attributes:
+      proprietary:
+        slot_uri: cim:OverexcitationLimiterUserDefined.proprietary
+        range: boolean
+        multivalued: false
+        required: true
+        description: 'Behaviour is based on a proprietary model as opposed to a detailed
+          model.
+
+          true = user-defined model is proprietary with behaviour mutually understood
+          by sending and receiving applications and parameters passed as general attributes
+
+          false = user-defined model is explicitly defined in terms of control blocks
+          and their input and output signals.'
+      ProprietaryParameterDynamics:
+        slot_uri: cim:OverexcitationLimiterUserDefined.ProprietaryParameterDynamics
+        range: ProprietaryParameterDynamics
+        multivalued: true
+        required: false
+        description: Parameter of this proprietary user-defined model.
+    is_a: OverexcitationLimiterDynamics
+    description: Overexcitation limiter system function block whose dynamic behaviour
+      is described by <font color="#0f0f0f">a user-defined model.</font>
+  UnderexcitationLimiterUserDefined:
+    class_uri: cim:UnderexcitationLimiterUserDefined
+    attributes:
+      proprietary:
+        slot_uri: cim:UnderexcitationLimiterUserDefined.proprietary
+        range: boolean
+        multivalued: false
+        required: true
+        description: 'Behaviour is based on a proprietary model as opposed to a detailed
+          model.
+
+          true = user-defined model is proprietary with behaviour mutually understood
+          by sending and receiving applications and parameters passed as general attributes
+
+          false = user-defined model is explicitly defined in terms of control blocks
+          and their input and output signals.'
+      ProprietaryParameterDynamics:
+        slot_uri: cim:UnderexcitationLimiterUserDefined.ProprietaryParameterDynamics
+        range: ProprietaryParameterDynamics
+        multivalued: true
+        required: false
+        description: Parameter of this proprietary user-defined model.
+    is_a: UnderexcitationLimiterDynamics
+    description: Underexcitation limiter function block whose dynamic behaviour is
+      described by <font color="#0f0f0f">a user-defined model.</font>
+  PowerSystemStabilizerUserDefined:
+    class_uri: cim:PowerSystemStabilizerUserDefined
+    attributes:
+      proprietary:
+        slot_uri: cim:PowerSystemStabilizerUserDefined.proprietary
+        range: boolean
+        multivalued: false
+        required: true
+        description: 'Behaviour is based on a proprietary model as opposed to a detailed
+          model.
+
+          true = user-defined model is proprietary with behaviour mutually understood
+          by sending and receiving applications and parameters passed as general attributes
+
+          false = user-defined model is explicitly defined in terms of control blocks
+          and their input and output signals.'
+      ProprietaryParameterDynamics:
+        slot_uri: cim:PowerSystemStabilizerUserDefined.ProprietaryParameterDynamics
+        range: ProprietaryParameterDynamics
+        multivalued: true
+        required: false
+        description: Parameter of this proprietary user-defined model.
+    is_a: PowerSystemStabilizerDynamics
+    description: <font color="#0f0f0f">Power system stabilizer</font> function block
+      whose dynamic behaviour is described by <font color="#0f0f0f">a user-defined
+      model.</font>
+  DiscontinuousExcitationControlUserDefined:
+    class_uri: cim:DiscontinuousExcitationControlUserDefined
+    attributes:
+      proprietary:
+        slot_uri: cim:DiscontinuousExcitationControlUserDefined.proprietary
+        range: boolean
+        multivalued: false
+        required: true
+        description: 'Behaviour is based on a proprietary model as opposed to a detailed
+          model.
+
+          true = user-defined model is proprietary with behaviour mutually understood
+          by sending and receiving applications and parameters passed as general attributes
+
+          false = user-defined model is explicitly defined in terms of control blocks
+          and their input and output signals.'
+      ProprietaryParameterDynamics:
+        slot_uri: cim:DiscontinuousExcitationControlUserDefined.ProprietaryParameterDynamics
+        range: ProprietaryParameterDynamics
+        multivalued: true
+        required: false
+        description: Parameter of this proprietary user-defined model.
+    is_a: DiscontinuousExcitationControlDynamics
+    description: Discontinuous excitation control function block whose dynamic behaviour
+      is described by <font color="#0f0f0f">a user-defined model.</font>
+  PFVArControllerType1UserDefined:
+    class_uri: cim:PFVArControllerType1UserDefined
+    attributes:
+      proprietary:
+        slot_uri: cim:PFVArControllerType1UserDefined.proprietary
+        range: boolean
+        multivalued: false
+        required: true
+        description: 'Behaviour is based on a proprietary model as opposed to a detailed
+          model.
+
+          true = user-defined model is proprietary with behaviour mutually understood
+          by sending and receiving applications and parameters passed as general attributes
+
+          false = user-defined model is explicitly defined in terms of control blocks
+          and their input and output signals.'
+      ProprietaryParameterDynamics:
+        slot_uri: cim:PFVArControllerType1UserDefined.ProprietaryParameterDynamics
+        range: ProprietaryParameterDynamics
+        multivalued: true
+        required: false
+        description: Parameter of this proprietary user-defined model.
+    is_a: PFVArControllerType1Dynamics
+    description: Power factor or VAr controller type 1 function block whose dynamic
+      behaviour is described by <font color="#0f0f0f">a user-defined model.</font>
+  VoltageAdjusterUserDefined:
+    class_uri: cim:VoltageAdjusterUserDefined
+    attributes:
+      proprietary:
+        slot_uri: cim:VoltageAdjusterUserDefined.proprietary
+        range: boolean
+        multivalued: false
+        required: true
+        description: 'Behaviour is based on a proprietary model as opposed to a detailed
+          model.
+
+          true = user-defined model is proprietary with behaviour mutually understood
+          by sending and receiving applications and parameters passed as general attributes
+
+          false = user-defined model is explicitly defined in terms of control blocks
+          and their input and output signals.'
+      ProprietaryParameterDynamics:
+        slot_uri: cim:VoltageAdjusterUserDefined.ProprietaryParameterDynamics
+        range: ProprietaryParameterDynamics
+        multivalued: true
+        required: false
+        description: Parameter of this proprietary user-defined model.
+    is_a: VoltageAdjusterDynamics
+    description: <font color="#0f0f0f">Voltage adjuster</font> function block whose
+      dynamic behaviour is described by <font color="#0f0f0f">a user-defined model.</font>
+  PFVArControllerType2UserDefined:
+    class_uri: cim:PFVArControllerType2UserDefined
+    attributes:
+      proprietary:
+        slot_uri: cim:PFVArControllerType2UserDefined.proprietary
+        range: boolean
+        multivalued: false
+        required: true
+        description: 'Behaviour is based on a proprietary model as opposed to a detailed
+          model.
+
+          true = user-defined model is proprietary with behaviour mutually understood
+          by sending and receiving applications and parameters passed as general attributes
+
+          false = user-defined model is explicitly defined in terms of control blocks
+          and their input and output signals.'
+      ProprietaryParameterDynamics:
+        slot_uri: cim:PFVArControllerType2UserDefined.ProprietaryParameterDynamics
+        range: ProprietaryParameterDynamics
+        multivalued: true
+        required: false
+        description: Parameter of this proprietary user-defined model.
+    is_a: PFVArControllerType2Dynamics
+    description: Power factor or VAr controller type 2 function block whose dynamic
+      behaviour is described by <font color="#0f0f0f">a user-defined model.</font>
+  VoltageCompensatorUserDefined:
+    class_uri: cim:VoltageCompensatorUserDefined
+    attributes:
+      proprietary:
+        slot_uri: cim:VoltageCompensatorUserDefined.proprietary
+        range: boolean
+        multivalued: false
+        required: true
+        description: 'Behaviour is based on a proprietary model as opposed to a detailed
+          model.
+
+          true = user-defined model is proprietary with behaviour mutually understood
+          by sending and receiving applications and parameters passed as general attributes
+
+          false = user-defined model is explicitly defined in terms of control blocks
+          and their input and output signals.'
+      ProprietaryParameterDynamics:
+        slot_uri: cim:VoltageCompensatorUserDefined.ProprietaryParameterDynamics
+        range: ProprietaryParameterDynamics
+        multivalued: true
+        required: false
+        description: Parameter of this proprietary user-defined model.
+    is_a: VoltageCompensatorDynamics
+    description: Voltage compensator function block whose dynamic behaviour is described
+      by <font color="#0f0f0f">a user-defined model.</font>
+  LoadUserDefined:
+    class_uri: cim:LoadUserDefined
+    attributes:
+      proprietary:
+        slot_uri: cim:LoadUserDefined.proprietary
+        range: boolean
+        multivalued: false
+        required: true
+        description: 'Behaviour is based on a proprietary model as opposed to a detailed
+          model.
+
+          true = user-defined model is proprietary with behaviour mutually understood
+          by sending and receiving applications and parameters passed as general attributes
+
+          false = user-defined model is explicitly defined in terms of control blocks
+          and their input and output signals.'
+      ProprietaryParameterDynamics:
+        slot_uri: cim:LoadUserDefined.ProprietaryParameterDynamics
+        range: ProprietaryParameterDynamics
+        multivalued: true
+        required: false
+        description: Parameter of this proprietary user-defined model.
+    is_a: LoadDynamics
+    description: Load whose dynamic behaviour is described by a user-defined model.
+  ProprietaryParameterDynamics:
+    class_uri: cim:ProprietaryParameterDynamics
+    attributes:
+      CSCUserDefined:
+        slot_uri: cim:ProprietaryParameterDynamics.CSCUserDefined
+        range: CSCUserDefined
+        multivalued: false
+        required: false
+        description: Proprietary user-defined model with which this parameter is associated.
+      SVCUserDefined:
+        slot_uri: cim:ProprietaryParameterDynamics.SVCUserDefined
+        range: SVCUserDefined
+        multivalued: false
+        required: false
+        description: Proprietary user-defined model with which this parameter is associated.
+      VSCUserDefined:
+        slot_uri: cim:ProprietaryParameterDynamics.VSCUserDefined
+        range: VSCUserDefined
+        multivalued: false
+        required: false
+        description: Proprietary user-defined model with which this parameter is associated.
+      WindPlantUserDefined:
+        slot_uri: cim:ProprietaryParameterDynamics.WindPlantUserDefined
+        range: WindPlantUserDefined
+        multivalued: false
+        required: false
+        description: Proprietary user-defined model with which this parameter is associated.
+      WindType1or2UserDefined:
+        slot_uri: cim:ProprietaryParameterDynamics.WindType1or2UserDefined
+        range: WindType1or2UserDefined
+        multivalued: false
+        required: false
+        description: Proprietary user-defined model with which this parameter is associated.
+      WindType3or4UserDefined:
+        slot_uri: cim:ProprietaryParameterDynamics.WindType3or4UserDefined
+        range: WindType3or4UserDefined
+        multivalued: false
+        required: false
+        description: Proprietary user-defined model with which this parameter is associated.
+      SynchronousMachineUserDefined:
+        slot_uri: cim:ProprietaryParameterDynamics.SynchronousMachineUserDefined
+        range: SynchronousMachineUserDefined
+        multivalued: false
+        required: false
+        description: Proprietary user-defined model with which this parameter is associated.
+      AsynchronousMachineUserDefined:
+        slot_uri: cim:ProprietaryParameterDynamics.AsynchronousMachineUserDefined
+        range: AsynchronousMachineUserDefined
+        multivalued: false
+        required: false
+        description: Proprietary user-defined model with which this parameter is associated.
+      TurbineGovernorUserDefined:
+        slot_uri: cim:ProprietaryParameterDynamics.TurbineGovernorUserDefined
+        range: TurbineGovernorUserDefined
+        multivalued: false
+        required: false
+        description: Proprietary user-defined model with which this parameter is associated.
+      TurbineLoadControllerUserDefined:
+        slot_uri: cim:ProprietaryParameterDynamics.TurbineLoadControllerUserDefined
+        range: TurbineLoadControllerUserDefined
+        multivalued: false
+        required: false
+        description: Proprietary user-defined model with which this parameter is associated.
+      MechanicalLoadUserDefined:
+        slot_uri: cim:ProprietaryParameterDynamics.MechanicalLoadUserDefined
+        range: MechanicalLoadUserDefined
+        multivalued: false
+        required: false
+        description: Proprietary user-defined model with which this parameter is associated.
+      ExcitationSystemUserDefined:
+        slot_uri: cim:ProprietaryParameterDynamics.ExcitationSystemUserDefined
+        range: ExcitationSystemUserDefined
+        multivalued: false
+        required: false
+        description: Proprietary user-defined model with which this parameter is associated.
+      OverexcitationLimiterUserDefined:
+        slot_uri: cim:ProprietaryParameterDynamics.OverexcitationLimiterUserDefined
+        range: OverexcitationLimiterUserDefined
+        multivalued: false
+        required: false
+        description: Proprietary user-defined model with which this parameter is associated.
+      UnderexcitationLimiterUserDefined:
+        slot_uri: cim:ProprietaryParameterDynamics.UnderexcitationLimiterUserDefined
+        range: UnderexcitationLimiterUserDefined
+        multivalued: false
+        required: false
+        description: Proprietary user-defined model with which this parameter is associated.
+      PowerSystemStabilizerUserDefined:
+        slot_uri: cim:ProprietaryParameterDynamics.PowerSystemStabilizerUserDefined
+        range: PowerSystemStabilizerUserDefined
+        multivalued: false
+        required: false
+        description: Proprietary user-defined model with which this parameter is associated.
+      DiscontinuousExcitationControlUserDefined:
+        slot_uri: cim:ProprietaryParameterDynamics.DiscontinuousExcitationControlUserDefined
+        range: DiscontinuousExcitationControlUserDefined
+        multivalued: false
+        required: false
+        description: Proprietary user-defined model with which this parameter is associated.
+      PFVArControllerType1UserDefined:
+        slot_uri: cim:ProprietaryParameterDynamics.PFVArControllerType1UserDefined
+        range: PFVArControllerType1UserDefined
+        multivalued: false
+        required: false
+        description: Proprietary user-defined model with which this parameter is associated.
+      VoltageAdjusterUserDefined:
+        slot_uri: cim:ProprietaryParameterDynamics.VoltageAdjusterUserDefined
+        range: VoltageAdjusterUserDefined
+        multivalued: false
+        required: false
+        description: Proprietary user-defined model with which this parameter is associated.
+      PFVArControllerType2UserDefined:
+        slot_uri: cim:ProprietaryParameterDynamics.PFVArControllerType2UserDefined
+        range: PFVArControllerType2UserDefined
+        multivalued: false
+        required: false
+        description: Proprietary user-defined model with which this parameter is associated.
+      VoltageCompensatorUserDefined:
+        slot_uri: cim:ProprietaryParameterDynamics.VoltageCompensatorUserDefined
+        range: VoltageCompensatorUserDefined
+        multivalued: false
+        required: false
+        description: Proprietary user-defined model with which this parameter is associated.
+      LoadUserDefined:
+        slot_uri: cim:ProprietaryParameterDynamics.LoadUserDefined
+        range: LoadUserDefined
+        multivalued: false
+        required: false
+        description: Proprietary user-defined model with which this parameter is associated.
+      parameterNumber:
+        slot_uri: cim:ProprietaryParameterDynamics.parameterNumber
+        range: integer
+        multivalued: false
+        required: true
+        description: Sequence number of the parameter among the set of parameters
+          associated with the related proprietary user-defined model.
+      booleanParameterValue:
+        slot_uri: cim:ProprietaryParameterDynamics.booleanParameterValue
+        range: boolean
+        multivalued: false
+        required: false
+        description: Boolean parameter value. If this attribute is populated, integerParameterValue
+          and floatParameterValue will not be.
+      integerParameterValue:
+        slot_uri: cim:ProprietaryParameterDynamics.integerParameterValue
+        range: integer
+        multivalued: false
+        required: false
+        description: Integer parameter value.  If this attribute is populated, booleanParameterValue
+          and floatParameterValue will not be.
+      floatParameterValue:
+        slot_uri: cim:ProprietaryParameterDynamics.floatParameterValue
+        range: float
+        multivalued: false
+        required: false
+        description: Floating point parameter value.  If this attribute is populated,
+          booleanParameterValue and integerParameterValue will not be.
+    description: "Supports definition of one or more parameters of several different\
+      \ datatypes for use by proprietary user-defined models.  \nThis class does not\
+      \ inherit from IdentifiedObject since it is not intended that a single instance\
+      \ of it be referenced by more than one proprietary user-defined model instance."
+  SynchronousMachineSimplified:
+    class_uri: cim:SynchronousMachineSimplified
+    is_a: SynchronousMachineDynamics
+    description: "The simplified model represents a synchronous generator as a constant\
+      \ internal voltage behind an impedance<i> </i>(<i>Rs + jXp</i>) as shown in\
+      \ the Simplified diagram.\nSince internal voltage is held constant, there is\
+      \ no <i>Efd</i> input and any excitation system model will be ignored.  There\
+      \ is also no <i>Ifd</i> output.\nThis model should not be used for representing\
+      \ a real generator except, perhaps, small generators whose response is insignificant.\
+      \  \nThe parameters used for the simplified model include:\n- RotatingMachineDynamics.damping\
+      \ (<i>D</i>);\n- RotatingMachineDynamics.inertia (<i>H</i>);\n- RotatingMachineDynamics.statorLeakageReactance\
+      \ (used to exchange <i>jXp </i>for SynchronousMachineSimplified);\n- RotatingMachineDynamics.statorResistance\
+      \ (<i>Rs</i>)."
+  SynchronousMachineDynamics:
+    class_uri: cim:SynchronousMachineDynamics
+    attributes:
+      SynchronousMachine:
+        slot_uri: cim:SynchronousMachineDynamics.SynchronousMachine
+        range: SynchronousMachine
+        multivalued: false
+        required: true
+        description: Synchronous machine to which synchronous machine dynamics model
+          applies.
+      CrossCompoundTurbineGovernorDyanmics:
+        slot_uri: cim:SynchronousMachineDynamics.CrossCompoundTurbineGovernorDyanmics
+        range: CrossCompoundTurbineGovernorDynamics
+        multivalued: false
+        required: false
+        description: The cross-compound turbine governor with which this high-pressure
+          synchronous machine is associated.
+      CrossCompoundTurbineGovernorDynamics:
+        slot_uri: cim:SynchronousMachineDynamics.CrossCompoundTurbineGovernorDynamics
+        range: CrossCompoundTurbineGovernorDynamics
+        multivalued: false
+        required: false
+        description: The cross-compound turbine governor with which this low-pressure
+          synchronous machine is associated.
+      MechanicalLoadDynamics:
+        slot_uri: cim:SynchronousMachineDynamics.MechanicalLoadDynamics
+        range: MechanicalLoadDynamics
+        multivalued: false
+        required: false
+        description: Mechanical load model associated with this synchronous machine
+          model.
+      ExcitationSystemDynamics:
+        slot_uri: cim:SynchronousMachineDynamics.ExcitationSystemDynamics
+        range: ExcitationSystemDynamics
+        multivalued: false
+        required: false
+        description: Excitation system model associated with this synchronous machine
+          model.
+      TurbineGovernorDynamics:
+        slot_uri: cim:SynchronousMachineDynamics.TurbineGovernorDynamics
+        range: TurbineGovernorDynamics
+        multivalued: true
+        required: false
+        description: Turbine-governor model associated with this synchronous machine
+          model. Multiplicity of greater than one is intended to support hydro units
+          that have multiple turbines on one generator.
+      GenICompensationForGenJ:
+        slot_uri: cim:SynchronousMachineDynamics.GenICompensationForGenJ
+        range: GenICompensationForGenJ
+        multivalued: true
+        required: false
+        description: Compensation of voltage compensator's generator for current flow
+          out of this  generator.
+    is_a: RotatingMachineDynamics
+    description: "Synchronous machine whose behaviour is described by reference to\
+      \ a standard model expressed in one of the following forms:\n- simplified (or\
+      \ classical), where a group of generators or motors is not modelled in detail;\n\
+      - detailed, in equivalent circuit form;\n- detailed, in time constant reactance\
+      \ form; or\n<font color=\"#0f0f0f\">- by definition of a user-defined model.</font>\n\
+      <font color=\"#0f0f0f\">It is a common practice to represent small generators\
+      \ by a negative load rather than by a dynamic generator model when performing\
+      \ dynamics simulations. In this case, a SynchronousMachine in the static model\
+      \ is not represented by anything in the dynamics model, instead it is treated\
+      \ as an ordinary load.</font>\n<font color=\"#0f0f0f\">Parameter details:</font>\n\
+      <ol>\n\t<li><font color=\"#0f0f0f\">Synchronous machine parameters such as <i>Xl,\
+      \ Xd, Xp</i> etc. are actually used as inductances in the models,</font> but\
+      \ are commonly referred to as reactances since, at nominal frequency, the PU\
+      \ values are the same. However, some references use the symbol <i>L</i> instead\
+      \ of <i>X</i>.</li>\n</ol>"
+  SynchronousMachineDetailed:
+    class_uri: cim:SynchronousMachineDetailed
+    attributes:
+      saturationFactorQAxis:
+        slot_uri: cim:SynchronousMachineDetailed.saturationFactorQAxis
+        range: float
+        multivalued: false
+        required: false
+        description: Quadrature-axis saturation factor at rated terminal voltage (<i>S1q</i>)
+          (&gt;= 0). Typical value = 0,02.
+      saturationFactor120QAxis:
+        slot_uri: cim:SynchronousMachineDetailed.saturationFactor120QAxis
+        range: float
+        multivalued: false
+        required: false
+        description: Quadrature-axis saturation factor at 120% of rated terminal voltage
+          (<i>S12q</i>) (&gt;= SynchonousMachineDetailed.saturationFactorQAxis).  Typical
+          value = 0,12.
+      efdBaseRatio:
+        slot_uri: cim:SynchronousMachineDetailed.efdBaseRatio
+        range: float
+        multivalued: false
+        required: true
+        description: Ratio (exciter voltage/generator voltage) of <i>Efd</i> bases
+          of exciter and generator models (&gt; 0). Typical value = 1.
+      ifdBaseType:
+        slot_uri: cim:SynchronousMachineDetailed.ifdBaseType
+        range: IfdBaseKind
+        multivalued: false
+        required: true
+        description: 'Excitation base system mode. It should be equal to the value
+          of <i>WLMDV</i> given by the user. <i>WLMDV</i> is the PU ratio between
+          the field voltage and the excitation current: <i>Efd</i> = <i>WLMDV</i>
+          x <i>Ifd</i>. Typical value = ifag.'
+    is_a: SynchronousMachineDynamics
+    description: "All synchronous machine detailed types use a subset of the same\
+      \ data parameters and input/output variables.  \nThe several variations differ\
+      \ in the following ways:\n- the number of  equivalent windings that are included;\n\
+      - the way in which saturation is incorporated into the model;\n- whether or\
+      \ not \u201Csubtransient saliency\u201D (<i>X''q</i> not = <i>X''d</i>) is represented.\n\
+      It is not necessary for each simulation tool to have separate models for each\
+      \ of the model types.  The same model can often be used for several types by\
+      \ alternative logic within the model.  Also, differences in saturation representation\
+      \ might not result in significant model performance differences so model substitutions\
+      \ are often acceptable."
+  SynchronousMachineTimeConstantReactance:
+    class_uri: cim:SynchronousMachineTimeConstantReactance
+    attributes:
+      rotorType:
+        slot_uri: cim:SynchronousMachineTimeConstantReactance.rotorType
+        range: RotorKind
+        multivalued: false
+        required: false
+        description: Type of rotor on physical machine.
+      modelType:
+        slot_uri: cim:SynchronousMachineTimeConstantReactance.modelType
+        range: SynchronousMachineModelKind
+        multivalued: false
+        required: true
+        description: Type of synchronous machine model used in dynamic simulation
+          applications.
+      ks:
+        slot_uri: cim:SynchronousMachineTimeConstantReactance.ks
+        range: float
+        multivalued: false
+        required: true
+        description: Saturation loading correction factor (<i>Ks</i>) (&gt;= 0).  Used
+          only by type J model.  Typical value = 0.
+      xDirectSync:
+        slot_uri: cim:SynchronousMachineTimeConstantReactance.xDirectSync
+        range: PU
+        multivalued: false
+        required: true
+        description: Direct-axis synchronous reactance (<i>Xd</i>) (&gt;= SynchronousMachineTimeConstantReactance.xDirectTrans).
+          The quotient of a sustained value of that AC component of armature voltage
+          that is produced by the total direct-axis flux due to direct-axis armature
+          current and the value of the AC component of this current, the machine running
+          at rated speed.  Typical value = 1,8.
+      xDirectTrans:
+        slot_uri: cim:SynchronousMachineTimeConstantReactance.xDirectTrans
+        range: PU
+        multivalued: false
+        required: true
+        description: Direct-axis transient reactance (unsaturated) (<i>X'd</i>) (&gt;=
+          SynchronousMachineTimeConstantReactance.xDirectSubtrans).  Typical value
+          = 0,5.
+      xDirectSubtrans:
+        slot_uri: cim:SynchronousMachineTimeConstantReactance.xDirectSubtrans
+        range: PU
+        multivalued: false
+        required: true
+        description: Direct-axis subtransient reactance (unsaturated) (<i>X''d</i>)
+          (&gt; RotatingMachineDynamics.statorLeakageReactance).  Typical value =
+          0,2.
+      xQuadSync:
+        slot_uri: cim:SynchronousMachineTimeConstantReactance.xQuadSync
+        range: PU
+        multivalued: false
+        required: true
+        description: 'Quadrature-axis synchronous reactance (<i>Xq</i>) (&gt;= SynchronousMachineTimeConstantReactance.xQuadTrans).
+
+          The ratio of the component of reactive armature voltage, due to the quadrature-axis
+          component of armature current, to this component of current, under steady
+          state conditions and at rated frequency.  Typical value = 1,6.'
+      xQuadTrans:
+        slot_uri: cim:SynchronousMachineTimeConstantReactance.xQuadTrans
+        range: PU
+        multivalued: false
+        required: false
+        description: Quadrature-axis transient reactance (<i>X'q</i>) (&gt;= SynchronousMachineTimeConstantReactance.xQuadSubtrans).  Typical
+          value = 0,3.
+      xQuadSubtrans:
+        slot_uri: cim:SynchronousMachineTimeConstantReactance.xQuadSubtrans
+        range: PU
+        multivalued: false
+        required: true
+        description: Quadrature-axis subtransient reactance (<i>X''q</i>) (&gt; RotatingMachineDynamics.statorLeakageReactance).  Typical
+          value = 0,2.
+      tpdo:
+        slot_uri: cim:SynchronousMachineTimeConstantReactance.tpdo
+        range: Seconds
+        multivalued: false
+        required: true
+        description: Direct-axis transient rotor time constant (<i>T'do</i>) (&gt;
+          SynchronousMachineTimeConstantReactance.tppdo).  Typical value = 5.
+      tppdo:
+        slot_uri: cim:SynchronousMachineTimeConstantReactance.tppdo
+        range: Seconds
+        multivalued: false
+        required: true
+        description: Direct-axis subtransient rotor time constant (<i>T''do</i>) (&gt;
+          0).  Typical value = 0,03.
+      tpqo:
+        slot_uri: cim:SynchronousMachineTimeConstantReactance.tpqo
+        range: Seconds
+        multivalued: false
+        required: false
+        description: Quadrature-axis transient rotor time constant (<i>T'qo</i>) (&gt;
+          SynchronousMachineTimeConstantReactance.tppqo). Typical value = 0,5.
+      tppqo:
+        slot_uri: cim:SynchronousMachineTimeConstantReactance.tppqo
+        range: Seconds
+        multivalued: false
+        required: true
+        description: Quadrature-axis subtransient rotor time constant (<i>T''qo</i>)
+          (&gt; 0). Typical value = 0,03.
+      tc:
+        slot_uri: cim:SynchronousMachineTimeConstantReactance.tc
+        range: Seconds
+        multivalued: false
+        required: true
+        description: "Damping time constant for \u201CCanay\u201D reactance (&gt;=\
+          \ 0).  Typical value = 0."
+    is_a: SynchronousMachineDetailed
+    description: "Synchronous machine detailed modelling types are defined by the\
+      \ combination of the attributes SynchronousMachineTimeConstantReactance.modelType\
+      \ and SynchronousMachineTimeConstantReactance.rotorType.  \nParameter details:\n\
+      <ol>\n\t<li>The \u201Cp\u201D in the time-related attribute names is a substitution\
+      \ for a \u201Cprime\u201D in the usual parameter notation, e.g. tpdo refers\
+      \ to <i>T'do</i>.</li>\n\t<li>The parameters used for models expressed in time\
+      \ constant reactance form include:</li>\n</ol>\n- RotatingMachine.ratedS (<i>MVAbase</i>);\n\
+      - RotatingMachineDynamics.damping (<i>D</i>);\n- RotatingMachineDynamics.inertia\
+      \ (<i>H</i>);\n- RotatingMachineDynamics.saturationFactor (<i>S1</i>);\n- RotatingMachineDynamics.saturationFactor120\
+      \ (<i>S12</i>);\n- RotatingMachineDynamics.statorLeakageReactance (<i>Xl</i>);\n\
+      - RotatingMachineDynamics.statorResistance (<i>Rs</i>);\n- SynchronousMachineTimeConstantReactance.ks\
+      \ (<i>Ks</i>);\n- SynchronousMachineDetailed.saturationFactorQAxis (<i>S1q</i>);\n\
+      - SynchronousMachineDetailed.saturationFactor120QAxis (<i>S12q</i>);\n- SynchronousMachineDetailed.efdBaseRatio;\n\
+      - SynchronousMachineDetailed.ifdBaseType;\n- .xDirectSync (<i>Xd</i>);\n- .xDirectTrans\
+      \ (<i>X'd</i>);\n- .xDirectSubtrans (<i>X''d</i>);\n- .xQuadSync (<i>Xq</i>);\n\
+      - .xQuadTrans (<i>X'q</i>);\n- .xQuadSubtrans (<i>X''q</i>);\n- .tpdo (<i>T'do</i>);\n\
+      - .tppdo (<i>T''do</i>);\n- .tpqo (<i>T'qo</i>);\n- .tppqo (<i>T''qo</i>);\n\
+      - .tc."
+  SynchronousMachineEquivalentCircuit:
+    class_uri: cim:SynchronousMachineEquivalentCircuit
+    attributes:
+      xad:
+        slot_uri: cim:SynchronousMachineEquivalentCircuit.xad
+        range: PU
+        multivalued: false
+        required: true
+        description: Direct-axis mutual reactance.
+      rfd:
+        slot_uri: cim:SynchronousMachineEquivalentCircuit.rfd
+        range: PU
+        multivalued: false
+        required: true
+        description: Field winding resistance.
+      xfd:
+        slot_uri: cim:SynchronousMachineEquivalentCircuit.xfd
+        range: PU
+        multivalued: false
+        required: true
+        description: Field winding leakage reactance.
+      r1d:
+        slot_uri: cim:SynchronousMachineEquivalentCircuit.r1d
+        range: PU
+        multivalued: false
+        required: true
+        description: Direct-axis damper 1 winding resistance.
+      x1d:
+        slot_uri: cim:SynchronousMachineEquivalentCircuit.x1d
+        range: PU
+        multivalued: false
+        required: true
+        description: Direct-axis damper 1 winding leakage reactance.
+      xf1d:
+        slot_uri: cim:SynchronousMachineEquivalentCircuit.xf1d
+        range: PU
+        multivalued: false
+        required: true
+        description: "Differential mutual (\u201CCanay\u201D) reactance."
+      xaq:
+        slot_uri: cim:SynchronousMachineEquivalentCircuit.xaq
+        range: PU
+        multivalued: false
+        required: true
+        description: Quadrature-axis mutual reactance.
+      r1q:
+        slot_uri: cim:SynchronousMachineEquivalentCircuit.r1q
+        range: PU
+        multivalued: false
+        required: true
+        description: Quadrature-axis damper 1 winding resistance.
+      x1q:
+        slot_uri: cim:SynchronousMachineEquivalentCircuit.x1q
+        range: PU
+        multivalued: false
+        required: true
+        description: Quadrature-axis damper 1 winding leakage reactance.
+      r2q:
+        slot_uri: cim:SynchronousMachineEquivalentCircuit.r2q
+        range: PU
+        multivalued: false
+        required: true
+        description: Quadrature-axis damper 2 winding resistance.
+      x2q:
+        slot_uri: cim:SynchronousMachineEquivalentCircuit.x2q
+        range: PU
+        multivalued: false
+        required: true
+        description: Quadrature-axis damper 2 winding leakage reactance.
+    is_a: SynchronousMachineDetailed
+    description: "The electrical equations for all variations of the synchronous models\
+      \ are based on the SynchronousEquivalentCircuit diagram for the direct- and\
+      \ quadrature- axes.\nEquations for conversion between equivalent circuit and\
+      \ time constant reactance forms:\n<i>Xd</i> = <i>Xad </i>+<i> Xl</i>\n<i>X\u2019\
+      d</i> = <i>Xl</i> + <i>Xad</i> x <i>Xfd</i> / (<i>Xad</i> + <i>Xfd</i>)\n<i>X\u201D\
+      d</i> = <i>Xl</i> + <i>Xad</i> x <i>Xfd</i> x <i>X1d</i> / (<i>Xad</i> x <i>Xfd</i>\
+      \ + <i>Xad</i> x <i>X1d</i> + <i>Xfd</i> x <i>X1d</i>)\n<i>Xq</i> = <i>Xaq</i>\
+      \ + <i>Xl</i>\n<i>X\u2019q</i> = <i>Xl</i> + <i>Xaq</i> x <i>X1q</i> / (<i>Xaq</i>\
+      \ + <i>X1q</i>)\n<i>X\u201Dq</i> = <i>Xl</i> + <i>Xaq</i> x <i>X1q</i> x <i>X2q</i>\
+      \ / (<i>Xaq</i> x <i>X1q</i> + <i>Xaq</i> x <i>X2q</i> + <i>X1q</i> x <i>X2q</i>)\n\
+      <i>T\u2019do</i> = (<i>Xad</i> + <i>Xfd</i>) / (<i>omega</i><i><sub>0</sub></i>\
+      \ x <i>Rfd</i>)\n<i>T\u201Ddo</i> = (<i>Xad</i> x <i>Xfd</i> + <i>Xad</i> x\
+      \ <i>X1d</i> + <i>Xfd</i> x <i>X1d</i>) / (<i>omega</i><i><sub>0</sub></i> x\
+      \ <i>R1d</i> x (<i>Xad</i> + <i>Xfd</i>)\n<i>T\u2019qo</i> = (<i>Xaq</i> + <i>X1q</i>)\
+      \ / (<i>omega</i><i><sub>0</sub></i> x <i>R1q</i>)\n<i>T\u201Dqo</i> = (<i>Xaq</i>\
+      \ x <i>X1q</i> + <i>Xaq</i> x <i>X2q</i> + <i>X1q</i> x <i>X2q</i>) / (<i>omega</i><i><sub>0</sub></i>\
+      \ x <i>R2q</i> x (<i>Xaq</i> + <i>X1q</i>)\nSame equations using CIM attributes\
+      \ from SynchronousMachineTimeConstantReactance class on left of \"=\" and SynchronousMachineEquivalentCircuit\
+      \ class on right (except as noted):\nxDirectSync = xad + RotatingMachineDynamics.statorLeakageReactance\n\
+      xDirectTrans = RotatingMachineDynamics.statorLeakageReactance + xad x xfd /\
+      \ (xad + xfd)\nxDirectSubtrans = RotatingMachineDynamics.statorLeakageReactance\
+      \ + xad x xfd x x1d / (xad x xfd + xad x x1d + xfd x x1d)\nxQuadSync = xaq +\
+      \ RotatingMachineDynamics.statorLeakageReactance\nxQuadTrans = RotatingMachineDynamics.statorLeakageReactance\
+      \ + xaq x x1q / (xaq+ x1q)\nxQuadSubtrans = RotatingMachineDynamics.statorLeakageReactance\
+      \ + xaq x x1q x x2q / (xaq x x1q + xaq x x2q + x1q x x2q) \ntpdo = (xad + xfd)\
+      \ / (2 x pi x nominal frequency x rfd)\ntppdo = (xad x xfd + xad x x1d + xfd\
+      \ x x1d) / (2 x pi x nominal frequency x r1d x (xad + xfd)\ntpqo = (xaq + x1q)\
+      \ / (2 x pi x nominal frequency x r1q)\ntppqo = (xaq x x1q + xaq x x2q + x1q\
+      \ x x2q) / (2 x pi x nominal frequency x r2q x (xaq + x1q)\nThese are only valid\
+      \ for a simplified model where \"Canay\" reactance is zero."
+  AsynchronousMachineDynamics:
+    class_uri: cim:AsynchronousMachineDynamics
+    attributes:
+      AsynchronousMachine:
+        slot_uri: cim:AsynchronousMachineDynamics.AsynchronousMachine
+        range: AsynchronousMachine
+        multivalued: false
+        required: true
+        description: Asynchronous machine to which this asynchronous machine dynamics
+          model applies.
+      TurbineGovernorDynamics:
+        slot_uri: cim:AsynchronousMachineDynamics.TurbineGovernorDynamics
+        range: TurbineGovernorDynamics
+        multivalued: false
+        required: false
+        description: Turbine-governor model associated with this asynchronous machine
+          model.
+      MechanicalLoadDynamics:
+        slot_uri: cim:AsynchronousMachineDynamics.MechanicalLoadDynamics
+        range: MechanicalLoadDynamics
+        multivalued: false
+        required: false
+        description: Mechanical load model associated with this asynchronous machine
+          model.
+      WindTurbineType1or2Dynamics:
+        slot_uri: cim:AsynchronousMachineDynamics.WindTurbineType1or2Dynamics
+        range: WindTurbineType1or2Dynamics
+        multivalued: false
+        required: false
+        description: Wind generator type 1 or type 2 model associated with this asynchronous
+          machine model.
+    is_a: RotatingMachineDynamics
+    description: "Asynchronous machine whose behaviour is described by reference to\
+      \ a standard model expressed in either time constant reactance form or equivalent\
+      \ circuit form <font color=\"#0f0f0f\">or by definition of a user-defined model.</font>\n\
+      Parameter details:\n<ol>\n\t<li>Asynchronous machine parameters such as <i>Xl,\
+      \ Xs,</i> etc. are actually used as inductances in the model, but are commonly\
+      \ referred to as reactances since, at nominal frequency, the PU values are the\
+      \ same. However, some references use the symbol <i>L</i> instead of <i>X</i>.</li>\n\
+      </ol>"
+  AsynchronousMachineTimeConstantReactance:
+    class_uri: cim:AsynchronousMachineTimeConstantReactance
+    attributes:
+      xs:
+        slot_uri: cim:AsynchronousMachineTimeConstantReactance.xs
+        range: PU
+        multivalued: false
+        required: true
+        description: Synchronous reactance (<i>Xs</i>) (&gt;= AsynchronousMachineTimeConstantReactance.xp).  Typical
+          value = 1,8.
+      xp:
+        slot_uri: cim:AsynchronousMachineTimeConstantReactance.xp
+        range: PU
+        multivalued: false
+        required: true
+        description: Transient reactance (unsaturated) (<i>X'</i>) (&gt;= AsynchronousMachineTimeConstantReactance.xpp).  Typical
+          value = 0,5.
+      xpp:
+        slot_uri: cim:AsynchronousMachineTimeConstantReactance.xpp
+        range: PU
+        multivalued: false
+        required: true
+        description: Subtransient reactance (unsaturated) (<i>X''</i>) (&gt; RotatingMachineDynamics.statorLeakageReactance).  Typical
+          value = 0,2.
+      tpo:
+        slot_uri: cim:AsynchronousMachineTimeConstantReactance.tpo
+        range: Seconds
+        multivalued: false
+        required: true
+        description: Transient rotor time constant (<i>T'o</i>) (&gt; AsynchronousMachineTimeConstantReactance.tppo).  Typical
+          value = 5.
+      tppo:
+        slot_uri: cim:AsynchronousMachineTimeConstantReactance.tppo
+        range: Seconds
+        multivalued: false
+        required: true
+        description: Subtransient rotor time constant (<i>T''o</i>) (&gt; 0).  Typical
+          value = 0,03.
+    is_a: AsynchronousMachineDynamics
+    description: "Parameter details:\n<ol>\n\t<li>If <i>X'' </i>=<i> X'</i>, a single\
+      \ cage (one equivalent rotor winding per axis) is modelled.</li>\n\t<li>The\
+      \ \u201C<i>p</i>\u201D in the attribute names is a substitution for a \u201C\
+      prime\u201D in the usual parameter notation, e.g. <i>tpo</i> refers to <i>T'o</i>.</li>\n\
+      </ol>\nThe parameters used for models expressed in time constant reactance form\
+      \ include:\n- RotatingMachine.ratedS (<i>MVAbase</i>);\n- RotatingMachineDynamics.damping\
+      \ (<i>D</i>);\n- RotatingMachineDynamics.inertia (<i>H</i>);\n- RotatingMachineDynamics.saturationFactor\
+      \ (<i>S1</i>);\n- RotatingMachineDynamics.saturationFactor120 (<i>S12</i>);\n\
+      - RotatingMachineDynamics.statorLeakageReactance (<i>Xl</i>);\n- RotatingMachineDynamics.statorResistance\
+      \ (<i>Rs</i>);\n- .xs (<i>Xs</i>);\n- .xp (<i>X'</i>);\n- .xpp (<i>X''</i>);\n\
+      - .tpo (<i>T'o</i>);\n- .tppo (<i>T''o</i>)."
+  AsynchronousMachineEquivalentCircuit:
+    class_uri: cim:AsynchronousMachineEquivalentCircuit
+    attributes:
+      xm:
+        slot_uri: cim:AsynchronousMachineEquivalentCircuit.xm
+        range: PU
+        multivalued: false
+        required: true
+        description: Magnetizing reactance.
+      rr1:
+        slot_uri: cim:AsynchronousMachineEquivalentCircuit.rr1
+        range: PU
+        multivalued: false
+        required: true
+        description: Damper 1 winding resistance.
+      xlr1:
+        slot_uri: cim:AsynchronousMachineEquivalentCircuit.xlr1
+        range: PU
+        multivalued: false
+        required: true
+        description: Damper 1 winding leakage reactance.
+      rr2:
+        slot_uri: cim:AsynchronousMachineEquivalentCircuit.rr2
+        range: PU
+        multivalued: false
+        required: true
+        description: Damper 2 winding resistance.
+      xlr2:
+        slot_uri: cim:AsynchronousMachineEquivalentCircuit.xlr2
+        range: PU
+        multivalued: false
+        required: true
+        description: Damper 2 winding leakage reactance.
+    is_a: AsynchronousMachineDynamics
+    description: "The electrical equations of all variations of the asynchronous model\
+      \ are based on the AsynchronousEquivalentCircuit diagram for the direct- and\
+      \ quadrature- axes, with two equivalent rotor windings in each axis.  \nEquations\
+      \ for conversion between equivalent circuit and time constant reactance forms:\n\
+      <i>Xs</i> = <i>Xm</i> + <i>Xl</i>\n<i>X'</i> = <i>Xl</i> + <i>Xm</i> x <i>Xlr1\
+      \ </i>/ (<i>Xm </i>+ <i>Xlr1</i>)\n<i>X''</i> = <i>Xl</i> + <i>Xm</i> x <i>Xlr1</i>\
+      \ x <i>Xlr2</i> / (<i>Xm</i> x <i>Xlr1</i> + <i>Xm</i> x <i>Xlr2</i> + <i>Xlr1</i>\
+      \ x <i>Xlr2</i>)\n<i>T'o</i> = (<i>Xm</i> + <i>Xlr1</i>) / (<i>omega</i><i><sub>0</sub></i>\
+      \ x <i>Rr1</i>)\n<i>T''o</i> = (<i>Xm</i> x <i>Xlr1</i> + <i>Xm</i> x <i>Xlr2</i>\
+      \ + <i>Xlr1</i> x <i>Xlr2</i>) / (<i>omega</i><i><sub>0</sub></i> x <i>Rr2</i>\
+      \ x (<i>Xm</i> + <i>Xlr1</i>)\nSame equations using CIM attributes from AsynchronousMachineTimeConstantReactance\
+      \ class on left of \"=\" and AsynchronousMachineEquivalentCircuit class on right\
+      \ (except as noted):\nxs = xm + RotatingMachineDynamics.statorLeakageReactance\n\
+      xp = RotatingMachineDynamics.statorLeakageReactance + xm x xlr1 / (xm + xlr1)\n\
+      xpp = RotatingMachineDynamics.statorLeakageReactance + xm x xlr1 x xlr2 / (xm\
+      \ x xlr1 + xm x xlr2 + xlr1 x xlr2)\ntpo = (xm + xlr1) / (2 x pi x nominal frequency\
+      \ x rr1)\ntppo = (xm x xlr1 + xm x xlr2 + xlr1 x xlr2) / (2 x pi x nominal frequency\
+      \ x rr2 x (xm + xlr1)."
+  CrossCompoundTurbineGovernorDynamics:
+    class_uri: cim:CrossCompoundTurbineGovernorDynamics
+    attributes:
+      HighPressureSynchronousMachineDynamics:
+        slot_uri: cim:CrossCompoundTurbineGovernorDynamics.HighPressureSynchronousMachineDynamics
+        range: SynchronousMachineDynamics
+        multivalued: false
+        required: true
+        description: High-pressure synchronous machine with which this cross-compound
+          turbine governor is associated.
+      LowPressureSynchronousMachineDynamics:
+        slot_uri: cim:CrossCompoundTurbineGovernorDynamics.LowPressureSynchronousMachineDynamics
+        range: SynchronousMachineDynamics
+        multivalued: false
+        required: true
+        description: Low-pressure synchronous machine with which this cross-compound
+          turbine governor is associated.
+    is_a: DynamicsFunctionBlock
+    description: Turbine-governor cross-compound function block whose behaviour is
+      described by reference to a standard model <font color="#0f0f0f">or by definition
+      of a user-defined model.</font>
+  TurbineGovernorDynamics:
+    class_uri: cim:TurbineGovernorDynamics
+    attributes:
+      SynchronousMachineDynamics:
+        slot_uri: cim:TurbineGovernorDynamics.SynchronousMachineDynamics
+        range: SynchronousMachineDynamics
+        multivalued: false
+        required: false
+        description: Synchronous machine model with which this turbine-governor model
+          is associated. TurbineGovernorDynamics shall have either an association
+          to SynchronousMachineDynamics or to AsynchronousMachineDynamics.
+      AsynchronousMachineDynamics:
+        slot_uri: cim:TurbineGovernorDynamics.AsynchronousMachineDynamics
+        range: AsynchronousMachineDynamics
+        multivalued: false
+        required: false
+        description: Asynchronous machine model with which this turbine-governor model
+          is associated. TurbineGovernorDynamics shall have either an association
+          to SynchronousMachineDynamics or to AsynchronousMachineDynamics.
+      TurbineLoadControllerDynamics:
+        slot_uri: cim:TurbineGovernorDynamics.TurbineLoadControllerDynamics
+        range: TurbineLoadControllerDynamics
+        multivalued: false
+        required: false
+        description: Turbine load controller providing input to this turbine-governor.
+    is_a: DynamicsFunctionBlock
+    description: Turbine-governor function block whose behaviour is described by reference
+      to a standard model <font color="#0f0f0f">or by definition of a user-defined
+      model.</font>
+  GovHydroIEEE0:
+    class_uri: cim:GovHydroIEEE0
+    attributes:
+      mwbase:
+        slot_uri: cim:GovHydroIEEE0.mwbase
+        range: ActivePower
+        multivalued: false
+        required: true
+        description: Base for power values (<i>MWbase</i>) (&gt; 0).  Unit = MW.
+      k:
+        slot_uri: cim:GovHydroIEEE0.k
+        range: PU
+        multivalued: false
+        required: true
+        description: Governor gain (<i>K)</i>.
+      t1:
+        slot_uri: cim:GovHydroIEEE0.t1
+        range: Seconds
+        multivalued: false
+        required: true
+        description: Governor lag time constant (<i>T1</i>) (&gt;= 0).  Typical value
+          = 0,25.
+      t2:
+        slot_uri: cim:GovHydroIEEE0.t2
+        range: Seconds
+        multivalued: false
+        required: true
+        description: Governor lead time constant (<i>T2)</i> (&gt;= 0).  Typical value
+          = 0.
+      t3:
+        slot_uri: cim:GovHydroIEEE0.t3
+        range: Seconds
+        multivalued: false
+        required: true
+        description: Gate actuator time constant (<i>T3</i>) (&gt;= 0).  Typical value
+          = 0,1.
+      t4:
+        slot_uri: cim:GovHydroIEEE0.t4
+        range: Seconds
+        multivalued: false
+        required: true
+        description: Water starting time (<i>T4</i>) (&gt;= 0).
+      pmax:
+        slot_uri: cim:GovHydroIEEE0.pmax
+        range: PU
+        multivalued: false
+        required: true
+        description: Gate maximum (<i>Pmax</i>) (&gt; GovHydroIEEE0.pmin).
+      pmin:
+        slot_uri: cim:GovHydroIEEE0.pmin
+        range: PU
+        multivalued: false
+        required: true
+        description: Gate minimum (<i>Pmin</i>) (&lt; GovHydroIEEE.pmax).
+    is_a: TurbineGovernorDynamics
+    description: 'IEEE simplified hydro governor-turbine model.  Used for mechanical-hydraulic
+      and electro-hydraulic turbine governors, with or without steam feedback. Typical
+      values given are for mechanical-hydraulic turbine-governor.
+
+      Ref<font color="#0f0f0f">erence: IEEE Transactions on Power Apparatus and Systems,
+      November/December 1973, Volume PAS-92, Number 6, <i><u>Dynamic Models for Steam
+      and Hydro Turbines in Power System Studies</u></i>, page 1904.</font>'
+  GovHydroIEEE2:
+    class_uri: cim:GovHydroIEEE2
+    attributes:
+      mwbase:
+        slot_uri: cim:GovHydroIEEE2.mwbase
+        range: ActivePower
+        multivalued: false
+        required: true
+        description: Base for power values (<i>MWbase</i>) (&gt; 0).  Unit = MW.
+      tg:
+        slot_uri: cim:GovHydroIEEE2.tg
+        range: Seconds
+        multivalued: false
+        required: true
+        description: Gate servo time constant (<i>Tg</i>) (&gt;= 0).  Typical value
+          = 0,5.
+      tp:
+        slot_uri: cim:GovHydroIEEE2.tp
+        range: Seconds
+        multivalued: false
+        required: true
+        description: Pilot servo valve time constant (<i>Tp</i>) (&gt;= 0).  Typical
+          value = 0,03.
+      uo:
+        slot_uri: cim:GovHydroIEEE2.uo
+        range: float
+        multivalued: false
+        required: true
+        description: Maximum gate opening velocity (<i>Uo</i>).  Unit = PU / s.  Typical
+          value = 0,1.
+      uc:
+        slot_uri: cim:GovHydroIEEE2.uc
+        range: float
+        multivalued: false
+        required: true
+        description: Maximum gate closing velocity (<i>Uc</i>) (&lt;0).  Typical value
+          = -0,1.
+      pmax:
+        slot_uri: cim:GovHydroIEEE2.pmax
+        range: PU
+        multivalued: false
+        required: true
+        description: Maximum gate opening (<i>Pmax</i>) (&gt; GovHydroIEEE2.pmin).  Typical
+          value = 1.
+      pmin:
+        slot_uri: cim:GovHydroIEEE2.pmin
+        range: PU
+        multivalued: false
+        required: true
+        description: Minimum gate opening (<i>Pmin</i>) (&lt;GovHydroIEEE2.pmax).  Typical
+          value = 0.
+      rperm:
+        slot_uri: cim:GovHydroIEEE2.rperm
+        range: PU
+        multivalued: false
+        required: true
+        description: Permanent droop (<i>Rperm</i>).  Typical value = 0,05.
+      rtemp:
+        slot_uri: cim:GovHydroIEEE2.rtemp
+        range: PU
+        multivalued: false
+        required: true
+        description: Temporary droop (<i>Rtemp</i>).  Typical value = 0,5.
+      tr:
+        slot_uri: cim:GovHydroIEEE2.tr
+        range: Seconds
+        multivalued: false
+        required: true
+        description: Dashpot time constant (<i>Tr</i>) (&gt;= 0).  Typical value =
+          12.
+      tw:
+        slot_uri: cim:GovHydroIEEE2.tw
+        range: Seconds
+        multivalued: false
+        required: true
+        description: Water inertia time constant (<i>Tw</i>) (&gt;= 0).  Typical value
+          = 2.
+      kturb:
+        slot_uri: cim:GovHydroIEEE2.kturb
+        range: PU
+        multivalued: false
+        required: true
+        description: Turbine gain (<i>Kturb</i>).  Typical value = 1.
+      aturb:
+        slot_uri: cim:GovHydroIEEE2.aturb
+        range: PU
+        multivalued: false
+        required: true
+        description: Turbine numerator multiplier (<i>Aturb</i>).  Typical value =
+          -1.
+      bturb:
+        slot_uri: cim:GovHydroIEEE2.bturb
+        range: PU
+        multivalued: false
+        required: true
+        description: Turbine denominator multiplier (<i>Bturb</i>) (&gt; 0).  Typical
+          value = 0,5.
+      gv1:
+        slot_uri: cim:GovHydroIEEE2.gv1
+        range: PU
+        multivalued: false
+        required: true
+        description: Nonlinear gain point 1, PU gv (<i>Gv1</i>).  Typical value =
+          0.
+      pgv1:
+        slot_uri: cim:GovHydroIEEE2.pgv1
+        range: PU
+        multivalued: false
+        required: true
+        description: Nonlinear gain point 1, PU power (<i>Pgv1</i>).  Typical value
+          = 0.
+      gv2:
+        slot_uri: cim:GovHydroIEEE2.gv2
+        range: PU
+        multivalued: false
+        required: true
+        description: Nonlinear gain point 2, PU gv (<i>Gv2</i>).  Typical value =
+          0.
+      pgv2:
+        slot_uri: cim:GovHydroIEEE2.pgv2
+        range: PU
+        multivalued: false
+        required: true
+        description: Nonlinear gain point 2, PU power (<i>Pgv2</i>).  Typical value
+          = 0.
+      gv3:
+        slot_uri: cim:GovHydroIEEE2.gv3
+        range: PU
+        multivalued: false
+        required: true
+        description: Nonlinear gain point 3, PU gv (<i>Gv3</i>).  Typical value =
+          0.
+      pgv3:
+        slot_uri: cim:GovHydroIEEE2.pgv3
+        range: PU
+        multivalued: false
+        required: true
+        description: Nonlinear gain point 3, PU power (<i>Pgv3</i>).  Typical value
+          = 0.
+      gv4:
+        slot_uri: cim:GovHydroIEEE2.gv4
+        range: PU
+        multivalued: false
+        required: true
+        description: Nonlinear gain point 4, PU gv (<i>Gv4</i>).  Typical value =
+          0.
+      pgv4:
+        slot_uri: cim:GovHydroIEEE2.pgv4
+        range: PU
+        multivalued: false
+        required: true
+        description: Nonlinear gain point 4, PU power (<i>Pgv4</i>).  Typical value
+          = 0.
+      gv5:
+        slot_uri: cim:GovHydroIEEE2.gv5
+        range: PU
+        multivalued: false
+        required: true
+        description: Nonlinear gain point 5, PU gv (<i>Gv5</i>).  Typical value =
+          0.
+      pgv5:
+        slot_uri: cim:GovHydroIEEE2.pgv5
+        range: PU
+        multivalued: false
+        required: true
+        description: Nonlinear gain point 5, PU power (<i>Pgv5</i>).  Typical value
+          = 0.
+      gv6:
+        slot_uri: cim:GovHydroIEEE2.gv6
+        range: PU
+        multivalued: false
+        required: true
+        description: Nonlinear gain point 6, PU gv (<i>Gv6</i>).  Typical value =
+          0.
+      pgv6:
+        slot_uri: cim:GovHydroIEEE2.pgv6
+        range: PU
+        multivalued: false
+        required: true
+        description: Nonlinear gain point 6, PU power (<i>Pgv6</i>).  Typical value
+          = 0.
+    is_a: TurbineGovernorDynamics
+    description: 'IEEE hydro turbine governor model represents plants with straightforward
+      penstock configurations and hydraulic-dashpot governors.
+
+      Ref<font color="#0f0f0f">erence: IEEE Transactions on Power Apparatus and Systems,
+      November/December 1973, Volume PAS-92, Number 6, <i><u>Dynamic Models for Steam
+      and Hydro Turbines in Power System Studies</u></i>, page 1904.</font>'
+  GovSteamIEEE1:
+    class_uri: cim:GovSteamIEEE1
+    attributes:
+      mwbase:
+        slot_uri: cim:GovSteamIEEE1.mwbase
+        range: ActivePower
+        multivalued: false
+        required: true
+        description: Base for power values (<i>MWbase</i>) (&gt; 0)<i>. </i>Unit =
+          MW.
+      k:
+        slot_uri: cim:GovSteamIEEE1.k
+        range: PU
+        multivalued: false
+        required: true
+        description: Governor gain (reciprocal of droop) (<i>K</i>) (&gt; 0).  Typical
+          value = 25.
+      t1:
+        slot_uri: cim:GovSteamIEEE1.t1
+        range: Seconds
+        multivalued: false
+        required: true
+        description: Governor lag time constant (<i>T1</i>) (&gt;= 0).  Typical value
+          = 0.
+      t2:
+        slot_uri: cim:GovSteamIEEE1.t2
+        range: Seconds
+        multivalued: false
+        required: true
+        description: Governor lead time constant (<i>T2</i>) (&gt;= 0).  Typical value
+          = 0.
+      t3:
+        slot_uri: cim:GovSteamIEEE1.t3
+        range: Seconds
+        multivalued: false
+        required: true
+        description: Valve positioner time constant (<i>T3</i>) (&gt; 0).  Typical
+          value = 0,1.
+      uo:
+        slot_uri: cim:GovSteamIEEE1.uo
+        range: float
+        multivalued: false
+        required: true
+        description: Maximum valve opening velocity (<i>Uo</i>) (&gt; 0).  Unit =
+          PU / s.  Typical value = 1.
+      uc:
+        slot_uri: cim:GovSteamIEEE1.uc
+        range: float
+        multivalued: false
+        required: true
+        description: Maximum valve closing velocity (<i>Uc</i>) (&lt; 0).  Unit =
+          PU / s.  Typical value = -10.
+      pmax:
+        slot_uri: cim:GovSteamIEEE1.pmax
+        range: PU
+        multivalued: false
+        required: true
+        description: Maximum valve opening (<i>Pmax</i>) (&gt; GovSteamIEEE1.pmin).  Typical
+          value = 1.
+      pmin:
+        slot_uri: cim:GovSteamIEEE1.pmin
+        range: PU
+        multivalued: false
+        required: true
+        description: Minimum valve opening (<i>Pmin</i>) (&gt;= 0 and &lt; GovSteamIEEE1.pmax).  Typical
+          value = 0.
+      t4:
+        slot_uri: cim:GovSteamIEEE1.t4
+        range: Seconds
+        multivalued: false
+        required: true
+        description: Inlet piping/steam bowl time constant (<i>T4</i>) (&gt;= 0).  Typical
+          value = 0,3.
+      k1:
+        slot_uri: cim:GovSteamIEEE1.k1
+        range: float
+        multivalued: false
+        required: true
+        description: Fraction of HP shaft power after first boiler pass (<i>K1</i>).  Typical
+          value = 0,2.
+      k2:
+        slot_uri: cim:GovSteamIEEE1.k2
+        range: float
+        multivalued: false
+        required: true
+        description: Fraction of LP shaft power after first boiler pass (<i>K2</i>).  Typical
+          value = 0.
+      t5:
+        slot_uri: cim:GovSteamIEEE1.t5
+        range: Seconds
+        multivalued: false
+        required: true
+        description: Time constant of second boiler pass (<i>T5</i>) (&gt;= 0).  Typical
+          value = 5.
+      k3:
+        slot_uri: cim:GovSteamIEEE1.k3
+        range: float
+        multivalued: false
+        required: true
+        description: Fraction of HP shaft power after second boiler pass (<i>K3</i>).  Typical
+          value = 0,3.
+      k4:
+        slot_uri: cim:GovSteamIEEE1.k4
+        range: float
+        multivalued: false
+        required: true
+        description: Fraction of LP shaft power after second boiler pass (<i>K4</i>).  Typical
+          value = 0.
+      t6:
+        slot_uri: cim:GovSteamIEEE1.t6
+        range: Seconds
+        multivalued: false
+        required: true
+        description: Time constant of third boiler pass (<i>T6</i>) (&gt;= 0).  Typical
+          value = 0,5.
+      k5:
+        slot_uri: cim:GovSteamIEEE1.k5
+        range: float
+        multivalued: false
+        required: true
+        description: Fraction of HP shaft power after third boiler pass (<i>K5</i>).  Typical
+          value = 0,5.
+      k6:
+        slot_uri: cim:GovSteamIEEE1.k6
+        range: float
+        multivalued: false
+        required: true
+        description: Fraction of LP shaft power after third boiler pass (<i>K6</i>).  Typical
+          value = 0.
+      t7:
+        slot_uri: cim:GovSteamIEEE1.t7
+        range: Seconds
+        multivalued: false
+        required: true
+        description: Time constant of fourth boiler pass (<i>T7</i>) (&gt;= 0).  Typical
+          value = 0.
+      k7:
+        slot_uri: cim:GovSteamIEEE1.k7
+        range: float
+        multivalued: false
+        required: true
+        description: Fraction of HP shaft power after fourth boiler pass (<i>K7</i>).  Typical
+          value = 0.
+      k8:
+        slot_uri: cim:GovSteamIEEE1.k8
+        range: float
+        multivalued: false
+        required: true
+        description: Fraction of LP shaft power after fourth boiler pass (<i>K8</i>).  Typical
+          value = 0.
+    is_a: TurbineGovernorDynamics
+    description: 'IEEE steam turbine governor model.
+
+      Ref<font color="#0f0f0f">erence: IEEE Transactions on Power Apparatus and Systems,
+      November/December 1973, Volume PAS-92, Number 6, <i><u>Dynamic Models for Steam
+      and Hydro Turbines in Power System Studies</u></i>, page 1904.</font>'
+  GovCT1:
+    class_uri: cim:GovCT1
+    attributes:
+      mwbase:
+        slot_uri: cim:GovCT1.mwbase
+        range: ActivePower
+        multivalued: false
+        required: true
+        description: Base for power values (<i>MWbase</i>) (&gt; 0).  Unit = MW.
+      r:
+        slot_uri: cim:GovCT1.r
+        range: PU
+        multivalued: false
+        required: true
+        description: Permanent droop (<i>R</i>).  Typical value = 0,04.
+      rselect:
+        slot_uri: cim:GovCT1.rselect
+        range: DroopSignalFeedbackKind
+        multivalued: false
+        required: true
+        description: Feedback signal for droop (<i>Rselect</i>).  Typical value =
+          electricalPower.
+      tpelec:
+        slot_uri: cim:GovCT1.tpelec
+        range: Seconds
+        multivalued: false
+        required: true
+        description: Electrical power transducer time constant (<i>Tpelec</i>) (&gt;
+          0).  Typical value = 1.
+      maxerr:
+        slot_uri: cim:GovCT1.maxerr
+        range: PU
+        multivalued: false
+        required: true
+        description: Maximum value for speed error signal (<i>maxerr</i>) (&gt; GovCT1.minerr).  Typical
+          value = 0,05.
+      minerr:
+        slot_uri: cim:GovCT1.minerr
+        range: PU
+        multivalued: false
+        required: true
+        description: Minimum value for speed error signal (<i>minerr</i>) (&lt; GovCT1.maxerr).  Typical
+          value = -0,05.
+      kpgov:
+        slot_uri: cim:GovCT1.kpgov
+        range: PU
+        multivalued: false
+        required: true
+        description: Governor proportional gain (<i>Kpgov</i>).  Typical value = 10.
+      kigov:
+        slot_uri: cim:GovCT1.kigov
+        range: PU
+        multivalued: false
+        required: true
+        description: Governor integral gain (<i>Kigov</i>).  Typical value = 2.
+      kdgov:
+        slot_uri: cim:GovCT1.kdgov
+        range: PU
+        multivalued: false
+        required: true
+        description: Governor derivative gain (<i>Kdgov</i>).  Typical value = 0.
+      tdgov:
+        slot_uri: cim:GovCT1.tdgov
+        range: Seconds
+        multivalued: false
+        required: true
+        description: Governor derivative controller time constant (<i>Tdgov</i>) (&gt;=
+          0).  Typical value = 1.
+      vmax:
+        slot_uri: cim:GovCT1.vmax
+        range: PU
+        multivalued: false
+        required: true
+        description: Maximum valve position limit (<i>Vmax</i>) (&gt; GovCT1.vmin).  Typical
+          value = 1.
+      vmin:
+        slot_uri: cim:GovCT1.vmin
+        range: PU
+        multivalued: false
+        required: true
+        description: Minimum valve position limit (<i>Vmin</i>) (&lt; GovCT1.vmax).  Typical
+          value = 0,15.
+      tact:
+        slot_uri: cim:GovCT1.tact
+        range: Seconds
+        multivalued: false
+        required: true
+        description: Actuator time constant (<i>Tact</i>) (&gt;= 0).  Typical value
+          = 0,5.
+      kturb:
+        slot_uri: cim:GovCT1.kturb
+        range: PU
+        multivalued: false
+        required: true
+        description: Turbine gain (<i>Kturb</i>) (&gt; 0).  Typical value = 1,5.
+      wfnl:
+        slot_uri: cim:GovCT1.wfnl
+        range: PU
+        multivalued: false
+        required: true
+        description: No load fuel flow (<i>Wfnl</i>).  Typical value = 0,2.
+      tb:
+        slot_uri: cim:GovCT1.tb
+        range: Seconds
+        multivalued: false
+        required: true
+        description: Turbine lag time constant (<i>Tb</i>) (&gt; 0).  Typical value
+          = 0,5.
+      tc:
+        slot_uri: cim:GovCT1.tc
+        range: Seconds
+        multivalued: false
+        required: true
+        description: Turbine lead time constant (<i>Tc</i>) (&gt;= 0).  Typical value
+          = 0.
+      wfspd:
+        slot_uri: cim:GovCT1.wfspd
+        range: boolean
+        multivalued: false
+        required: true
+        description: 'Switch for fuel source characteristic to recognize that fuel
+          flow, for a given fuel valve stroke, can be proportional to engine speed
+          (<i>Wfspd</i>).
+
+          true = fuel flow proportional to speed (for some gas turbines and diesel
+          engines with positive displacement fuel injectors)
+
+          false = fuel control system keeps fuel flow independent of engine speed.
+
+          Typical value = true.'
+      teng:
+        slot_uri: cim:GovCT1.teng
+        range: Seconds
+        multivalued: false
+        required: true
+        description: Transport time delay for diesel engine used in representing diesel
+          engines where there is a small but measurable transport delay between a
+          change in fuel flow setting and the development of torque (<i>Teng</i>)
+          (&gt;= 0).  <i>Teng</i> should be zero in all but special cases where this
+          transport delay is of particular concern.  Typical value = 0.
+      tfload:
+        slot_uri: cim:GovCT1.tfload
+        range: Seconds
+        multivalued: false
+        required: true
+        description: Load-limiter time constant (<i>Tfload</i>) (&gt; 0).  Typical
+          value = 3.
+      kpload:
+        slot_uri: cim:GovCT1.kpload
+        range: PU
+        multivalued: false
+        required: true
+        description: Load limiter proportional gain for PI controller (<i>Kpload</i>).  Typical
+          value = 2.
+      kiload:
+        slot_uri: cim:GovCT1.kiload
+        range: PU
+        multivalued: false
+        required: true
+        description: Load limiter integral gain for PI controller (<i>Kiload</i>).  Typical
+          value = 0,67.
+      ldref:
+        slot_uri: cim:GovCT1.ldref
+        range: PU
+        multivalued: false
+        required: true
+        description: Load limiter reference value (<i>Ldref</i>).  Typical value =
+          1.
+      dm:
+        slot_uri: cim:GovCT1.dm
+        range: PU
+        multivalued: false
+        required: true
+        description: Speed sensitivity coefficient (<i>Dm</i>).  <i>Dm</i> can represent
+          either the variation of the engine power with the shaft speed or the variation
+          of maximum power capability with shaft speed.  If it is positive it describes
+          the falling slope of the engine speed verses power characteristic as speed
+          increases. A slightly falling characteristic is typical for reciprocating
+          engines and some aero-derivative turbines.  If it is negative the engine
+          power is assumed to be unaffected by the shaft speed, but the maximum permissible
+          fuel flow is taken to fall with falling shaft speed. This is characteristic
+          of single-shaft industrial turbines due to exhaust temperature limits.  Typical
+          value = 0.
+      ropen:
+        slot_uri: cim:GovCT1.ropen
+        range: float
+        multivalued: false
+        required: true
+        description: Maximum valve opening rate (<i>Ropen</i>).  Unit = PU / s.  Typical
+          value = 0.10.
+      rclose:
+        slot_uri: cim:GovCT1.rclose
+        range: float
+        multivalued: false
+        required: true
+        description: Minimum valve closing rate (<i>Rclose</i>).  Unit = PU / s.  Typical
+          value = -0,1.
+      kimw:
+        slot_uri: cim:GovCT1.kimw
+        range: PU
+        multivalued: false
+        required: true
+        description: Power controller (reset) gain (<i>Kimw</i>).  The default value
+          of 0,01 corresponds to a reset time of 100 s.  A value of 0,001 corresponds
+          to a relatively slow-acting load controller.  Typical value = 0,01.
+      aset:
+        slot_uri: cim:GovCT1.aset
+        range: float
+        multivalued: false
+        required: true
+        description: Acceleration limiter setpoint (<i>Aset</i>).  Unit = PU / s.  Typical
+          value = 0,01.
+      ka:
+        slot_uri: cim:GovCT1.ka
+        range: PU
+        multivalued: false
+        required: true
+        description: Acceleration limiter gain (<i>Ka</i>).  Typical value = 10.
+      ta:
+        slot_uri: cim:GovCT1.ta
+        range: Seconds
+        multivalued: false
+        required: true
+        description: Acceleration limiter time constant (<i>Ta</i>) (&gt; 0).  Typical
+          value = 0,1.
+      db:
+        slot_uri: cim:GovCT1.db
+        range: PU
+        multivalued: false
+        required: true
+        description: Speed governor deadband in PU speed (<i>db</i>).  In the majority
+          of applications, it is recommended that this value be set to zero.  Typical
+          value = 0.
+      tsa:
+        slot_uri: cim:GovCT1.tsa
+        range: Seconds
+        multivalued: false
+        required: true
+        description: Temperature detection lead time constant (<i>Tsa</i>) (&gt;=
+          0).  Typical value = 4.
+      tsb:
+        slot_uri: cim:GovCT1.tsb
+        range: Seconds
+        multivalued: false
+        required: true
+        description: Temperature detection lag time constant (<i>Tsb</i>) (&gt;= 0).  Typical
+          value = 5.
+      rup:
+        slot_uri: cim:GovCT1.rup
+        range: PU
+        multivalued: false
+        required: true
+        description: Maximum rate of load limit increase (<i>Rup</i>).  Typical value
+          = 99.
+      rdown:
+        slot_uri: cim:GovCT1.rdown
+        range: PU
+        multivalued: false
+        required: true
+        description: Maximum rate of load limit decrease (<i>Rdown</i>).  Typical
+          value = -99.
+    is_a: TurbineGovernorDynamics
+    description: "General model for any prime mover with a PID governor, used primarily\
+      \ for combustion turbine and combined cycle units.\nThis model can be used to\
+      \ represent a variety of prime movers controlled by PID governors.  It is suitable,\
+      \ for example, for the representation of: \n<ul>\n\t<li>gas turbine and single\
+      \ shaft combined cycle turbines</li>\n</ul>\n<ul>\n\t<li>diesel engines with\
+      \ modern electronic or digital governors  </li>\n</ul>\n<ul>\n\t<li>steam turbines\
+      \ where steam is supplied from a large boiler drum or a large header whose pressure\
+      \ is substantially constant over the period under study</li>\n\t<li>simple hydro\
+      \ turbines in dam configurations where the water column length is short and\
+      \ water inertia effects are minimal.</li>\n</ul>\nAdditional information on\
+      \ this model is available in the 2012 IEEE report, <i><u>Dynamic Models for\
+      \ Turbine-Governors in Power System Studies</u></i>, 3.1.2.3 pages 3-4 (GGOV1)."
+  GovCT2:
+    class_uri: cim:GovCT2
+    attributes:
+      mwbase:
+        slot_uri: cim:GovCT2.mwbase
+        range: ActivePower
+        multivalued: false
+        required: true
+        description: Base for power values (<i>MWbase</i>) (&gt; 0).  Unit = MW.
+      r:
+        slot_uri: cim:GovCT2.r
+        range: PU
+        multivalued: false
+        required: true
+        description: Permanent droop (<i>R</i>).  Typical value = 0,05.
+      rselect:
+        slot_uri: cim:GovCT2.rselect
+        range: DroopSignalFeedbackKind
+        multivalued: false
+        required: true
+        description: Feedback signal for droop (<i>Rselect</i>).  Typical value =
+          electricalPower.
+      tpelec:
+        slot_uri: cim:GovCT2.tpelec
+        range: Seconds
+        multivalued: false
+        required: true
+        description: Electrical power transducer time constant (<i>Tpelec</i>) (&gt;=
+          0).  Typical value = 2,5.
+      maxerr:
+        slot_uri: cim:GovCT2.maxerr
+        range: PU
+        multivalued: false
+        required: true
+        description: Maximum value for speed error signal (<i>Maxerr</i>) (&gt; GovCT2.minerr).  Typical
+          value = 1.
+      minerr:
+        slot_uri: cim:GovCT2.minerr
+        range: PU
+        multivalued: false
+        required: true
+        description: Minimum value for speed error signal (<i>Minerr</i>) (&lt; GovCT2.maxerr).  Typical
+          value = -1.
+      kpgov:
+        slot_uri: cim:GovCT2.kpgov
+        range: PU
+        multivalued: false
+        required: true
+        description: Governor proportional gain (<i>Kpgov</i>).  Typical value = 4.
+      kigov:
+        slot_uri: cim:GovCT2.kigov
+        range: PU
+        multivalued: false
+        required: true
+        description: Governor integral gain (<i>Kigov</i>).  Typical value = 0,45.
+      kdgov:
+        slot_uri: cim:GovCT2.kdgov
+        range: PU
+        multivalued: false
+        required: true
+        description: Governor derivative gain (<i>Kdgov</i>).  Typical value = 0.
+      tdgov:
+        slot_uri: cim:GovCT2.tdgov
+        range: Seconds
+        multivalued: false
+        required: true
+        description: Governor derivative controller time constant (<i>Tdgov</i>) (&gt;=
+          0).  Typical value = 1.
+      vmax:
+        slot_uri: cim:GovCT2.vmax
+        range: PU
+        multivalued: false
+        required: true
+        description: Maximum valve position limit (<i>Vmax</i>) (&gt; GovCT2.vmin).  Typical
+          value = 1.
+      vmin:
+        slot_uri: cim:GovCT2.vmin
+        range: PU
+        multivalued: false
+        required: true
+        description: Minimum valve position limit (<i>Vmin</i>) (&lt; GovCT2.vmax).  Typical
+          value = 0,175.
+      tact:
+        slot_uri: cim:GovCT2.tact
+        range: Seconds
+        multivalued: false
+        required: true
+        description: Actuator time constant (<i>Tact</i>) (&gt;= 0).  Typical value
+          = 0,4.
+      kturb:
+        slot_uri: cim:GovCT2.kturb
+        range: PU
+        multivalued: false
+        required: true
+        description: Turbine gain (<i>Kturb</i>).  Typical value = 1,9168.
+      wfnl:
+        slot_uri: cim:GovCT2.wfnl
+        range: PU
+        multivalued: false
+        required: true
+        description: No load fuel flow (<i>Wfnl</i>).  Typical value = 0,187.
+      tb:
+        slot_uri: cim:GovCT2.tb
+        range: Seconds
+        multivalued: false
+        required: true
+        description: Turbine lag time constant (<i>Tb</i>) (&gt;= 0).  Typical value
+          = 0,1.
+      tc:
+        slot_uri: cim:GovCT2.tc
+        range: Seconds
+        multivalued: false
+        required: true
+        description: Turbine lead time constant (<i>Tc</i>) (&gt;= 0).  Typical value
+          = 0.
+      wfspd:
+        slot_uri: cim:GovCT2.wfspd
+        range: boolean
+        multivalued: false
+        required: true
+        description: 'Switch for fuel source characteristic to recognize that fuel
+          flow, for a given fuel valve stroke, can be proportional to engine speed
+          (<i>Wfspd</i>).
+
+          true = fuel flow proportional to speed (for some gas turbines and diesel
+          engines with positive displacement fuel injectors)
+
+          false = fuel control system keeps fuel flow independent of engine speed.
+
+          Typical value = false.'
+      teng:
+        slot_uri: cim:GovCT2.teng
+        range: Seconds
+        multivalued: false
+        required: true
+        description: Transport time delay for diesel engine used in representing diesel
+          engines where there is a small but measurable transport delay between a
+          change in fuel flow setting and the development of torque (<i>Teng</i>)
+          (&gt;= 0).  <i>Teng</i> should be zero in all but special cases where this
+          transport delay is of particular concern.  Typical value = 0.
+      tfload:
+        slot_uri: cim:GovCT2.tfload
+        range: Seconds
+        multivalued: false
+        required: true
+        description: Load limiter time constant (<i>Tfload</i>) (&gt;= 0).  Typical
+          value = 3.
+      kpload:
+        slot_uri: cim:GovCT2.kpload
+        range: PU
+        multivalued: false
+        required: true
+        description: Load limiter proportional gain for PI controller (<i>Kpload</i>).  Typical
+          value = 1.
+      kiload:
+        slot_uri: cim:GovCT2.kiload
+        range: PU
+        multivalued: false
+        required: true
+        description: Load limiter integral gain for PI controller (<i>Kiload</i>).  Typical
+          value = 1.
+      ldref:
+        slot_uri: cim:GovCT2.ldref
+        range: PU
+        multivalued: false
+        required: true
+        description: Load limiter reference value (<i>Ldref</i>).  Typical value =
+          1.
+      dm:
+        slot_uri: cim:GovCT2.dm
+        range: PU
+        multivalued: false
+        required: true
+        description: Speed sensitivity coefficient (<i>Dm</i>).  <i>Dm</i> can represent
+          either the variation of the engine power with the shaft speed or the variation
+          of maximum power capability with shaft speed.  If it is positive it describes
+          the falling slope of the engine speed verses power characteristic as speed
+          increases. A slightly falling characteristic is typical for reciprocating
+          engines and some aero-derivative turbines.  If it is negative the engine
+          power is assumed to be unaffected by the shaft speed, but the maximum permissible
+          fuel flow is taken to fall with falling shaft speed. This is characteristic
+          of single-shaft industrial turbines due to exhaust temperature limits.  Typical
+          value = 0.
+      ropen:
+        slot_uri: cim:GovCT2.ropen
+        range: float
+        multivalued: false
+        required: true
+        description: Maximum valve opening rate (<i>Ropen</i>).  Unit = PU / s.  Typical
+          value = 99.
+      rclose:
+        slot_uri: cim:GovCT2.rclose
+        range: float
+        multivalued: false
+        required: true
+        description: Minimum valve closing rate (<i>Rclose</i>).  Unit = PU / s.  Typical
+          value = -99.
+      kimw:
+        slot_uri: cim:GovCT2.kimw
+        range: PU
+        multivalued: false
+        required: true
+        description: Power controller (reset) gain (<i>Kimw</i>).  The default value
+          of 0,01 corresponds to a reset time of 100 seconds.  A value of 0,001 corresponds
+          to a relatively slow-acting load controller.  Typical value = 0.
+      aset:
+        slot_uri: cim:GovCT2.aset
+        range: float
+        multivalued: false
+        required: true
+        description: Acceleration limiter setpoint (<i>Aset</i>).  Unit = PU / s.  Typical
+          value = 10.
+      ka:
+        slot_uri: cim:GovCT2.ka
+        range: PU
+        multivalued: false
+        required: true
+        description: Acceleration limiter gain (<i>Ka</i>).  Typical value = 10.
+      ta:
+        slot_uri: cim:GovCT2.ta
+        range: Seconds
+        multivalued: false
+        required: true
+        description: Acceleration limiter time constant (<i>Ta</i>) (&gt;= 0).  Typical
+          value = 1.
+      db:
+        slot_uri: cim:GovCT2.db
+        range: PU
+        multivalued: false
+        required: true
+        description: Speed governor deadband in PU speed (<i>db</i>).  In the majority
+          of applications, it is recommended that this value be set to zero.  Typical
+          value = 0.
+      tsa:
+        slot_uri: cim:GovCT2.tsa
+        range: Seconds
+        multivalued: false
+        required: true
+        description: Temperature detection lead time constant (<i>Tsa</i>) (&gt;=
+          0).  Typical value = 0.
+      tsb:
+        slot_uri: cim:GovCT2.tsb
+        range: Seconds
+        multivalued: false
+        required: true
+        description: Temperature detection lag time constant (<i>Tsb</i>) (&gt;= 0).  Typical
+          value = 50.
+      rup:
+        slot_uri: cim:GovCT2.rup
+        range: PU
+        multivalued: false
+        required: true
+        description: Maximum rate of load limit increase (<i>Rup</i>).  Typical value
+          = 99.
+      rdown:
+        slot_uri: cim:GovCT2.rdown
+        range: PU
+        multivalued: false
+        required: true
+        description: Maximum rate of load limit decrease (<i>Rdown</i>).  Typical
+          value = -99.
+      prate:
+        slot_uri: cim:GovCT2.prate
+        range: PU
+        multivalued: false
+        required: true
+        description: Ramp rate for frequency-dependent power limit (<i>Prate</i>).  Typical
+          value = 0,017.
+      flim1:
+        slot_uri: cim:GovCT2.flim1
+        range: Frequency
+        multivalued: false
+        required: true
+        description: Frequency threshold 1 (<i>Flim1</i>).  Unit = Hz.  Typical value
+          = 59.
+      plim1:
+        slot_uri: cim:GovCT2.plim1
+        range: PU
+        multivalued: false
+        required: true
+        description: Power limit 1 (<i>Plim1</i>).  Typical value = 0,8325.
+      flim2:
+        slot_uri: cim:GovCT2.flim2
+        range: Frequency
+        multivalued: false
+        required: true
+        description: Frequency threshold 2 (<i>Flim2</i>).  Unit = Hz.  Typical value
+          = 0.
+      plim2:
+        slot_uri: cim:GovCT2.plim2
+        range: PU
+        multivalued: false
+        required: true
+        description: Power limit 2 (Plim2).  Typical value = 0.
+      flim3:
+        slot_uri: cim:GovCT2.flim3
+        range: Frequency
+        multivalued: false
+        required: true
+        description: Frequency threshold 3 (<i>Flim3</i>).  Unit = Hz.  Typical value
+          = 0.
+      plim3:
+        slot_uri: cim:GovCT2.plim3
+        range: PU
+        multivalued: false
+        required: true
+        description: Power limit 3 (<i>Plim3</i>).  Typical value = 0.
+      flim4:
+        slot_uri: cim:GovCT2.flim4
+        range: Frequency
+        multivalued: false
+        required: true
+        description: Frequency threshold 4 (<i>Flim4</i>).  Unit = Hz.  Typical value
+          = 0.
+      plim4:
+        slot_uri: cim:GovCT2.plim4
+        range: PU
+        multivalued: false
+        required: true
+        description: Power limit 4 (<i>Plim4</i>).  Typical value = 0.
+      flim5:
+        slot_uri: cim:GovCT2.flim5
+        range: Frequency
+        multivalued: false
+        required: true
+        description: Frequency threshold 5 (<i>Flim5</i>).  Unit = Hz.  Typical value
+          = 0.
+      plim5:
+        slot_uri: cim:GovCT2.plim5
+        range: PU
+        multivalued: false
+        required: true
+        description: Power limit 5 (<i>Plim5</i>).  Typical value = 0.
+      flim6:
+        slot_uri: cim:GovCT2.flim6
+        range: Frequency
+        multivalued: false
+        required: true
+        description: Frequency threshold 6 (<i>Flim6</i>).  Unit = Hz.  Typical value
+          = 0.
+      plim6:
+        slot_uri: cim:GovCT2.plim6
+        range: PU
+        multivalued: false
+        required: true
+        description: Power limit 6 (<i>Plim6</i>).  Typical value = 0.
+      flim7:
+        slot_uri: cim:GovCT2.flim7
+        range: Frequency
+        multivalued: false
+        required: true
+        description: Frequency threshold 7 (<i>Flim7</i>).  Unit = Hz.  Typical value
+          = 0.
+      plim7:
+        slot_uri: cim:GovCT2.plim7
+        range: PU
+        multivalued: false
+        required: true
+        description: Power limit 7 (<i>Plim7</i>).  Typical value = 0.
+      flim8:
+        slot_uri: cim:GovCT2.flim8
+        range: Frequency
+        multivalued: false
+        required: true
+        description: Frequency threshold 8 (<i>Flim8</i>).  Unit = Hz.  Typical value
+          = 0.
+      plim8:
+        slot_uri: cim:GovCT2.plim8
+        range: PU
+        multivalued: false
+        required: true
+        description: Power limit 8 (<i>Plim8</i>).  Typical value = 0.
+      flim9:
+        slot_uri: cim:GovCT2.flim9
+        range: Frequency
+        multivalued: false
+        required: true
+        description: Frequency threshold 9 (<i>Flim9</i>).  Unit = Hz.  Typical value
+          = 0.
+      plim9:
+        slot_uri: cim:GovCT2.plim9
+        range: PU
+        multivalued: false
+        required: true
+        description: Power Limit 9 (<i>Plim9</i>).  Typical value = 0.
+      flim10:
+        slot_uri: cim:GovCT2.flim10
+        range: Frequency
+        multivalued: false
+        required: true
+        description: Frequency threshold 10 (<i>Flim10</i>).  Unit = Hz.  Typical
+          value = 0.
+      plim10:
+        slot_uri: cim:GovCT2.plim10
+        range: PU
+        multivalued: false
+        required: true
+        description: Power limit 10 (<i>Plim10</i>).  Typical value = 0.
+    is_a: TurbineGovernorDynamics
+    description: General governor with frequency-dependent fuel flow limit.  This
+      model is a modification of the GovCT1<b> </b>model in order to represent the
+      frequency-dependent fuel flow limit of a specific gas turbine manufacturer.
+  GovGAST:
+    class_uri: cim:GovGAST
+    attributes:
+      mwbase:
+        slot_uri: cim:GovGAST.mwbase
+        range: ActivePower
+        multivalued: false
+        required: true
+        description: Base for power values (<i>MWbase</i>) (&gt; 0).  Unit = MW.
+      r:
+        slot_uri: cim:GovGAST.r
+        range: PU
+        multivalued: false
+        required: true
+        description: Permanent droop (<i>R</i>) (&gt;0). Typical value = 0,04.
+      t1:
+        slot_uri: cim:GovGAST.t1
+        range: Seconds
+        multivalued: false
+        required: true
+        description: Governor mechanism time constant (<i>T1</i>) (&gt;= 0).  <i>T1</i>
+          represents the natural valve positioning time constant of the governor for
+          small disturbances, as seen when rate limiting is not in effect.  Typical
+          value = 0,5.
+      t2:
+        slot_uri: cim:GovGAST.t2
+        range: Seconds
+        multivalued: false
+        required: true
+        description: Turbine power time constant (<i>T2</i>) (&gt;= 0).  <i>T2</i>
+          represents delay due to internal energy storage of the gas turbine engine.
+          <i>T2</i> can be used to give a rough approximation to the delay associated
+          with acceleration of the compressor spool of a multi-shaft engine, or with
+          the compressibility of gas in the plenum of a free power turbine of an aero-derivative
+          unit, for example.  Typical value = 0,5.
+      t3:
+        slot_uri: cim:GovGAST.t3
+        range: Seconds
+        multivalued: false
+        required: true
+        description: Turbine exhaust temperature time constant (<i>T3</i>) (&gt;=
+          0).  Typical value = 3.
+      at:
+        slot_uri: cim:GovGAST.at
+        range: PU
+        multivalued: false
+        required: true
+        description: Ambient temperature load limit (<i>Load Limit</i>).  Typical
+          value = 1.
+      kt:
+        slot_uri: cim:GovGAST.kt
+        range: PU
+        multivalued: false
+        required: true
+        description: Temperature limiter gain (<i>Kt</i>).  Typical value = 3.
+      vmax:
+        slot_uri: cim:GovGAST.vmax
+        range: PU
+        multivalued: false
+        required: true
+        description: Maximum turbine power, PU of MWbase (<i>Vmax</i>) (&gt; GovGAST.vmin).  Typical
+          value = 1.
+      vmin:
+        slot_uri: cim:GovGAST.vmin
+        range: PU
+        multivalued: false
+        required: true
+        description: Minimum turbine power, PU of MWbase (<i>Vmin</i>) (&lt; GovGAST.vmax).  Typical
+          value = 0.
+      dturb:
+        slot_uri: cim:GovGAST.dturb
+        range: PU
+        multivalued: false
+        required: true
+        description: Turbine damping factor (<i>Dturb</i>).  Typical value = 0,18.
+    is_a: TurbineGovernorDynamics
+    description: Single shaft gas turbine.
+  GovGAST1:
+    class_uri: cim:GovGAST1
+    attributes:
+      mwbase:
+        slot_uri: cim:GovGAST1.mwbase
+        range: ActivePower
+        multivalued: false
+        required: true
+        description: Base for power values (<i>MWbase</i>) (&gt; 0).  Unit = MW.
+      r:
+        slot_uri: cim:GovGAST1.r
+        range: PU
+        multivalued: false
+        required: true
+        description: Permanent droop (<i>R</i>) (&gt;0).  Typical value = 0,04.
+      t1:
+        slot_uri: cim:GovGAST1.t1
+        range: Seconds
+        multivalued: false
+        required: true
+        description: Governor mechanism time constant (<i>T1</i>) (&gt;= 0).  <i>T1</i>
+          represents the natural valve positioning time constant of the governor for
+          small disturbances, as seen when rate limiting is not in effect.  Typical
+          value = 0,5.
+      t2:
+        slot_uri: cim:GovGAST1.t2
+        range: Seconds
+        multivalued: false
+        required: true
+        description: Turbine power time constant (<i>T2</i>) (&gt;= 0). <i>T2</i>
+          represents delay due to internal energy storage of the gas turbine engine.
+          <i>T2</i> can be used to give a rough approximation to the delay associated
+          with acceleration of the compressor spool of a multi-shaft engine, or with
+          the compressibility of gas in the plenum of the free power turbine of an
+          aero-derivative unit, for example.  Typical value = 0,5.
+      t3:
+        slot_uri: cim:GovGAST1.t3
+        range: Seconds
+        multivalued: false
+        required: true
+        description: Turbine exhaust temperature time constant (<i>T3</i>) (&gt;=
+          0).  <i>T3</i> represents delay in the exhaust temperature and load limiting
+          system. Typical value = 3.
+      lmax:
+        slot_uri: cim:GovGAST1.lmax
+        range: PU
+        multivalued: false
+        required: true
+        description: Ambient temperature load limit (<i>Lmax</i>).  <i>Lmax</i> is
+          the turbine power output corresponding to the limiting exhaust gas temperature.  Typical
+          value = 1.
+      kt:
+        slot_uri: cim:GovGAST1.kt
+        range: PU
+        multivalued: false
+        required: true
+        description: Temperature limiter gain (<i>Kt</i>).  Typical value = 3.
+      vmax:
+        slot_uri: cim:GovGAST1.vmax
+        range: PU
+        multivalued: false
+        required: true
+        description: Maximum turbine power, PU of MWbase (<i>Vmax</i>) (&gt; GovGAST1.vmin).  Typical
+          value = 1.
+      vmin:
+        slot_uri: cim:GovGAST1.vmin
+        range: PU
+        multivalued: false
+        required: true
+        description: Minimum turbine power, PU of MWbase (<i>Vmin</i>) (&lt; GovGAST1.vmax).  Typical
+          value = 0.
+      fidle:
+        slot_uri: cim:GovGAST1.fidle
+        range: PU
+        multivalued: false
+        required: true
+        description: Fuel flow at zero power output (<i>Fidle</i>).  Typical value
+          = 0,18.
+      rmax:
+        slot_uri: cim:GovGAST1.rmax
+        range: float
+        multivalued: false
+        required: true
+        description: Maximum fuel valve opening rate (<i>Rmax</i>).  Unit = PU / s.  Typical
+          value = 1.
+      loadinc:
+        slot_uri: cim:GovGAST1.loadinc
+        range: PU
+        multivalued: false
+        required: true
+        description: Valve position change allowed at fast rate (<i>Loadinc</i>).  Typical
+          value = 0,05.
+      tltr:
+        slot_uri: cim:GovGAST1.tltr
+        range: Seconds
+        multivalued: false
+        required: true
+        description: Valve position averaging time constant (<i>Tltr</i>) (&gt;= 0).  Typical
+          value = 10.
+      ltrate:
+        slot_uri: cim:GovGAST1.ltrate
+        range: float
+        multivalued: false
+        required: true
+        description: Maximum long term fuel valve opening rate (<i>Ltrate</i>).  Typical
+          value = 0,02.
+      a:
+        slot_uri: cim:GovGAST1.a
+        range: float
+        multivalued: false
+        required: true
+        description: Turbine power time constant numerator scale factor (<i>a</i>).  Typical
+          value = 0,8.
+      b:
+        slot_uri: cim:GovGAST1.b
+        range: float
+        multivalued: false
+        required: true
+        description: Turbine power time constant denominator scale factor (<i>b</i>)
+          (&gt;0).  Typical value = 1.
+      db1:
+        slot_uri: cim:GovGAST1.db1
+        range: Frequency
+        multivalued: false
+        required: true
+        description: Intentional dead-band width (<i>db1</i>).  Unit = Hz.  Typical
+          value = 0.
+      eps:
+        slot_uri: cim:GovGAST1.eps
+        range: Frequency
+        multivalued: false
+        required: true
+        description: Intentional db hysteresis (<i>eps</i>).  Unit = Hz.  Typical
+          value = 0.
+      db2:
+        slot_uri: cim:GovGAST1.db2
+        range: ActivePower
+        multivalued: false
+        required: true
+        description: Unintentional dead-band (<i>db2</i>).  Unit = MW.  Typical value
+          = 0.
+      gv1:
+        slot_uri: cim:GovGAST1.gv1
+        range: PU
+        multivalued: false
+        required: true
+        description: Nonlinear gain point 1, PU gv (<i>Gv1</i>).  Typical value =
+          0.
+      pgv1:
+        slot_uri: cim:GovGAST1.pgv1
+        range: PU
+        multivalued: false
+        required: true
+        description: Nonlinear gain point 1, PU power (<i>Pgv1</i>).  Typical value
+          = 0.
+      gv2:
+        slot_uri: cim:GovGAST1.gv2
+        range: PU
+        multivalued: false
+        required: true
+        description: Nonlinear gain point 2,PU gv (<i>Gv2</i>).  Typical value = 0.
+      pgv2:
+        slot_uri: cim:GovGAST1.pgv2
+        range: PU
+        multivalued: false
+        required: true
+        description: Nonlinear gain point 2, PU power (<i>Pgv2</i>).  Typical value
+          = 0.
+      gv3:
+        slot_uri: cim:GovGAST1.gv3
+        range: PU
+        multivalued: false
+        required: true
+        description: Nonlinear gain point 3, PU gv (<i>Gv3</i>).  Typical value =
+          0.
+      pgv3:
+        slot_uri: cim:GovGAST1.pgv3
+        range: PU
+        multivalued: false
+        required: true
+        description: Nonlinear gain point 3, PU power (<i>Pgv3</i>).  Typical value
+          = 0.
+      gv4:
+        slot_uri: cim:GovGAST1.gv4
+        range: PU
+        multivalued: false
+        required: true
+        description: Nonlinear gain point 4, PU gv (<i>Gv4</i>).  Typical value =
+          0.
+      pgv4:
+        slot_uri: cim:GovGAST1.pgv4
+        range: PU
+        multivalued: false
+        required: true
+        description: Nonlinear gain point 4, PU power (<i>Pgv4</i>).  Typical value
+          = 0.
+      gv5:
+        slot_uri: cim:GovGAST1.gv5
+        range: PU
+        multivalued: false
+        required: true
+        description: Nonlinear gain point 5, PU gv (<i>Gv5</i>).  Typical value =
+          0.
+      pgv5:
+        slot_uri: cim:GovGAST1.pgv5
+        range: PU
+        multivalued: false
+        required: true
+        description: Nonlinear gain point 5, PU power (<i>Pgv5</i>).  Typical value
+          = 0.
+      gv6:
+        slot_uri: cim:GovGAST1.gv6
+        range: PU
+        multivalued: false
+        required: true
+        description: Nonlinear gain point 6, PU gv (<i>Gv6</i>).  Typical value =
+          0.
+      pgv6:
+        slot_uri: cim:GovGAST1.pgv6
+        range: PU
+        multivalued: false
+        required: true
+        description: Nonlinear gain point 6, PU power (<i>Pgv6</i>).  Typical value
+          = 0.
+      ka:
+        slot_uri: cim:GovGAST1.ka
+        range: PU
+        multivalued: false
+        required: true
+        description: Governor gain (<i>Ka</i>).  Typical value = 0.
+      t4:
+        slot_uri: cim:GovGAST1.t4
+        range: Seconds
+        multivalued: false
+        required: true
+        description: Governor lead time constant (<i>T4</i>) (&gt;= 0).  Typical value
+          = 0.
+      t5:
+        slot_uri: cim:GovGAST1.t5
+        range: Seconds
+        multivalued: false
+        required: true
+        description: Governor lag time constant (<i>T5</i>) (&gt;= 0).  If = 0, entire
+          gain and lead-lag block is bypassed.  Typical value = 0.
+    is_a: TurbineGovernorDynamics
+    description: Modified single shaft gas turbine.
+  GovGAST2:
+    class_uri: cim:GovGAST2
+    attributes:
+      mwbase:
+        slot_uri: cim:GovGAST2.mwbase
+        range: ActivePower
+        multivalued: false
+        required: true
+        description: Base for power values (<i>MWbase</i>) (&gt; 0).  Unit = MW.
+      w:
+        slot_uri: cim:GovGAST2.w
+        range: PU
+        multivalued: false
+        required: true
+        description: Governor gain (1/droop) on turbine rating (<i>W</i>).
+      x:
+        slot_uri: cim:GovGAST2.x
+        range: Seconds
+        multivalued: false
+        required: true
+        description: Governor lead time constant (<i>X</i>) (&gt;= 0).
+      y:
+        slot_uri: cim:GovGAST2.y
+        range: Seconds
+        multivalued: false
+        required: true
+        description: Governor lag time constant (<i>Y</i>) (&gt; 0).
+      z:
+        slot_uri: cim:GovGAST2.z
+        range: integer
+        multivalued: false
+        required: true
+        description: 'Governor mode (<i>Z</i>).
+
+          1 = droop
+
+          0 = isochronous.'
+      etd:
+        slot_uri: cim:GovGAST2.etd
+        range: Seconds
+        multivalued: false
+        required: true
+        description: Turbine and exhaust delay (<i>Etd</i>) (&gt;= 0).
+      tcd:
+        slot_uri: cim:GovGAST2.tcd
+        range: Seconds
+        multivalued: false
+        required: true
+        description: Compressor discharge time constant (<i>Tcd</i>) (&gt;= 0).
+      trate:
+        slot_uri: cim:GovGAST2.trate
+        range: ActivePower
+        multivalued: false
+        required: true
+        description: Turbine rating (<i>Trate</i>).  Unit = MW.
+      t:
+        slot_uri: cim:GovGAST2.t
+        range: Seconds
+        multivalued: false
+        required: true
+        description: Fuel control time constant (<i>T</i>) (&gt;= 0).
+      tmax:
+        slot_uri: cim:GovGAST2.tmax
+        range: PU
+        multivalued: false
+        required: true
+        description: Maximum turbine limit (<i>Tmax</i>) (&gt; GovGAST2.tmin).
+      tmin:
+        slot_uri: cim:GovGAST2.tmin
+        range: PU
+        multivalued: false
+        required: true
+        description: Minimum turbine limit (<i>Tmin</i>) (&lt; GovGAST2.tmax).
+      ecr:
+        slot_uri: cim:GovGAST2.ecr
+        range: Seconds
+        multivalued: false
+        required: true
+        description: Combustion reaction time delay (<i>Ecr</i>) (&gt;= 0).
+      k3:
+        slot_uri: cim:GovGAST2.k3
+        range: PU
+        multivalued: false
+        required: true
+        description: Ratio of fuel adjustment (<i>K3</i>).
+      a:
+        slot_uri: cim:GovGAST2.a
+        range: float
+        multivalued: false
+        required: true
+        description: Valve positioner (<i>A</i>).
+      b:
+        slot_uri: cim:GovGAST2.b
+        range: float
+        multivalued: false
+        required: true
+        description: Valve positioner (<i>B</i>).
+      c:
+        slot_uri: cim:GovGAST2.c
+        range: float
+        multivalued: false
+        required: true
+        description: Valve positioner (<i>C</i>).
+      tf:
+        slot_uri: cim:GovGAST2.tf
+        range: Seconds
+        multivalued: false
+        required: true
+        description: Fuel system time constant (<i>Tf</i>) (&gt;= 0).
+      kf:
+        slot_uri: cim:GovGAST2.kf
+        range: PU
+        multivalued: false
+        required: true
+        description: Fuel system feedback (<i>Kf</i>).
+      k5:
+        slot_uri: cim:GovGAST2.k5
+        range: PU
+        multivalued: false
+        required: true
+        description: Gain of radiation shield (<i>K5</i>).
+      k4:
+        slot_uri: cim:GovGAST2.k4
+        range: PU
+        multivalued: false
+        required: true
+        description: Gain of radiation shield (<i>K4</i>).
+      t3:
+        slot_uri: cim:GovGAST2.t3
+        range: Seconds
+        multivalued: false
+        required: true
+        description: Radiation shield time constant (<i>T3</i>) (&gt;= 0).
+      t4:
+        slot_uri: cim:GovGAST2.t4
+        range: Seconds
+        multivalued: false
+        required: true
+        description: Thermocouple time constant (<i>T4</i>) (&gt;= 0).
+      tt:
+        slot_uri: cim:GovGAST2.tt
+        range: Seconds
+        multivalued: false
+        required: true
+        description: Temperature controller integration rate (<i>Tt</i>) (&gt;= 0).
+      t5:
+        slot_uri: cim:GovGAST2.t5
+        range: Seconds
+        multivalued: false
+        required: true
+        description: Temperature control time constant (<i>T5</i>) (&gt;= 0).
+      af1:
+        slot_uri: cim:GovGAST2.af1
+        range: PU
+        multivalued: false
+        required: true
+        description: Exhaust temperature parameter (<i>Af1</i>).  Unit = PU temperature.  Based
+          on temperature in degrees C.
+      bf1:
+        slot_uri: cim:GovGAST2.bf1
+        range: PU
+        multivalued: false
+        required: true
+        description: (<i>Bf1</i>).  <i>Bf1</i> = <i>E</i>(1 - <i>W</i>) where <i>E</i>
+          (speed sensitivity coefficient) is 0,55 to 0,65 x <i>Tr</i>.  Unit = PU
+          temperature.  Based on temperature in degrees C.
+      af2:
+        slot_uri: cim:GovGAST2.af2
+        range: PU
+        multivalued: false
+        required: true
+        description: Coefficient equal to 0,5(1-speed) (<i>Af2</i>).
+      bf2:
+        slot_uri: cim:GovGAST2.bf2
+        range: PU
+        multivalued: false
+        required: true
+        description: Turbine torque coefficient K<sub>hhv</sub> (depends on heating
+          value of fuel stream in combustion chamber) (<i>Bf2</i>).
+      cf2:
+        slot_uri: cim:GovGAST2.cf2
+        range: PU
+        multivalued: false
+        required: true
+        description: Coefficient defining fuel flow where power output is 0% (<i>Cf2</i>).  Synchronous
+          but no output.  Typically 0,23 x K<sub>hhv</sub> (23% fuel flow).
+      tr:
+        slot_uri: cim:GovGAST2.tr
+        range: Temperature
+        multivalued: false
+        required: true
+        description: "Rated temperature (<i>Tr</i>).  Unit = \xB0C depending on parameters<i>\
+          \ Af1 </i>and <i>Bf1</i>."
+      k6:
+        slot_uri: cim:GovGAST2.k6
+        range: PU
+        multivalued: false
+        required: true
+        description: Minimum fuel flow (<i>K6</i>).
+      tc:
+        slot_uri: cim:GovGAST2.tc
+        range: Temperature
+        multivalued: false
+        required: true
+        description: "Temperature control (<i>Tc</i>).  Unit = \xB0F or \xB0C depending\
+          \ on parameters <i>Af1</i> and <i>Bf1</i>."
+    is_a: TurbineGovernorDynamics
+    description: Gas turbine.
+  GovGAST3:
+    class_uri: cim:GovGAST3
+    attributes:
+      bp:
+        slot_uri: cim:GovGAST3.bp
+        range: PU
+        multivalued: false
+        required: true
+        description: Droop (<i>bp</i>).  Typical value = 0,05.
+      tg:
+        slot_uri: cim:GovGAST3.tg
+        range: Seconds
+        multivalued: false
+        required: true
+        description: Time constant of speed governor (<i>Tg</i>) (&gt;= 0).  Typical
+          value = 0,05.
+      rcmx:
+        slot_uri: cim:GovGAST3.rcmx
+        range: PU
+        multivalued: false
+        required: true
+        description: Maximum fuel flow (<i>RCMX</i>).  Typical value = 1.
+      rcmn:
+        slot_uri: cim:GovGAST3.rcmn
+        range: PU
+        multivalued: false
+        required: true
+        description: Minimum fuel flow (<i>RCMN</i>).  Typical value = -0,1.
+      ky:
+        slot_uri: cim:GovGAST3.ky
+        range: float
+        multivalued: false
+        required: true
+        description: Coefficient of transfer function of fuel valve positioner (<i>Ky</i>).  Typical
+          value = 1.
+      ty:
+        slot_uri: cim:GovGAST3.ty
+        range: Seconds
+        multivalued: false
+        required: true
+        description: Time constant of fuel valve positioner (<i>Ty</i>) (&gt;= 0).  Typical
+          value = 0,2.
+      tac:
+        slot_uri: cim:GovGAST3.tac
+        range: Seconds
+        multivalued: false
+        required: true
+        description: Fuel control time constant (<i>Tac</i>) (&gt;= 0).  Typical value
+          = 0,1.
+      kac:
+        slot_uri: cim:GovGAST3.kac
+        range: float
+        multivalued: false
+        required: true
+        description: Fuel system feedback (<i>K</i><i><sub>AC</sub></i>).  Typical
+          value = 0.
+      tc:
+        slot_uri: cim:GovGAST3.tc
+        range: Seconds
+        multivalued: false
+        required: true
+        description: Compressor discharge volume time constant (<i>Tc</i>) (&gt;=
+          0).  Typical value = 0,2.
+      bca:
+        slot_uri: cim:GovGAST3.bca
+        range: float
+        multivalued: false
+        required: true
+        description: Acceleration limit set-point (<i>Bca</i>).  Unit = 1/s.  Typical
+          value = 0,01.
+      kca:
+        slot_uri: cim:GovGAST3.kca
+        range: float
+        multivalued: false
+        required: true
+        description: Acceleration control integral gain (<i>Kca</i>). Unit = 1/s.  Typical
+          value = 100.
+      dtc:
+        slot_uri: cim:GovGAST3.dtc
+        range: Temperature
+        multivalued: false
+        required: true
+        description: Exhaust temperature variation due to fuel flow increasing from
+          0 to 1 PU (<i>deltaTc</i>).  Typical value = 390.
+      ka:
+        slot_uri: cim:GovGAST3.ka
+        range: PU
+        multivalued: false
+        required: true
+        description: Minimum fuel flow (<i>Ka</i>).  Typical value = 0,23.
+      tsi:
+        slot_uri: cim:GovGAST3.tsi
+        range: Seconds
+        multivalued: false
+        required: true
+        description: Time constant of radiation shield (<i>Tsi</i>) (&gt;= 0).  Typical
+          value = 15.
+      ksi:
+        slot_uri: cim:GovGAST3.ksi
+        range: float
+        multivalued: false
+        required: true
+        description: Gain of radiation shield (<i>Ksi</i>).  Typical value = 0,8.
+      ttc:
+        slot_uri: cim:GovGAST3.ttc
+        range: Seconds
+        multivalued: false
+        required: true
+        description: Time constant of thermocouple (<i>Ttc</i>) (&gt;= 0).  Typical
+          value = 2,5.
+      tfen:
+        slot_uri: cim:GovGAST3.tfen
+        range: Temperature
+        multivalued: false
+        required: true
+        description: Turbine rated exhaust temperature correspondent to Pm=1 PU (<i>Tfen</i>).  Typical
+          value = 540.
+      td:
+        slot_uri: cim:GovGAST3.td
+        range: Seconds
+        multivalued: false
+        required: true
+        description: Temperature controller derivative gain (<i>Td</i>) (&gt;= 0).  Typical
+          value = 3,3.
+      tt:
+        slot_uri: cim:GovGAST3.tt
+        range: Temperature
+        multivalued: false
+        required: true
+        description: Temperature controller integration rate (<i>Tt</i>).  Typical
+          value = 250.
+      mxef:
+        slot_uri: cim:GovGAST3.mxef
+        range: PU
+        multivalued: false
+        required: true
+        description: Fuel flow maximum positive error value (<i>MXef</i>).  Typical
+          value = 0,05.
+      mnef:
+        slot_uri: cim:GovGAST3.mnef
+        range: PU
+        multivalued: false
+        required: true
+        description: Fuel flow maximum negative error value (<i>MNef</i>).  Typical
+          value = -0,05.
+    is_a: TurbineGovernorDynamics
+    description: Generic turbogas with acceleration and temperature controller.
+  GovGAST4:
+    class_uri: cim:GovGAST4
+    attributes:
+      bp:
+        slot_uri: cim:GovGAST4.bp
+        range: PU
+        multivalued: false
+        required: true
+        description: Droop (<i>b</i><i><sub>p</sub></i>).  Typical value = 0,05.
+      ty:
+        slot_uri: cim:GovGAST4.ty
+        range: Seconds
+        multivalued: false
+        required: true
+        description: Time constant of fuel valve positioner (<i>Ty</i>) (&gt;= 0).  Typical
+          value = 0,1.
+      ta:
+        slot_uri: cim:GovGAST4.ta
+        range: Seconds
+        multivalued: false
+        required: true
+        description: Maximum gate opening velocity (<i>TA</i>) (&gt;= 0).  Typical
+          value = 3.
+      tc:
+        slot_uri: cim:GovGAST4.tc
+        range: Seconds
+        multivalued: false
+        required: true
+        description: Maximum gate closing velocity (<i>TC</i>) (&gt;= 0).  Typical
+          value = 0,5.
+      tcm:
+        slot_uri: cim:GovGAST4.tcm
+        range: Seconds
+        multivalued: false
+        required: true
+        description: Fuel control time constant (<i>Tcm</i>) (&gt;= 0).  Typical value
+          = 0,1.
+      ktm:
+        slot_uri: cim:GovGAST4.ktm
+        range: PU
+        multivalued: false
+        required: true
+        description: Compressor gain (<i>Ktm</i>).  Typical value = 0.
+      tm:
+        slot_uri: cim:GovGAST4.tm
+        range: Seconds
+        multivalued: false
+        required: true
+        description: Compressor discharge volume time constant (<i>Tm</i>) (&gt;=
+          0).  Typical value = 0,2.
+      rymx:
+        slot_uri: cim:GovGAST4.rymx
+        range: PU
+        multivalued: false
+        required: true
+        description: Maximum valve opening (<i>RYMX</i>).  Typical value = 1,1.
+      rymn:
+        slot_uri: cim:GovGAST4.rymn
+        range: PU
+        multivalued: false
+        required: true
+        description: Minimum valve opening (<i>RYMN</i>).  Typical value = 0.
+      mxef:
+        slot_uri: cim:GovGAST4.mxef
+        range: PU
+        multivalued: false
+        required: true
+        description: Fuel flow maximum positive error value (<i>MXef</i>).  Typical
+          value = 0,05.
+      mnef:
+        slot_uri: cim:GovGAST4.mnef
+        range: PU
+        multivalued: false
+        required: true
+        description: Fuel flow maximum negative error value (<i>MNef</i>).  Typical
+          value = -0,05.
+    is_a: TurbineGovernorDynamics
+    description: Generic turbogas.
+  GovGASTWD:
+    class_uri: cim:GovGASTWD
+    attributes:
+      mwbase:
+        slot_uri: cim:GovGASTWD.mwbase
+        range: ActivePower
+        multivalued: false
+        required: true
+        description: Base for power values (<i>MWbase</i>) (&gt; 0).  Unit = MW.
+      kdroop:
+        slot_uri: cim:GovGASTWD.kdroop
+        range: PU
+        multivalued: false
+        required: true
+        description: (<i>Kdroop</i>) (&gt;= 0).
+      kp:
+        slot_uri: cim:GovGASTWD.kp
+        range: PU
+        multivalued: false
+        required: true
+        description: PID proportional gain (<i>Kp</i>).
+      ki:
+        slot_uri: cim:GovGASTWD.ki
+        range: PU
+        multivalued: false
+        required: true
+        description: Isochronous Governor Gain (<i>Ki</i>).
+      kd:
+        slot_uri: cim:GovGASTWD.kd
+        range: PU
+        multivalued: false
+        required: true
+        description: Drop governor gain (<i>Kd</i>).
+      etd:
+        slot_uri: cim:GovGASTWD.etd
+        range: Seconds
+        multivalued: false
+        required: true
+        description: Turbine and exhaust delay (<i>Etd</i>) (&gt;= 0).
+      tcd:
+        slot_uri: cim:GovGASTWD.tcd
+        range: Seconds
+        multivalued: false
+        required: true
+        description: Compressor discharge time constant (<i>Tcd</i>) (&gt;= 0).
+      trate:
+        slot_uri: cim:GovGASTWD.trate
+        range: ActivePower
+        multivalued: false
+        required: true
+        description: Turbine rating (<i>Trate</i>).  Unit = MW.
+      t:
+        slot_uri: cim:GovGASTWD.t
+        range: Seconds
+        multivalued: false
+        required: true
+        description: Fuel control time constant (<i>T</i>) (&gt;= 0).
+      tmax:
+        slot_uri: cim:GovGASTWD.tmax
+        range: PU
+        multivalued: false
+        required: true
+        description: Maximum Turbine limit (<i>Tmax</i>) (&gt; GovGASTWD.tmin).
+      tmin:
+        slot_uri: cim:GovGASTWD.tmin
+        range: PU
+        multivalued: false
+        required: true
+        description: Minimum turbine limit (<i>Tmin</i>) (&lt; GovGASTWD.tmax).
+      ecr:
+        slot_uri: cim:GovGASTWD.ecr
+        range: Seconds
+        multivalued: false
+        required: true
+        description: Combustion reaction time delay (<i>Ecr</i>) (&gt;= 0).
+      k3:
+        slot_uri: cim:GovGASTWD.k3
+        range: PU
+        multivalued: false
+        required: true
+        description: Ratio of fuel adjustment (<i>K3</i>).
+      a:
+        slot_uri: cim:GovGASTWD.a
+        range: float
+        multivalued: false
+        required: true
+        description: Valve positioner (<i>A</i>).
+      b:
+        slot_uri: cim:GovGASTWD.b
+        range: float
+        multivalued: false
+        required: true
+        description: Valve positioner (<i>B</i>).
+      c:
+        slot_uri: cim:GovGASTWD.c
+        range: float
+        multivalued: false
+        required: true
+        description: Valve positioner (<i>C</i>).
+      tf:
+        slot_uri: cim:GovGASTWD.tf
+        range: Seconds
+        multivalued: false
+        required: true
+        description: Fuel system time constant (<i>Tf</i>) (&gt;= 0).
+      kf:
+        slot_uri: cim:GovGASTWD.kf
+        range: PU
+        multivalued: false
+        required: true
+        description: Fuel system feedback (<i>Kf</i>).
+      k5:
+        slot_uri: cim:GovGASTWD.k5
+        range: PU
+        multivalued: false
+        required: true
+        description: Gain of radiation shield (<i>K5</i>).
+      k4:
+        slot_uri: cim:GovGASTWD.k4
+        range: PU
+        multivalued: false
+        required: true
+        description: Gain of radiation shield (<i>K4</i>).
+      t3:
+        slot_uri: cim:GovGASTWD.t3
+        range: Seconds
+        multivalued: false
+        required: true
+        description: Radiation shield time constant (<i>T3</i>) (&gt;= 0).
+      t4:
+        slot_uri: cim:GovGASTWD.t4
+        range: Seconds
+        multivalued: false
+        required: true
+        description: Thermocouple time constant (<i>T4</i>) (&gt;= 0).
+      tt:
+        slot_uri: cim:GovGASTWD.tt
+        range: Seconds
+        multivalued: false
+        required: true
+        description: Temperature controller integration rate (<i>Tt</i>) (&gt;= 0).
+      t5:
+        slot_uri: cim:GovGASTWD.t5
+        range: Seconds
+        multivalued: false
+        required: true
+        description: Temperature control time constant (<i>T5</i>) (&gt;= 0).
+      af1:
+        slot_uri: cim:GovGASTWD.af1
+        range: PU
+        multivalued: false
+        required: true
+        description: Exhaust temperature parameter (<i>Af1</i>).
+      bf1:
+        slot_uri: cim:GovGASTWD.bf1
+        range: PU
+        multivalued: false
+        required: true
+        description: (<i>Bf1</i>).  <i>Bf1</i> = <i>E</i>(1-<i>w</i>) where <i>E</i>
+          (speed sensitivity coefficient) is 0,55 to 0,65 x <i>Tr</i>.
+      af2:
+        slot_uri: cim:GovGASTWD.af2
+        range: PU
+        multivalued: false
+        required: true
+        description: Coefficient equal to 0,5(1-speed) (<i>Af2</i>).
+      bf2:
+        slot_uri: cim:GovGASTWD.bf2
+        range: PU
+        multivalued: false
+        required: true
+        description: Turbine torque coefficient K<sub>hhv</sub> (depends on heating
+          value of fuel stream in combustion chamber) (<i>Bf2</i>).
+      cf2:
+        slot_uri: cim:GovGASTWD.cf2
+        range: PU
+        multivalued: false
+        required: true
+        description: Coefficient defining fuel flow where power output is 0 % (<i>Cf2</i>).  Synchronous
+          but no output.  Typically 0,23 x K<sub>hhv </sub>(23 % fuel flow).
+      tr:
+        slot_uri: cim:GovGASTWD.tr
+        range: Temperature
+        multivalued: false
+        required: true
+        description: Rated temperature (<i>Tr</i>).
+      k6:
+        slot_uri: cim:GovGASTWD.k6
+        range: PU
+        multivalued: false
+        required: true
+        description: Minimum fuel flow (<i>K6</i>).
+      tc:
+        slot_uri: cim:GovGASTWD.tc
+        range: Temperature
+        multivalued: false
+        required: true
+        description: Temperature control (<i>Tc</i>).
+      td:
+        slot_uri: cim:GovGASTWD.td
+        range: Seconds
+        multivalued: false
+        required: true
+        description: Power transducer time constant (<i>Td</i>) (&gt;= 0).
+    is_a: TurbineGovernorDynamics
+    description: "Woodward\u2122 gas turbine governor. \n[Footnote: Woodward gas turbines\
+      \ are an example of suitable products available commercially. This information\
+      \ is given for the convenience of users of this document and does not constitute\
+      \ an endorsement by IEC of these products.]"
+  GovHydro1:
+    class_uri: cim:GovHydro1
+    attributes:
+      mwbase:
+        slot_uri: cim:GovHydro1.mwbase
+        range: ActivePower
+        multivalued: false
+        required: true
+        description: Base for power values (<i>MWbase</i>) (&gt; 0).  Unit = MW.
+      rperm:
+        slot_uri: cim:GovHydro1.rperm
+        range: PU
+        multivalued: false
+        required: true
+        description: Permanent droop (<i>R</i>) (&gt; 0).  Typical value = 0,04.
+      rtemp:
+        slot_uri: cim:GovHydro1.rtemp
+        range: PU
+        multivalued: false
+        required: true
+        description: Temporary droop (<i>r</i>) (&gt; GovHydro1.rperm).  Typical value
+          = 0,3.
+      tr:
+        slot_uri: cim:GovHydro1.tr
+        range: Seconds
+        multivalued: false
+        required: true
+        description: Washout time constant (<i>Tr</i>) (&gt; 0).  Typical value =
+          5.
+      tf:
+        slot_uri: cim:GovHydro1.tf
+        range: Seconds
+        multivalued: false
+        required: true
+        description: Filter time constant (<i>Tf</i>) (&gt; 0).  Typical value = 0,05.
+      tg:
+        slot_uri: cim:GovHydro1.tg
+        range: Seconds
+        multivalued: false
+        required: true
+        description: Gate servo time constant (<i>Tg</i>) (&gt; 0).  Typical value
+          = 0,5.
+      velm:
+        slot_uri: cim:GovHydro1.velm
+        range: float
+        multivalued: false
+        required: true
+        description: Maximum gate velocity (<i>Vlem</i>) (&gt; 0).  Typical value
+          = 0,2.
+      gmax:
+        slot_uri: cim:GovHydro1.gmax
+        range: PU
+        multivalued: false
+        required: true
+        description: Maximum gate opening (<i>Gmax</i>) (&gt; 0 and &gt; GovHydro.gmin).  Typical
+          value = 1.
+      gmin:
+        slot_uri: cim:GovHydro1.gmin
+        range: PU
+        multivalued: false
+        required: true
+        description: Minimum gate opening (<i>Gmin</i>) (&gt;= 0 and &lt; GovHydro1.gmax).  Typical
+          value = 0.
+      tw:
+        slot_uri: cim:GovHydro1.tw
+        range: Seconds
+        multivalued: false
+        required: true
+        description: Water inertia time constant (<i>Tw</i>) (&gt; 0).  Typical value
+          = 1.
+      at:
+        slot_uri: cim:GovHydro1.at
+        range: PU
+        multivalued: false
+        required: true
+        description: Turbine gain (<i>At</i>) (&gt; 0).  Typical value = 1,2.
+      dturb:
+        slot_uri: cim:GovHydro1.dturb
+        range: PU
+        multivalued: false
+        required: true
+        description: Turbine damping factor (<i>Dturb</i>) (&gt;= 0).  Typical value
+          = 0,5.
+      qnl:
+        slot_uri: cim:GovHydro1.qnl
+        range: PU
+        multivalued: false
+        required: true
+        description: No-load flow at nominal head (<i>qnl</i>) (&gt;= 0).  Typical
+          value = 0,08.
+      hdam:
+        slot_uri: cim:GovHydro1.hdam
+        range: PU
+        multivalued: false
+        required: true
+        description: Turbine nominal head (<i>hdam</i>).  Typical value = 1.
+    is_a: TurbineGovernorDynamics
+    description: Basic hydro turbine governor.
+  GovHydro2:
+    class_uri: cim:GovHydro2
+    attributes:
+      mwbase:
+        slot_uri: cim:GovHydro2.mwbase
+        range: ActivePower
+        multivalued: false
+        required: true
+        description: Base for power values (<i>MWbase</i>) (&gt; 0).  Unit = MW.
+      tg:
+        slot_uri: cim:GovHydro2.tg
+        range: Seconds
+        multivalued: false
+        required: true
+        description: Gate servo time constant (<i>Tg</i>) (&gt; 0).  Typical value
+          = 0,5.
+      tp:
+        slot_uri: cim:GovHydro2.tp
+        range: Seconds
+        multivalued: false
+        required: true
+        description: Pilot servo valve time constant (<i>Tp</i>) (&gt;= 0).  Typical
+          value = 0,03.
+      uo:
+        slot_uri: cim:GovHydro2.uo
+        range: float
+        multivalued: false
+        required: true
+        description: Maximum gate opening velocity (<i>Uo</i>).  Unit = PU / s.  Typical
+          value = 0,1.
+      uc:
+        slot_uri: cim:GovHydro2.uc
+        range: float
+        multivalued: false
+        required: true
+        description: Maximum gate closing velocity (<i>Uc</i>) (&lt; 0).  Unit = PU
+          / s.   Typical value = -0,1.
+      pmax:
+        slot_uri: cim:GovHydro2.pmax
+        range: PU
+        multivalued: false
+        required: true
+        description: Maximum gate opening (<i>Pmax</i>) (&gt; GovHydro2.pmin).  Typical
+          value = 1.
+      pmin:
+        slot_uri: cim:GovHydro2.pmin
+        range: PU
+        multivalued: false
+        required: true
+        description: Minimum gate opening (<i>Pmin</i>) (&lt; GovHydro2.pmax).  Typical
+          value = 0.
+      rperm:
+        slot_uri: cim:GovHydro2.rperm
+        range: PU
+        multivalued: false
+        required: true
+        description: Permanent droop (<i>Rperm</i>).  Typical value = 0,05.
+      rtemp:
+        slot_uri: cim:GovHydro2.rtemp
+        range: PU
+        multivalued: false
+        required: true
+        description: Temporary droop (<i>Rtemp</i>).  Typical value = 0,5.
+      tr:
+        slot_uri: cim:GovHydro2.tr
+        range: Seconds
+        multivalued: false
+        required: true
+        description: Dashpot time constant (<i>Tr</i>) (&gt;= 0).  Typical value =
+          12.
+      tw:
+        slot_uri: cim:GovHydro2.tw
+        range: Seconds
+        multivalued: false
+        required: true
+        description: Water inertia time constant (<i>Tw</i>) (&gt;= 0).  Typical value
+          = 2.
+      kturb:
+        slot_uri: cim:GovHydro2.kturb
+        range: PU
+        multivalued: false
+        required: true
+        description: Turbine gain (<i>Kturb</i>).  Typical value = 1.
+      aturb:
+        slot_uri: cim:GovHydro2.aturb
+        range: PU
+        multivalued: false
+        required: true
+        description: Turbine numerator multiplier (<i>Aturb</i>).  Typical value =
+          -1.
+      bturb:
+        slot_uri: cim:GovHydro2.bturb
+        range: PU
+        multivalued: false
+        required: true
+        description: Turbine denominator multiplier (<i>Bturb</i>) (&gt; 0).  Typical
+          value = 0,5.
+      db1:
+        slot_uri: cim:GovHydro2.db1
+        range: Frequency
+        multivalued: false
+        required: true
+        description: Intentional deadband width (<i>db1</i>).  Unit = Hz.  Typical
+          value = 0.
+      eps:
+        slot_uri: cim:GovHydro2.eps
+        range: Frequency
+        multivalued: false
+        required: true
+        description: Intentional db hysteresis (<i>eps</i>).  Unit = Hz.  Typical
+          value = 0.
+      db2:
+        slot_uri: cim:GovHydro2.db2
+        range: ActivePower
+        multivalued: false
+        required: true
+        description: Unintentional deadband (<i>db2</i>).  Unit = MW.  Typical value
+          = 0.
+      gv1:
+        slot_uri: cim:GovHydro2.gv1
+        range: PU
+        multivalued: false
+        required: true
+        description: Nonlinear gain point 1, PU gv (<i>Gv1</i>).  Typical value =
+          0.
+      pgv1:
+        slot_uri: cim:GovHydro2.pgv1
+        range: PU
+        multivalued: false
+        required: true
+        description: Nonlinear gain point 1, PU power (<i>Pgv1</i>).  Typical value
+          = 0.
+      gv2:
+        slot_uri: cim:GovHydro2.gv2
+        range: PU
+        multivalued: false
+        required: true
+        description: Nonlinear gain point 2, PU gv (<i>Gv2</i>).  Typical value =
+          0.
+      pgv2:
+        slot_uri: cim:GovHydro2.pgv2
+        range: PU
+        multivalued: false
+        required: true
+        description: Nonlinear gain point 2, PU power (<i>Pgv2</i>).  Typical value
+          = 0.
+      gv3:
+        slot_uri: cim:GovHydro2.gv3
+        range: PU
+        multivalued: false
+        required: true
+        description: Nonlinear gain point 3, PU gv (<i>Gv3</i>).  Typical value =
+          0.
+      pgv3:
+        slot_uri: cim:GovHydro2.pgv3
+        range: PU
+        multivalued: false
+        required: true
+        description: Nonlinear gain point 3, PU power (<i>Pgv3</i>).  Typical value
+          = 0.
+      gv4:
+        slot_uri: cim:GovHydro2.gv4
+        range: PU
+        multivalued: false
+        required: true
+        description: Nonlinear gain point 4, PU gv (<i>Gv4</i>).  Typical value =
+          0.
+      pgv4:
+        slot_uri: cim:GovHydro2.pgv4
+        range: PU
+        multivalued: false
+        required: true
+        description: Nonlinear gain point 4, PU power (P<i>gv4</i>).  Typical value
+          = 0.
+      gv5:
+        slot_uri: cim:GovHydro2.gv5
+        range: PU
+        multivalued: false
+        required: true
+        description: Nonlinear gain point 5, PU gv (<i>Gv5</i>).  Typical value =
+          0.
+      pgv5:
+        slot_uri: cim:GovHydro2.pgv5
+        range: PU
+        multivalued: false
+        required: true
+        description: Nonlinear gain point 5, PU power (<i>Pgv5</i>).  Typical value
+          = 0.
+      gv6:
+        slot_uri: cim:GovHydro2.gv6
+        range: PU
+        multivalued: false
+        required: true
+        description: Nonlinear gain point 6, PU gv (<i>Gv6</i>).  Typical value =
+          0.
+      pgv6:
+        slot_uri: cim:GovHydro2.pgv6
+        range: PU
+        multivalued: false
+        required: true
+        description: Nonlinear gain point 6, PU power (<i>Pgv6</i>).  Typical value
+          = 0.
+    is_a: TurbineGovernorDynamics
+    description: IEEE hydro turbine governor with straightforward penstock configuration
+      and hydraulic-dashpot governor.
+  GovHydro3:
+    class_uri: cim:GovHydro3
+    attributes:
+      mwbase:
+        slot_uri: cim:GovHydro3.mwbase
+        range: ActivePower
+        multivalued: false
+        required: true
+        description: Base for power values (<i>MWbase</i>) (&gt; 0).  Unit = MW.
+      pmax:
+        slot_uri: cim:GovHydro3.pmax
+        range: PU
+        multivalued: false
+        required: true
+        description: Maximum gate opening, PU of MWbase (<i>Pmax</i>) (&gt; GovHydro3.pmin).  Typical
+          value = 1.
+      pmin:
+        slot_uri: cim:GovHydro3.pmin
+        range: PU
+        multivalued: false
+        required: true
+        description: Minimum gate opening, PU of <i>MWbase</i> (<i>Pmin</i>) (&lt;
+          GovHydro3.pmax).  Typical value = 0.
+      governorControl:
+        slot_uri: cim:GovHydro3.governorControl
+        range: boolean
+        multivalued: false
+        required: true
+        description: 'Governor control flag (<i>Cflag</i>).
+
+          true = PID control is active
+
+          false = double derivative control is active.
+
+          Typical value = true.'
+      rgate:
+        slot_uri: cim:GovHydro3.rgate
+        range: PU
+        multivalued: false
+        required: true
+        description: Steady-state droop, PU, for governor output feedback (<i>Rgate</i>).  Typical
+          value = 0.
+      relec:
+        slot_uri: cim:GovHydro3.relec
+        range: PU
+        multivalued: false
+        required: true
+        description: Steady-state droop, PU, for electrical power feedback (<i>Relec</i>).  Typical
+          value = 0,05.
+      td:
+        slot_uri: cim:GovHydro3.td
+        range: Seconds
+        multivalued: false
+        required: true
+        description: Input filter time constant (<i>Td</i>) (&gt;= 0).  Typical value
+          = 0,05.
+      tf:
+        slot_uri: cim:GovHydro3.tf
+        range: Seconds
+        multivalued: false
+        required: true
+        description: Washout time constant (<i>Tf</i>) (&gt;= 0).  Typical value =
+          0,1.
+      tp:
+        slot_uri: cim:GovHydro3.tp
+        range: Seconds
+        multivalued: false
+        required: true
+        description: Gate servo time constant (<i>Tp</i>) (&gt;= 0).  Typical value
+          = 0,05.
+      velop:
+        slot_uri: cim:GovHydro3.velop
+        range: float
+        multivalued: false
+        required: true
+        description: Maximum gate opening velocity (<i>Velop</i>).  Unit = PU / s.
+          Typical value = 0,2.
+      velcl:
+        slot_uri: cim:GovHydro3.velcl
+        range: float
+        multivalued: false
+        required: true
+        description: Maximum gate closing velocity (<i>Velcl</i>).  Unit = PU / s.  Typical
+          value = -0,2.
+      k1:
+        slot_uri: cim:GovHydro3.k1
+        range: PU
+        multivalued: false
+        required: true
+        description: Derivative gain (<i>K1</i>).  Typical value = 0,01.
+      k2:
+        slot_uri: cim:GovHydro3.k2
+        range: PU
+        multivalued: false
+        required: true
+        description: Double derivative gain, if <i>Cflag</i> = -1 (<i>K2</i>).  Typical
+          value = 2,5.
+      ki:
+        slot_uri: cim:GovHydro3.ki
+        range: PU
+        multivalued: false
+        required: true
+        description: Integral gain (<i>Ki</i>).  Typical value = 0,5.
+      kg:
+        slot_uri: cim:GovHydro3.kg
+        range: PU
+        multivalued: false
+        required: true
+        description: Gate servo gain (<i>Kg</i>).  Typical value = 2.
+      tt:
+        slot_uri: cim:GovHydro3.tt
+        range: Seconds
+        multivalued: false
+        required: true
+        description: Power feedback time constant (<i>Tt</i>) (&gt;= 0).  Typical
+          value = 0,2.
+      db1:
+        slot_uri: cim:GovHydro3.db1
+        range: Frequency
+        multivalued: false
+        required: true
+        description: Intentional dead-band width (<i>db1</i>).  Unit = Hz.  Typical
+          value = 0.
+      eps:
+        slot_uri: cim:GovHydro3.eps
+        range: Frequency
+        multivalued: false
+        required: true
+        description: Intentional db hysteresis (<i>eps</i>).  Unit = Hz.  Typical
+          value = 0.
+      db2:
+        slot_uri: cim:GovHydro3.db2
+        range: ActivePower
+        multivalued: false
+        required: true
+        description: Unintentional dead-band (<i>db2</i>).  Unit = MW.  Typical value
+          = 0.
+      tw:
+        slot_uri: cim:GovHydro3.tw
+        range: Seconds
+        multivalued: false
+        required: true
+        description: Water inertia time constant (<i>Tw</i>) (&gt;= 0).  If = 0, block
+          is bypassed.  Typical value = 1.
+      at:
+        slot_uri: cim:GovHydro3.at
+        range: PU
+        multivalued: false
+        required: true
+        description: Turbine gain (<i>At</i>) (&gt;0).  Typical value = 1,2.
+      dturb:
+        slot_uri: cim:GovHydro3.dturb
+        range: PU
+        multivalued: false
+        required: true
+        description: Turbine damping factor (<i>Dturb</i>).  Typical value = 0,2.
+      qnl:
+        slot_uri: cim:GovHydro3.qnl
+        range: PU
+        multivalued: false
+        required: true
+        description: No-load turbine flow at nominal head (<i>Qnl</i>).  Typical value
+          = 0,08.
+      h0:
+        slot_uri: cim:GovHydro3.h0
+        range: PU
+        multivalued: false
+        required: true
+        description: Turbine nominal head (<i>H0</i>).  Typical value = 1.
+      gv1:
+        slot_uri: cim:GovHydro3.gv1
+        range: PU
+        multivalued: false
+        required: true
+        description: Nonlinear gain point 1, PU gv (<i>Gv1</i>).  Typical value =
+          0.
+      pgv1:
+        slot_uri: cim:GovHydro3.pgv1
+        range: PU
+        multivalued: false
+        required: true
+        description: Nonlinear gain point 1, PU power (<i>Pgv1</i>).  Typical value
+          = 0.
+      gv2:
+        slot_uri: cim:GovHydro3.gv2
+        range: PU
+        multivalued: false
+        required: true
+        description: Nonlinear gain point 2, PU gv (<i>Gv2</i>).  Typical value =
+          0.
+      pgv2:
+        slot_uri: cim:GovHydro3.pgv2
+        range: PU
+        multivalued: false
+        required: true
+        description: Nonlinear gain point 2, PU power (<i>Pgv2</i>).  Typical value
+          = 0.
+      gv3:
+        slot_uri: cim:GovHydro3.gv3
+        range: PU
+        multivalued: false
+        required: true
+        description: Nonlinear gain point 3, PU gv (<i>Gv3</i>).  Typical value =
+          0.
+      pgv3:
+        slot_uri: cim:GovHydro3.pgv3
+        range: PU
+        multivalued: false
+        required: true
+        description: Nonlinear gain point 3, PU power (<i>Pgv3</i>).  Typical value
+          = 0.
+      gv4:
+        slot_uri: cim:GovHydro3.gv4
+        range: PU
+        multivalued: false
+        required: true
+        description: Nonlinear gain point 4, PU gv (<i>Gv4</i>).  Typical value =
+          0.
+      pgv4:
+        slot_uri: cim:GovHydro3.pgv4
+        range: PU
+        multivalued: false
+        required: true
+        description: Nonlinear gain point 4, PU power (<i>Pgv4</i>).  Typical value
+          = 0.
+      gv5:
+        slot_uri: cim:GovHydro3.gv5
+        range: PU
+        multivalued: false
+        required: true
+        description: Nonlinear gain point 5, PU gv (<i>Gv5</i>).  Typical value =
+          0.
+      pgv5:
+        slot_uri: cim:GovHydro3.pgv5
+        range: PU
+        multivalued: false
+        required: true
+        description: Nonlinear gain point 5, PU power (<i>Pgv5</i>).  Typical value
+          = 0.
+      gv6:
+        slot_uri: cim:GovHydro3.gv6
+        range: PU
+        multivalued: false
+        required: true
+        description: Nonlinear gain point 6, PU gv (<i>Gv6</i>).  Typical value =
+          0.
+      pgv6:
+        slot_uri: cim:GovHydro3.pgv6
+        range: PU
+        multivalued: false
+        required: true
+        description: Nonlinear gain point 6, PU power (<i>Pgv6</i>).  Typical value
+          = 0.
+    is_a: TurbineGovernorDynamics
+    description: Modified IEEE hydro governor-turbine. This model differs from that
+      defined in the IEEE modelling guideline paper in that the limits on gate position
+      and velocity do not permit "wind up" of the upstream signals.
+  GovHydro4:
+    class_uri: cim:GovHydro4
+    attributes:
+      mwbase:
+        slot_uri: cim:GovHydro4.mwbase
+        range: ActivePower
+        multivalued: false
+        required: true
+        description: Base for power values (<i>MWbase</i>) (&gt; 0).  Unit = MW.
+      tg:
+        slot_uri: cim:GovHydro4.tg
+        range: Seconds
+        multivalued: false
+        required: true
+        description: Gate servo time constant (<i>Tg</i>) (&gt; 0).  Typical value
+          = 0,5.
+      tp:
+        slot_uri: cim:GovHydro4.tp
+        range: Seconds
+        multivalued: false
+        required: true
+        description: Pilot servo time constant (<i>Tp</i>) (&gt;= 0).  Typical value
+          = 0,1.
+      uo:
+        slot_uri: cim:GovHydro4.uo
+        range: float
+        multivalued: false
+        required: true
+        description: Max gate opening velocity (<i>Uo</i>).  Typical value = 0,2.
+      uc:
+        slot_uri: cim:GovHydro4.uc
+        range: float
+        multivalued: false
+        required: true
+        description: Max gate closing velocity (<i>Uc</i>).  Typical value = 0,2.
+      gmax:
+        slot_uri: cim:GovHydro4.gmax
+        range: PU
+        multivalued: false
+        required: true
+        description: Maximum gate opening, PU of <i>MWbase</i> (<i>Gmax</i>) (&gt;
+          GovHydro4.gmin).  Typical value = 1.
+      gmin:
+        slot_uri: cim:GovHydro4.gmin
+        range: PU
+        multivalued: false
+        required: true
+        description: Minimum gate opening, PU of <i>MWbase</i> (<i>Gmin</i>) (&lt;
+          GovHydro4.gmax).  Typical value = 0.
+      rperm:
+        slot_uri: cim:GovHydro4.rperm
+        range: Seconds
+        multivalued: false
+        required: true
+        description: Permanent droop (<i>Rperm</i>) (&gt;= 0).  Typical value = 0,05.
+      rtemp:
+        slot_uri: cim:GovHydro4.rtemp
+        range: Seconds
+        multivalued: false
+        required: true
+        description: Temporary droop (<i>Rtemp</i>) (&gt;= 0).  Typical value = 0,3.
+      tr:
+        slot_uri: cim:GovHydro4.tr
+        range: Seconds
+        multivalued: false
+        required: true
+        description: Dashpot time constant (<i>Tr</i>) (&gt;= 0).  Typical value =
+          5.
+      tw:
+        slot_uri: cim:GovHydro4.tw
+        range: Seconds
+        multivalued: false
+        required: true
+        description: Water inertia time constant (<i>Tw</i>) (&gt; 0).  Typical value
+          = 1.
+      at:
+        slot_uri: cim:GovHydro4.at
+        range: PU
+        multivalued: false
+        required: true
+        description: Turbine gain (<i>At</i>).  Typical value = 1,2.
+      dturb:
+        slot_uri: cim:GovHydro4.dturb
+        range: PU
+        multivalued: false
+        required: true
+        description: Turbine damping factor (<i>Dturb</i>).  Unit = delta P (PU of
+          <i>MWbase</i>) / delta speed (PU).  Typical value for simple = 0,5, Francis/Pelton
+          = 1,1, Kaplan = 1,1.
+      hdam:
+        slot_uri: cim:GovHydro4.hdam
+        range: PU
+        multivalued: false
+        required: true
+        description: Head available at dam (<i>hdam</i>).  Typical value = 1.
+      qnl:
+        slot_uri: cim:GovHydro4.qnl
+        range: PU
+        multivalued: false
+        required: true
+        description: 'No-load flow at nominal head (<i>Qnl</i>).
+
+          Typical value for simple = 0,08, Francis/Pelton = 0, Kaplan = 0.'
+      db1:
+        slot_uri: cim:GovHydro4.db1
+        range: Frequency
+        multivalued: false
+        required: true
+        description: Intentional deadband width (<i>db1</i>).  Unit = Hz.  Typical
+          value = 0.
+      eps:
+        slot_uri: cim:GovHydro4.eps
+        range: Frequency
+        multivalued: false
+        required: true
+        description: Intentional db hysteresis (<i>eps</i>).  Unit = Hz.  Typical
+          value = 0.
+      db2:
+        slot_uri: cim:GovHydro4.db2
+        range: ActivePower
+        multivalued: false
+        required: true
+        description: Unintentional dead-band (<i>db2</i>).  Unit = MW.  Typical value
+          = 0.
+      gv0:
+        slot_uri: cim:GovHydro4.gv0
+        range: PU
+        multivalued: false
+        required: true
+        description: Nonlinear gain point 0, PU gv (<i>Gv0</i>) (= 0 for simple).  Typical
+          for Francis/Pelton = 0,1, Kaplan = 0,1.
+      pgv0:
+        slot_uri: cim:GovHydro4.pgv0
+        range: PU
+        multivalued: false
+        required: true
+        description: Nonlinear gain point 0, PU power (<i>Pgv0</i>) (= 0 for simple).  Typical
+          value = 0.
+      gv1:
+        slot_uri: cim:GovHydro4.gv1
+        range: PU
+        multivalued: false
+        required: true
+        description: Nonlinear gain point 1, PU gv (<i>Gv1</i>) (= 0 for simple, &gt;
+          GovHydro4.gv0 for Francis/Pelton and Kaplan). Typical value for Francis/Pelton
+          = 0,4, Kaplan = 0,4.
+      pgv1:
+        slot_uri: cim:GovHydro4.pgv1
+        range: PU
+        multivalued: false
+        required: true
+        description: 'Nonlinear gain point 1, PU power (<i>Pgv1</i>) (= 0 for simple).
+
+          Typical value for Francis/Pelton = 0,42, Kaplan = 0,35.'
+      gv2:
+        slot_uri: cim:GovHydro4.gv2
+        range: PU
+        multivalued: false
+        required: true
+        description: Nonlinear gain point 2, PU gv (<i>Gv2</i>) (= 0 for simple, &gt;
+          GovHydro4.gv1 for Francis/Pelton and Kaplan). Typical value for Francis/Pelton
+          = 0,5, Kaplan = 0,5.
+      pgv2:
+        slot_uri: cim:GovHydro4.pgv2
+        range: PU
+        multivalued: false
+        required: true
+        description: 'Nonlinear gain point 2, PU power (<i>Pgv2</i>) (= 0 for simple).
+
+          Typical value for Francis/Pelton = 0,56, Kaplan = 0,468.'
+      gv3:
+        slot_uri: cim:GovHydro4.gv3
+        range: PU
+        multivalued: false
+        required: true
+        description: Nonlinear gain point 3, PU gv (<i>Gv3</i>)  (= 0 for simple,
+          &gt; GovHydro4.gv2 for Francis/Pelton and Kaplan). Typical value for Francis/Pelton
+          = 0,7, Kaplan = 0,7.
+      pgv3:
+        slot_uri: cim:GovHydro4.pgv3
+        range: PU
+        multivalued: false
+        required: true
+        description: 'Nonlinear gain point 3, PU power (<i>Pgv3</i>) (= 0 for simple).
+
+          Typical value for Francis/Pelton = 0,8, Kaplan = 0,796.'
+      gv4:
+        slot_uri: cim:GovHydro4.gv4
+        range: PU
+        multivalued: false
+        required: true
+        description: Nonlinear gain point 4, PU gv (<i>Gv4</i>)  (= 0 for simple,
+          &gt; GovHydro4.gv3 for Francis/Pelton and Kaplan). Typical value for  Francis/Pelton
+          = 0,8, Kaplan = 0,8.
+      pgv4:
+        slot_uri: cim:GovHydro4.pgv4
+        range: PU
+        multivalued: false
+        required: true
+        description: 'Nonlinear gain point 4, PU power (<i>Pgv4</i>) (= 0 for simple).
+
+          Typical value for Francis/Pelton = 0,9, Kaplan = 0,917.'
+      gv5:
+        slot_uri: cim:GovHydro4.gv5
+        range: PU
+        multivalued: false
+        required: true
+        description: Nonlinear gain point 5, PU gv (<i>Gv5</i>)  (= 0 for simple,
+          &lt; 1 and &gt; GovHydro4.gv4 for Francis/Pelton and Kaplan). Typical value
+          for Francis/Pelton = 0,9, Kaplan = 0,9.
+      pgv5:
+        slot_uri: cim:GovHydro4.pgv5
+        range: PU
+        multivalued: false
+        required: true
+        description: "Nonlinear gain point 5, PU power (<i>Pgv5</i>) (= 0 for simple).\
+          \ \nTypical value for Francis/Pelton = 0,97, Kaplan = 0,99."
+      bgv0:
+        slot_uri: cim:GovHydro4.bgv0
+        range: PU
+        multivalued: false
+        required: true
+        description: Kaplan blade servo point 0 (<i>Bgv0</i>) (= 0 for simple, = 0
+          for Francis/Pelton).  Typical value for Kaplan = 0.
+      bgv1:
+        slot_uri: cim:GovHydro4.bgv1
+        range: PU
+        multivalued: false
+        required: true
+        description: Kaplan blade servo point 1 (<i>Bgv1</i>) (= 0 for simple, = 0
+          for Francis/Pelton).  Typical value for Kaplan = 0.
+      bgv2:
+        slot_uri: cim:GovHydro4.bgv2
+        range: PU
+        multivalued: false
+        required: true
+        description: Kaplan blade servo point 2 (<i>Bgv2</i>) (= 0 for simple, = 0
+          for Francis/Pelton).  Typical value for Kaplan = 0,1.
+      bgv3:
+        slot_uri: cim:GovHydro4.bgv3
+        range: PU
+        multivalued: false
+        required: true
+        description: Kaplan blade servo point 3 (<i>Bgv3</i>) (= 0 for simple, = 0
+          for Francis/Pelton).  Typical value for Kaplan = 0,667.
+      bgv4:
+        slot_uri: cim:GovHydro4.bgv4
+        range: PU
+        multivalued: false
+        required: true
+        description: Kaplan blade servo point 4 (<i>Bgv4</i>) (= 0 for simple, = 0
+          for Francis/Pelton).  Typical value for Kaplan = 0,9.
+      bgv5:
+        slot_uri: cim:GovHydro4.bgv5
+        range: PU
+        multivalued: false
+        required: true
+        description: Kaplan blade servo point 5 (<i>Bgv5</i>) (= 0 for simple, = 0
+          for Francis/Pelton).  Typical value for Kaplan = 1.
+      bmax:
+        slot_uri: cim:GovHydro4.bmax
+        range: float
+        multivalued: false
+        required: true
+        description: Maximum blade adjustment factor (<i>Bmax</i>)  (= 0 for simple,
+          = 0 for Francis/Pelton).  Typical value for Kaplan = 1,1276.
+      tblade:
+        slot_uri: cim:GovHydro4.tblade
+        range: Seconds
+        multivalued: false
+        required: true
+        description: Blade servo time constant (<i>Tblade</i>) (&gt;= 0).  Typical
+          value = 100.
+      model:
+        slot_uri: cim:GovHydro4.model
+        range: GovHydro4ModelKind
+        multivalued: false
+        required: true
+        description: The kind of model being represented (simple, Francis/Pelton or
+          Kaplan).
+    is_a: TurbineGovernorDynamics
+    description: Hydro turbine and governor. Represents plants with straight-forward
+      penstock configurations and hydraulic governors of the traditional 'dashpot'
+      type.  This model can be used to represent simple, Francis/Pelton or Kaplan
+      turbines.
+  GovHydroDD:
+    class_uri: cim:GovHydroDD
+    attributes:
+      mwbase:
+        slot_uri: cim:GovHydroDD.mwbase
+        range: ActivePower
+        multivalued: false
+        required: true
+        description: Base for power values (<i>MWbase</i>) (&gt;0).  Unit = MW.
+      pmax:
+        slot_uri: cim:GovHydroDD.pmax
+        range: PU
+        multivalued: false
+        required: true
+        description: Maximum gate opening, PU of <i>MWbase</i> (<i>Pmax</i>) (&gt;
+          GovHydroDD.pmin).  Typical value = 1.
+      pmin:
+        slot_uri: cim:GovHydroDD.pmin
+        range: PU
+        multivalued: false
+        required: true
+        description: Minimum gate opening, PU of <i>MWbase</i> (<i>Pmin</i>) (&gt;
+          GovHydroDD.pmax).  Typical value = 0.
+      r:
+        slot_uri: cim:GovHydroDD.r
+        range: PU
+        multivalued: false
+        required: true
+        description: Steady state droop (<i>R</i>).  Typical value = 0,05.
+      td:
+        slot_uri: cim:GovHydroDD.td
+        range: Seconds
+        multivalued: false
+        required: true
+        description: Input filter time constant (<i>Td</i>) (&gt;= 0).  If = 0, block
+          is bypassed.  Typical value = 0.
+      tf:
+        slot_uri: cim:GovHydroDD.tf
+        range: Seconds
+        multivalued: false
+        required: true
+        description: Washout time constant (<i>Tf</i>) (&gt;= 0).  Typical value =
+          0,1.
+      tp:
+        slot_uri: cim:GovHydroDD.tp
+        range: Seconds
+        multivalued: false
+        required: true
+        description: Gate servo time constant (<i>Tp</i>) (&gt;= 0).  If = 0, block
+          is bypassed.  Typical value = 0,35.
+      velop:
+        slot_uri: cim:GovHydroDD.velop
+        range: float
+        multivalued: false
+        required: true
+        description: Maximum gate opening velocity (<i>Velop</i>).  Unit = PU / s.  Typical
+          value = 0,09.
+      velcl:
+        slot_uri: cim:GovHydroDD.velcl
+        range: float
+        multivalued: false
+        required: true
+        description: Maximum gate closing velocity (<i>Velcl</i>).  Unit = PU / s.  Typical
+          value = -0,14.
+      k1:
+        slot_uri: cim:GovHydroDD.k1
+        range: PU
+        multivalued: false
+        required: true
+        description: Single derivative gain (<i>K1</i>).  Typical value = 3,6.
+      k2:
+        slot_uri: cim:GovHydroDD.k2
+        range: PU
+        multivalued: false
+        required: true
+        description: Double derivative gain (<i>K2</i>).  Typical value = 0,2.
+      ki:
+        slot_uri: cim:GovHydroDD.ki
+        range: PU
+        multivalued: false
+        required: true
+        description: Integral gain (<i>Ki</i>).  Typical value = 1.
+      kg:
+        slot_uri: cim:GovHydroDD.kg
+        range: PU
+        multivalued: false
+        required: true
+        description: Gate servo gain (<i>Kg</i>).  Typical value = 3.
+      tturb:
+        slot_uri: cim:GovHydroDD.tturb
+        range: Seconds
+        multivalued: false
+        required: true
+        description: Turbine time constant (<i>Tturb</i>)  (&gt;= 0).  See parameter
+          detail 3.  Typical value = 0,8.
+      aturb:
+        slot_uri: cim:GovHydroDD.aturb
+        range: PU
+        multivalued: false
+        required: true
+        description: Turbine numerator multiplier (<i>Aturb</i>) (see parameter detail
+          3).  Typical value = -1.
+      bturb:
+        slot_uri: cim:GovHydroDD.bturb
+        range: PU
+        multivalued: false
+        required: true
+        description: Turbine denominator multiplier (<i>Bturb</i>) (see parameter
+          detail 3).  Typical value = 0,5.
+      tt:
+        slot_uri: cim:GovHydroDD.tt
+        range: Seconds
+        multivalued: false
+        required: true
+        description: Power feedback time constant (<i>Tt</i>) (&gt;= 0).  If = 0,
+          block is bypassed.  Typical value = 0,02.
+      db1:
+        slot_uri: cim:GovHydroDD.db1
+        range: Frequency
+        multivalued: false
+        required: true
+        description: Intentional dead-band width (<i>db1</i>).  Unit = Hz.  Typical
+          value = 0.
+      eps:
+        slot_uri: cim:GovHydroDD.eps
+        range: Frequency
+        multivalued: false
+        required: true
+        description: Intentional db hysteresis (<i>eps</i>).  Unit = Hz.  Typical
+          value = 0.
+      db2:
+        slot_uri: cim:GovHydroDD.db2
+        range: ActivePower
+        multivalued: false
+        required: true
+        description: Unintentional dead-band (<i>db2</i>).  Unit = MW.  Typical value
+          = 0.
+      gv1:
+        slot_uri: cim:GovHydroDD.gv1
+        range: PU
+        multivalued: false
+        required: true
+        description: Nonlinear gain point 1, PU gv (<i>Gv1</i>).  Typical value =
+          0.
+      pgv1:
+        slot_uri: cim:GovHydroDD.pgv1
+        range: PU
+        multivalued: false
+        required: true
+        description: Nonlinear gain point 1, PU power (<i>Pgv1</i>).  Typical value
+          = 0.
+      gv2:
+        slot_uri: cim:GovHydroDD.gv2
+        range: PU
+        multivalued: false
+        required: true
+        description: Nonlinear gain point 2, PU gv (<i>Gv2</i>).  Typical value =
+          0.
+      pgv2:
+        slot_uri: cim:GovHydroDD.pgv2
+        range: PU
+        multivalued: false
+        required: true
+        description: Nonlinear gain point 2, PU power (<i>Pgv2</i>).  Typical value
+          = 0.
+      gv3:
+        slot_uri: cim:GovHydroDD.gv3
+        range: PU
+        multivalued: false
+        required: true
+        description: Nonlinear gain point 3, PU gv (<i>Gv3</i>).  Typical value =
+          0.
+      pgv3:
+        slot_uri: cim:GovHydroDD.pgv3
+        range: PU
+        multivalued: false
+        required: true
+        description: Nonlinear gain point 3, PU power (<i>Pgv3</i>).  Typical value
+          = 0.
+      gv4:
+        slot_uri: cim:GovHydroDD.gv4
+        range: PU
+        multivalued: false
+        required: true
+        description: Nonlinear gain point 4, PU gv (<i>Gv4</i>).  Typical value =
+          0.
+      pgv4:
+        slot_uri: cim:GovHydroDD.pgv4
+        range: PU
+        multivalued: false
+        required: true
+        description: Nonlinear gain point 4, PU power (<i>Pgv4</i>).  Typical value
+          = 0.
+      gv5:
+        slot_uri: cim:GovHydroDD.gv5
+        range: PU
+        multivalued: false
+        required: true
+        description: Nonlinear gain point 5, PU gv (<i>Gv5</i>).  Typical value =
+          0.
+      pgv5:
+        slot_uri: cim:GovHydroDD.pgv5
+        range: PU
+        multivalued: false
+        required: true
+        description: Nonlinear gain point 5, PU power (<i>Pgv5</i>).  Typical value
+          = 0.
+      gv6:
+        slot_uri: cim:GovHydroDD.gv6
+        range: PU
+        multivalued: false
+        required: true
+        description: Nonlinear gain point 6, PU gv (<i>Gv6</i>).  Typical value =
+          0.
+      pgv6:
+        slot_uri: cim:GovHydroDD.pgv6
+        range: PU
+        multivalued: false
+        required: true
+        description: Nonlinear gain point 6, PU power (<i>Pgv6</i>).  Typical value
+          = 0.
+      gmax:
+        slot_uri: cim:GovHydroDD.gmax
+        range: PU
+        multivalued: false
+        required: true
+        description: Maximum gate opening (<i>Gmax</i>) (&gt; GovHydroDD.gmin).  Typical
+          value = 0.
+      gmin:
+        slot_uri: cim:GovHydroDD.gmin
+        range: PU
+        multivalued: false
+        required: true
+        description: Minimum gate opening (<i>Gmin</i>) (&lt; GovHydroDD.gmax).  Typical
+          value = 0.
+      inputSignal:
+        slot_uri: cim:GovHydroDD.inputSignal
+        range: boolean
+        multivalued: false
+        required: true
+        description: "Input signal switch (<i>Flag</i>). \ntrue = <i>Pe</i> input\
+          \ is used\nfalse = feedback is received from <i>CV</i>.\n<i>Flag</i> is\
+          \ normally dependent on <i>Tt</i>.  If <i>Tt</i> is zero, <i>Flag</i> is\
+          \ set to false. If <i>Tt</i> is not zero, <i>Flag</i> is set to true.  \n\
+          Typical value = true."
+    is_a: TurbineGovernorDynamics
+    description: Double derivative hydro governor and turbine.
+  GovHydroFrancis:
+    class_uri: cim:GovHydroFrancis
+    attributes:
+      am:
+        slot_uri: cim:GovHydroFrancis.am
+        range: PU
+        multivalued: false
+        required: true
+        description: Opening section <i>S</i><i><sub>EFF</sub></i> at the maximum
+          efficiency (<i>Am</i>).  Typical value = 0,7.
+      av0:
+        slot_uri: cim:GovHydroFrancis.av0
+        range: Area
+        multivalued: false
+        required: true
+        description: Area of the surge tank (<i>A</i><i><sub>V0</sub></i>). Unit =
+          m<sup>2</sup>. Typical value = 30.
+      av1:
+        slot_uri: cim:GovHydroFrancis.av1
+        range: Area
+        multivalued: false
+        required: true
+        description: Area of the compensation tank (<i>A</i><i><sub>V1</sub></i>).
+          Unit = m<sup>2</sup>. Typical value = 700.
+      bp:
+        slot_uri: cim:GovHydroFrancis.bp
+        range: PU
+        multivalued: false
+        required: true
+        description: Droop (<i>Bp</i>).  Typical value = 0,05.
+      db1:
+        slot_uri: cim:GovHydroFrancis.db1
+        range: Frequency
+        multivalued: false
+        required: true
+        description: Intentional dead-band width (<i>DB1</i>).  Unit = Hz.  Typical
+          value = 0.
+      etamax:
+        slot_uri: cim:GovHydroFrancis.etamax
+        range: PU
+        multivalued: false
+        required: true
+        description: Maximum efficiency (<i>EtaMax</i>).  Typical value = 1,05.
+      governorControl:
+        slot_uri: cim:GovHydroFrancis.governorControl
+        range: FrancisGovernorControlKind
+        multivalued: false
+        required: true
+        description: Governor control flag (<i>Cflag</i>).  Typical value = mechanicHydrolicTachoAccelerator.
+      h1:
+        slot_uri: cim:GovHydroFrancis.h1
+        range: Length
+        multivalued: false
+        required: true
+        description: Head of compensation chamber water level with respect to the
+          level of penstock (<i>H</i><i><sub>1</sub></i>).  Unit = km.  Typical value
+          = 0,004.
+      h2:
+        slot_uri: cim:GovHydroFrancis.h2
+        range: Length
+        multivalued: false
+        required: true
+        description: Head of surge tank water level with respect to the level of penstock
+          (<i>H</i><i><sub>2</sub></i>).  Unit = km.  Typical value = 0,040.
+      hn:
+        slot_uri: cim:GovHydroFrancis.hn
+        range: Length
+        multivalued: false
+        required: true
+        description: Rated hydraulic head (<i>H</i><i><sub>n</sub></i>).  Unit = km.  Typical
+          value = 0,250.
+      kc:
+        slot_uri: cim:GovHydroFrancis.kc
+        range: PU
+        multivalued: false
+        required: true
+        description: Penstock loss coefficient (due to friction) (<i>Kc</i>).  Typical
+          value = 0,025.
+      kg:
+        slot_uri: cim:GovHydroFrancis.kg
+        range: PU
+        multivalued: false
+        required: true
+        description: Water tunnel and surge chamber loss coefficient (due to friction)
+          (<i>Kg</i>).  Typical value = 0,025.
+      kt:
+        slot_uri: cim:GovHydroFrancis.kt
+        range: PU
+        multivalued: false
+        required: true
+        description: Washout gain (<i>Kt</i>).  Typical value = 0,25.
+      qc0:
+        slot_uri: cim:GovHydroFrancis.qc0
+        range: PU
+        multivalued: false
+        required: true
+        description: No-load turbine flow at nominal head (<i>Qc0</i>).  Typical value
+          = 0,1.
+      qn:
+        slot_uri: cim:GovHydroFrancis.qn
+        range: VolumeFlowRate
+        multivalued: false
+        required: true
+        description: Rated flow (<i>Q</i><i><sub>n</sub></i>). Unit = m<sup>3</sup>/s.
+          Typical value = 250.
+      ta:
+        slot_uri: cim:GovHydroFrancis.ta
+        range: Seconds
+        multivalued: false
+        required: true
+        description: Derivative gain (<i>Ta</i>) (&gt;= 0).  Typical value = 3.
+      td:
+        slot_uri: cim:GovHydroFrancis.td
+        range: Seconds
+        multivalued: false
+        required: true
+        description: Washout time constant (<i>Td</i>) (&gt;= 0).  Typical value =
+          6.
+      ts:
+        slot_uri: cim:GovHydroFrancis.ts
+        range: Seconds
+        multivalued: false
+        required: true
+        description: Gate servo time constant (<i>Ts</i>) (&gt;= 0).  Typical value
+          = 0,5.
+      twnc:
+        slot_uri: cim:GovHydroFrancis.twnc
+        range: Seconds
+        multivalued: false
+        required: true
+        description: Water inertia time constant (<i>Twnc</i>) (&gt;= 0).  Typical
+          value = 1.
+      twng:
+        slot_uri: cim:GovHydroFrancis.twng
+        range: Seconds
+        multivalued: false
+        required: true
+        description: Water tunnel and surge chamber inertia time constant (<i>Twng</i>)
+          (&gt;= 0). Typical value = 3.
+      tx:
+        slot_uri: cim:GovHydroFrancis.tx
+        range: Seconds
+        multivalued: false
+        required: true
+        description: Derivative feedback gain (<i>Tx</i>) (&gt;= 0).  Typical value
+          = 1.
+      va:
+        slot_uri: cim:GovHydroFrancis.va
+        range: float
+        multivalued: false
+        required: true
+        description: Maximum gate opening velocity (<i>Va</i>).  Unit = PU / s.  Typical
+          value = 0,06.
+      valvmax:
+        slot_uri: cim:GovHydroFrancis.valvmax
+        range: PU
+        multivalued: false
+        required: true
+        description: Maximum gate opening (<i>ValvMax</i>) (&gt; GovHydroFrancis.valvmin).  Typical
+          value = 1,1.
+      valvmin:
+        slot_uri: cim:GovHydroFrancis.valvmin
+        range: PU
+        multivalued: false
+        required: true
+        description: Minimum gate opening (<i>ValvMin</i>) (&lt; GovHydroFrancis.valvmax).  Typical
+          value = 0.
+      vc:
+        slot_uri: cim:GovHydroFrancis.vc
+        range: float
+        multivalued: false
+        required: true
+        description: Maximum gate closing velocity (<i>Vc</i>).  Unit = PU / s.  Typical
+          value = -0,06.
+      waterTunnelSurgeChamberSimulation:
+        slot_uri: cim:GovHydroFrancis.waterTunnelSurgeChamberSimulation
+        range: boolean
+        multivalued: false
+        required: true
+        description: 'Water tunnel and surge chamber simulation (<i>Tflag</i>).
+
+          true = enable of water tunnel and surge chamber simulation
+
+          false = inhibit of water tunnel and surge chamber simulation.
+
+          Typical value = false.'
+      zsfc:
+        slot_uri: cim:GovHydroFrancis.zsfc
+        range: Length
+        multivalued: false
+        required: true
+        description: Head of upper water level with respect to the level of penstock
+          (<i>Zsfc</i>). Unit = km.  Typical value = 0,025.
+    is_a: TurbineGovernorDynamics
+    description: 'Detailed hydro unit - Francis model.  This model can be used to
+      represent three types of governors.
+
+      A schematic of the hydraulic system of detailed hydro unit models, such as Francis
+      and Pelton, is provided in the DetailedHydroModelHydraulicSystem diagram.'
+  GovHydroPelton:
+    class_uri: cim:GovHydroPelton
+    attributes:
+      av0:
+        slot_uri: cim:GovHydroPelton.av0
+        range: Area
+        multivalued: false
+        required: true
+        description: Area of the surge tank (<i>A</i><i><sub>V0</sub></i>). Unit =
+          m<sup>2</sup>. Typical value = 30.
+      av1:
+        slot_uri: cim:GovHydroPelton.av1
+        range: Area
+        multivalued: false
+        required: true
+        description: Area of the compensation tank (<i>A</i><i><sub>V1</sub></i>).
+          Unit = m<sup>2</sup>. Typical value = 700.
+      bp:
+        slot_uri: cim:GovHydroPelton.bp
+        range: PU
+        multivalued: false
+        required: true
+        description: Droop (<i>bp</i>).  Typical value = 0,05.
+      db1:
+        slot_uri: cim:GovHydroPelton.db1
+        range: Frequency
+        multivalued: false
+        required: true
+        description: Intentional dead-band width (<i>DB1</i>).  Unit = Hz.  Typical
+          value = 0.
+      db2:
+        slot_uri: cim:GovHydroPelton.db2
+        range: Frequency
+        multivalued: false
+        required: true
+        description: Intentional dead-band width of valve opening error (<i>DB2</i>).
+          Unit = Hz.  Typical value = 0,01.
+      h1:
+        slot_uri: cim:GovHydroPelton.h1
+        range: Length
+        multivalued: false
+        required: true
+        description: Head of compensation chamber water level with respect to the
+          level of penstock (<i>H</i><i><sub>1</sub></i>).  Unit = km.  Typical value
+          = 0,004.
+      h2:
+        slot_uri: cim:GovHydroPelton.h2
+        range: Length
+        multivalued: false
+        required: true
+        description: Head of surge tank water level with respect to the level of penstock
+          (<i>H</i><i><sub>2</sub></i>).  Unit = km.  Typical value = 0,040.
+      hn:
+        slot_uri: cim:GovHydroPelton.hn
+        range: Length
+        multivalued: false
+        required: true
+        description: Rated hydraulic head (<i>H</i><i><sub>n</sub></i>).  Unit = km.  Typical
+          value = 0,250.
+      kc:
+        slot_uri: cim:GovHydroPelton.kc
+        range: PU
+        multivalued: false
+        required: true
+        description: Penstock loss coefficient (due to friction) (<i>Kc</i>).  Typical
+          value = 0,025.
+      kg:
+        slot_uri: cim:GovHydroPelton.kg
+        range: PU
+        multivalued: false
+        required: true
+        description: Water tunnel and surge chamber loss coefficient (due to friction)
+          (<i>Kg</i>).  Typical value = 0,025.
+      qc0:
+        slot_uri: cim:GovHydroPelton.qc0
+        range: PU
+        multivalued: false
+        required: true
+        description: No-load turbine flow at nominal head (<i>Qc0</i>).  Typical value
+          = 0,05.
+      qn:
+        slot_uri: cim:GovHydroPelton.qn
+        range: VolumeFlowRate
+        multivalued: false
+        required: true
+        description: Rated flow (<i>Q</i><i><sub>n</sub></i>). Unit = m<sup>3</sup>/s.
+          Typical value = 250.
+      simplifiedPelton:
+        slot_uri: cim:GovHydroPelton.simplifiedPelton
+        range: boolean
+        multivalued: false
+        required: true
+        description: 'Simplified Pelton model simulation (<i>Sflag</i>).
+
+          true = enable of simplified Pelton model simulation
+
+          false = enable of complete Pelton model simulation (non-linear gain).
+
+          Typical value = true.'
+      staticCompensating:
+        slot_uri: cim:GovHydroPelton.staticCompensating
+        range: boolean
+        multivalued: false
+        required: true
+        description: "Static compensating characteristic (<i>Cflag</i>). It should\
+          \ be true if simplifiedPelton = false.\ntrue = enable of static compensating\
+          \ characteristic \nfalse = inhibit of static compensating characteristic.\n\
+          Typical value = false."
+      ta:
+        slot_uri: cim:GovHydroPelton.ta
+        range: Seconds
+        multivalued: false
+        required: true
+        description: Derivative gain (accelerometer time constant) (<i>Ta</i>) (&gt;=
+          0).  Typical value = 3.
+      ts:
+        slot_uri: cim:GovHydroPelton.ts
+        range: Seconds
+        multivalued: false
+        required: true
+        description: Gate servo time constant (<i>Ts</i>) (&gt;= 0).  Typical value
+          = 0,15.
+      tv:
+        slot_uri: cim:GovHydroPelton.tv
+        range: Seconds
+        multivalued: false
+        required: true
+        description: Servomotor integrator time constant (<i>Tv</i>) (&gt;= 0).  Typical
+          value = 0,3.
+      twnc:
+        slot_uri: cim:GovHydroPelton.twnc
+        range: Seconds
+        multivalued: false
+        required: true
+        description: Water inertia time constant (<i>Twnc</i>) (&gt;= 0).  Typical
+          value = 1.
+      twng:
+        slot_uri: cim:GovHydroPelton.twng
+        range: Seconds
+        multivalued: false
+        required: true
+        description: Water tunnel and surge chamber inertia time constant (<i>Twng</i>)
+          (&gt;= 0). Typical value = 3.
+      tx:
+        slot_uri: cim:GovHydroPelton.tx
+        range: Seconds
+        multivalued: false
+        required: true
+        description: Electronic integrator time constant (<i>Tx</i>) (&gt;= 0).  Typical
+          value = 0,5.
+      va:
+        slot_uri: cim:GovHydroPelton.va
+        range: float
+        multivalued: false
+        required: true
+        description: Maximum gate opening velocity (<i>Va</i>).  Unit = PU / s.  Typical
+          value = 0,06.
+      valvmax:
+        slot_uri: cim:GovHydroPelton.valvmax
+        range: PU
+        multivalued: false
+        required: true
+        description: Maximum gate opening (<i>ValvMax</i>) (&gt; GovHydroPelton.valvmin).  Typical
+          value = 1,1.
+      valvmin:
+        slot_uri: cim:GovHydroPelton.valvmin
+        range: PU
+        multivalued: false
+        required: true
+        description: Minimum gate opening (<i>ValvMin</i>) (&lt; GovHydroPelton.valvmax).  Typical
+          value = 0.
+      vav:
+        slot_uri: cim:GovHydroPelton.vav
+        range: PU
+        multivalued: false
+        required: true
+        description: Maximum servomotor valve opening velocity (<i>Vav</i>).  Typical
+          value = 0,1.
+      vc:
+        slot_uri: cim:GovHydroPelton.vc
+        range: float
+        multivalued: false
+        required: true
+        description: Maximum gate closing velocity (<i>Vc</i>).  Unit = PU / s.  Typical
+          value = -0,06.
+      vcv:
+        slot_uri: cim:GovHydroPelton.vcv
+        range: PU
+        multivalued: false
+        required: true
+        description: Maximum servomotor valve closing velocity (<i>Vcv</i>).  Typical
+          value = -0,1.
+      waterTunnelSurgeChamberSimulation:
+        slot_uri: cim:GovHydroPelton.waterTunnelSurgeChamberSimulation
+        range: boolean
+        multivalued: false
+        required: true
+        description: 'Water tunnel and surge chamber simulation (<i>Tflag</i>).
+
+          true = enable of water tunnel and surge chamber simulation
+
+          false = inhibit of water tunnel and surge chamber simulation.
+
+          Typical value = false.'
+      zsfc:
+        slot_uri: cim:GovHydroPelton.zsfc
+        range: Length
+        multivalued: false
+        required: true
+        description: Head of upper water level with respect to the level of penstock
+          (<i>Zsfc</i>).  Unit = km.  Typical value = 0,025.
+    is_a: TurbineGovernorDynamics
+    description: 'Detailed hydro unit - Pelton model.  This model can be used to represent
+      the dynamic related to water tunnel and surge chamber.
+
+      The DetailedHydroModelHydraulicSystem diagram, located under the GovHydroFrancis
+      class, provides a schematic of the hydraulic system of detailed hydro unit models,
+      such as Francis and Pelton.'
+  GovHydroPID:
+    class_uri: cim:GovHydroPID
+    attributes:
+      mwbase:
+        slot_uri: cim:GovHydroPID.mwbase
+        range: ActivePower
+        multivalued: false
+        required: true
+        description: Base for power values (<i>MWbase</i>) (&gt; 0).  Unit = MW.
+      pmax:
+        slot_uri: cim:GovHydroPID.pmax
+        range: PU
+        multivalued: false
+        required: true
+        description: Maximum gate opening, PU of MWbase (<i>Pmax</i>) (&gt; GovHydroPID.pmin).  Typical
+          value = 1.
+      pmin:
+        slot_uri: cim:GovHydroPID.pmin
+        range: PU
+        multivalued: false
+        required: true
+        description: Minimum gate opening, PU of MWbase (<i>Pmin</i>) (&lt; GovHydroPID.pmax).  Typical
+          value = 0.
+      r:
+        slot_uri: cim:GovHydroPID.r
+        range: PU
+        multivalued: false
+        required: true
+        description: Steady state droop (<i>R</i>).  Typical value = 0,05.
+      td:
+        slot_uri: cim:GovHydroPID.td
+        range: Seconds
+        multivalued: false
+        required: true
+        description: Input filter time constant (<i>Td</i>) (&gt;= 0).  If = 0, block
+          is bypassed.  Typical value = 0.
+      tf:
+        slot_uri: cim:GovHydroPID.tf
+        range: Seconds
+        multivalued: false
+        required: true
+        description: Washout time constant (<i>Tf</i>) (&gt;= 0).  Typical value =
+          0,1.
+      tp:
+        slot_uri: cim:GovHydroPID.tp
+        range: Seconds
+        multivalued: false
+        required: true
+        description: Gate servo time constant (<i>Tp</i>) (&gt;= 0).  If = 0, block
+          is bypassed.  Typical value = 0,35.
+      velop:
+        slot_uri: cim:GovHydroPID.velop
+        range: float
+        multivalued: false
+        required: true
+        description: Maximum gate opening velocity (<i>Velop</i>).  Unit = PU / s.  Typical
+          value = 0,09.
+      velcl:
+        slot_uri: cim:GovHydroPID.velcl
+        range: float
+        multivalued: false
+        required: true
+        description: Maximum gate closing velocity (<i>Velcl</i>).  Unit = PU / s.  Typical
+          value = -0,14.
+      kd:
+        slot_uri: cim:GovHydroPID.kd
+        range: PU
+        multivalued: false
+        required: true
+        description: Derivative gain (<i>Kd</i>).  Typical value = 1,11.
+      kp:
+        slot_uri: cim:GovHydroPID.kp
+        range: PU
+        multivalued: false
+        required: true
+        description: Proportional gain (<i>Kp</i>).  Typical value = 0,1.
+      ki:
+        slot_uri: cim:GovHydroPID.ki
+        range: PU
+        multivalued: false
+        required: true
+        description: Integral gain (<i>Ki</i>).  Typical value = 0,36.
+      kg:
+        slot_uri: cim:GovHydroPID.kg
+        range: PU
+        multivalued: false
+        required: true
+        description: Gate servo gain (<i>Kg</i>).  Typical value = 2,5.
+      tturb:
+        slot_uri: cim:GovHydroPID.tturb
+        range: Seconds
+        multivalued: false
+        required: true
+        description: Turbine time constant (<i>Tturb</i>) (&gt;= 0). See Parameter
+          detail 3.  Typical value = 0,8.
+      aturb:
+        slot_uri: cim:GovHydroPID.aturb
+        range: PU
+        multivalued: false
+        required: true
+        description: Turbine numerator multiplier (<i>Aturb</i>) (see parameter detail
+          3).  Typical value -1.
+      bturb:
+        slot_uri: cim:GovHydroPID.bturb
+        range: PU
+        multivalued: false
+        required: true
+        description: Turbine denominator multiplier (<i>Bturb</i>) (see parameter
+          detail 3).  Typical value = 0,5.
+      tt:
+        slot_uri: cim:GovHydroPID.tt
+        range: Seconds
+        multivalued: false
+        required: true
+        description: Power feedback time constant (<i>Tt</i>) (&gt;= 0).  If = 0,
+          block is bypassed.  Typical value = 0,02.
+      db1:
+        slot_uri: cim:GovHydroPID.db1
+        range: Frequency
+        multivalued: false
+        required: true
+        description: Intentional dead-band width (<i>db1</i>).  Unit = Hz.  Typical
+          value = 0.
+      inputSignal:
+        slot_uri: cim:GovHydroPID.inputSignal
+        range: boolean
+        multivalued: false
+        required: true
+        description: "Input signal switch (<i>Flag</i>). \ntrue = <i>Pe</i> input\
+          \ is used\nfalse = feedback is received from <i>CV</i>.\n<i>Flag</i> is\
+          \ normally dependent on <i>Tt</i>.  If <i>Tt </i>is zero, <i>Flag</i> is\
+          \ set to false. If <i>Tt</i> is not zero, <i>Flag</i> is set to true.  \n\
+          Typical value = true."
+      eps:
+        slot_uri: cim:GovHydroPID.eps
+        range: Frequency
+        multivalued: false
+        required: true
+        description: Intentional db hysteresis (<i>eps</i>).  Unit = Hz.  Typical
+          value = 0.
+      db2:
+        slot_uri: cim:GovHydroPID.db2
+        range: ActivePower
+        multivalued: false
+        required: true
+        description: Unintentional dead-band (<i>db2</i>).  Unit = MW.  Typical value
+          = 0.
+      gv1:
+        slot_uri: cim:GovHydroPID.gv1
+        range: PU
+        multivalued: false
+        required: true
+        description: Nonlinear gain point 1, PU gv (<i>Gv1</i>).  Typical value =
+          0.
+      pgv1:
+        slot_uri: cim:GovHydroPID.pgv1
+        range: PU
+        multivalued: false
+        required: true
+        description: Nonlinear gain point 1, PU power (<i>Pgv1</i>).  Typical value
+          = 0.
+      gv2:
+        slot_uri: cim:GovHydroPID.gv2
+        range: PU
+        multivalued: false
+        required: true
+        description: Nonlinear gain point 2, PU gv (<i>Gv2</i>).  Typical value =
+          0.
+      pgv2:
+        slot_uri: cim:GovHydroPID.pgv2
+        range: PU
+        multivalued: false
+        required: true
+        description: Nonlinear gain point 2, PU power (<i>Pgv2</i>).  Typical value
+          = 0.
+      gv3:
+        slot_uri: cim:GovHydroPID.gv3
+        range: PU
+        multivalued: false
+        required: true
+        description: Nonlinear gain point 3, PU gv (<i>Gv3</i>).  Typical value =
+          0.
+      pgv3:
+        slot_uri: cim:GovHydroPID.pgv3
+        range: PU
+        multivalued: false
+        required: true
+        description: Nonlinear gain point 3, PU power (<i>Pgv3</i>).  Typical value
+          = 0.
+      gv4:
+        slot_uri: cim:GovHydroPID.gv4
+        range: PU
+        multivalued: false
+        required: true
+        description: Nonlinear gain point 4, PU gv (<i>Gv4</i>).  Typical value =
+          0.
+      pgv4:
+        slot_uri: cim:GovHydroPID.pgv4
+        range: PU
+        multivalued: false
+        required: true
+        description: Nonlinear gain point 4, PU power (<i>Pgv4</i>).  Typical value
+          = 0.
+      gv5:
+        slot_uri: cim:GovHydroPID.gv5
+        range: PU
+        multivalued: false
+        required: true
+        description: Nonlinear gain point 5, PU gv (<i>Gv5</i>).  Typical value =
+          0.
+      pgv5:
+        slot_uri: cim:GovHydroPID.pgv5
+        range: PU
+        multivalued: false
+        required: true
+        description: Nonlinear gain point 5, PU power (<i>Pgv5</i>).  Typical value
+          = 0.
+      gv6:
+        slot_uri: cim:GovHydroPID.gv6
+        range: PU
+        multivalued: false
+        required: true
+        description: Nonlinear gain point 6, PU gv (<i>Gv6</i>).  Typical value =
+          0.
+      pgv6:
+        slot_uri: cim:GovHydroPID.pgv6
+        range: PU
+        multivalued: false
+        required: true
+        description: Nonlinear gain point 6, PU power (<i>Pgv6</i>).  Typical value
+          = 0.
+    is_a: TurbineGovernorDynamics
+    description: PID governor and turbine.
+  GovHydroPID2:
+    class_uri: cim:GovHydroPID2
+    attributes:
+      mwbase:
+        slot_uri: cim:GovHydroPID2.mwbase
+        range: ActivePower
+        multivalued: false
+        required: true
+        description: Base for power values (<i>MWbase</i>) (&gt;0).  Unit = MW.
+      treg:
+        slot_uri: cim:GovHydroPID2.treg
+        range: Seconds
+        multivalued: false
+        required: true
+        description: Speed detector time constant (<i>Treg</i>) (&gt;= 0).  Typical
+          value = 0.
+      rperm:
+        slot_uri: cim:GovHydroPID2.rperm
+        range: PU
+        multivalued: false
+        required: true
+        description: Permanent drop (<i>Rperm</i>).  Typical value = 0.
+      kp:
+        slot_uri: cim:GovHydroPID2.kp
+        range: PU
+        multivalued: false
+        required: true
+        description: Proportional gain (<i>Kp</i>).  Typical value = 0.
+      ki:
+        slot_uri: cim:GovHydroPID2.ki
+        range: float
+        multivalued: false
+        required: true
+        description: Reset gain (<i>Ki</i>).  Unit = PU/s.  Typical value = 0.
+      kd:
+        slot_uri: cim:GovHydroPID2.kd
+        range: PU
+        multivalued: false
+        required: true
+        description: Derivative gain (<i>Kd</i>).  Typical value = 0.
+      ta:
+        slot_uri: cim:GovHydroPID2.ta
+        range: Seconds
+        multivalued: false
+        required: true
+        description: Controller time constant (<i>Ta</i>) (&gt;= 0).  Typical value
+          = 0.
+      tb:
+        slot_uri: cim:GovHydroPID2.tb
+        range: Seconds
+        multivalued: false
+        required: true
+        description: Gate servo time constant (<i>Tb</i>) (&gt; 0).
+      velmax:
+        slot_uri: cim:GovHydroPID2.velmax
+        range: float
+        multivalued: false
+        required: true
+        description: Maximum gate opening velocity (<i>Velmax</i>) (&lt; GovHydroPID2.velmin).  Unit
+          = PU / s.  Typical value = 0.
+      velmin:
+        slot_uri: cim:GovHydroPID2.velmin
+        range: float
+        multivalued: false
+        required: true
+        description: Maximum gate closing velocity (<i>Velmin</i>) (&gt; GovHydroPID2.velmax).  Unit
+          = PU / s.  Typical value = 0.
+      gmax:
+        slot_uri: cim:GovHydroPID2.gmax
+        range: PU
+        multivalued: false
+        required: true
+        description: Maximum gate opening (<i>Gmax</i>) (&gt; GovHydroPID2.gmin).  Typical
+          value = 0.
+      gmin:
+        slot_uri: cim:GovHydroPID2.gmin
+        range: PU
+        multivalued: false
+        required: true
+        description: Minimum gate opening (<i>Gmin</i>) (&gt; GovHydroPID2.gmax).  Typical
+          value = 0.
+      tw:
+        slot_uri: cim:GovHydroPID2.tw
+        range: Seconds
+        multivalued: false
+        required: true
+        description: Water inertia time constant (<i>Tw</i>) (&gt;= 0).  Typical value
+          = 0.
+      d:
+        slot_uri: cim:GovHydroPID2.d
+        range: PU
+        multivalued: false
+        required: true
+        description: Turbine damping factor (<i>D</i>).  Unit = delta P / delta speed.  Typical
+          value = 0.
+      g0:
+        slot_uri: cim:GovHydroPID2.g0
+        range: PU
+        multivalued: false
+        required: true
+        description: Gate opening at speed no load (<i>G0</i>).  Typical value = 0.
+      g1:
+        slot_uri: cim:GovHydroPID2.g1
+        range: PU
+        multivalued: false
+        required: true
+        description: Intermediate gate opening (<i>G1</i>).  Typical value = 0.
+      p1:
+        slot_uri: cim:GovHydroPID2.p1
+        range: PU
+        multivalued: false
+        required: true
+        description: Power at gate opening <i>G1</i> (<i>P1</i>).  Typical value =
+          0.
+      g2:
+        slot_uri: cim:GovHydroPID2.g2
+        range: PU
+        multivalued: false
+        required: true
+        description: Intermediate gate opening (<i>G2</i>).  Typical value = 0.
+      p2:
+        slot_uri: cim:GovHydroPID2.p2
+        range: PU
+        multivalued: false
+        required: true
+        description: Power at gate opening G2 (<i>P2</i>).  Typical value = 0.
+      p3:
+        slot_uri: cim:GovHydroPID2.p3
+        range: PU
+        multivalued: false
+        required: true
+        description: Power at full opened gate (<i>P3</i>).  Typical value = 0.
+      atw:
+        slot_uri: cim:GovHydroPID2.atw
+        range: PU
+        multivalued: false
+        required: true
+        description: Factor multiplying <i>Tw</i> (<i>Atw</i>).  Typical value = 0.
+      feedbackSignal:
+        slot_uri: cim:GovHydroPID2.feedbackSignal
+        range: boolean
+        multivalued: false
+        required: true
+        description: 'Feedback signal type flag (<i>Flag</i>).
+
+          true = use gate position feedback signal
+
+          false = use Pe.'
+    is_a: TurbineGovernorDynamics
+    description: 'Hydro turbine and governor. Represents plants with straightforward
+      penstock configurations and "three term" electro-hydraulic governors (i.e. Woodward<sup>TM</sup>
+      electronic).
+
+      [Footnote: Woodward electronic governors are an example of suitable products
+      available commercially. This information is given for the convenience of users
+      of this document and does not constitute an endorsement by IEC of these products.]'
+  GovHydroR:
+    class_uri: cim:GovHydroR
+    attributes:
+      mwbase:
+        slot_uri: cim:GovHydroR.mwbase
+        range: ActivePower
+        multivalued: false
+        required: true
+        description: Base for power values (<i>MWbase</i>) (&gt; 0).  Unit = MW.
+      pmax:
+        slot_uri: cim:GovHydroR.pmax
+        range: PU
+        multivalued: false
+        required: true
+        description: Maximum gate opening, PU of <i>MWbase</i> (<i>Pmax</i>) (&gt;
+          GovHydroR.pmin).  Typical value = 1.
+      pmin:
+        slot_uri: cim:GovHydroR.pmin
+        range: PU
+        multivalued: false
+        required: true
+        description: Minimum gate opening, PU of <i>MWbase</i> (<i>Pmin</i>) (&lt;
+          GovHydroR.pmax).  Typical value = 0.
+      r:
+        slot_uri: cim:GovHydroR.r
+        range: PU
+        multivalued: false
+        required: true
+        description: Steady-state droop (<i>R</i>).  Typical value = 0,05.
+      td:
+        slot_uri: cim:GovHydroR.td
+        range: Seconds
+        multivalued: false
+        required: true
+        description: Input filter time constant (<i>Td</i>) (&gt;= 0).  Typical value
+          = 0,05.
+      t1:
+        slot_uri: cim:GovHydroR.t1
+        range: Seconds
+        multivalued: false
+        required: true
+        description: Lead time constant 1 (<i>T1</i>) (&gt;= 0).  Typical value =
+          1,5.
+      t2:
+        slot_uri: cim:GovHydroR.t2
+        range: Seconds
+        multivalued: false
+        required: true
+        description: Lag time constant 1 (<i>T2</i>) (&gt;= 0).  Typical value = 0,1.
+      t3:
+        slot_uri: cim:GovHydroR.t3
+        range: Seconds
+        multivalued: false
+        required: true
+        description: Lead time constant 2 (<i>T3</i>) (&gt;= 0).  Typical value =
+          1,5.
+      t4:
+        slot_uri: cim:GovHydroR.t4
+        range: Seconds
+        multivalued: false
+        required: true
+        description: Lag time constant 2 (<i>T4</i>) (&gt;= 0).  Typical value = 0,1.
+      t5:
+        slot_uri: cim:GovHydroR.t5
+        range: Seconds
+        multivalued: false
+        required: true
+        description: Lead time constant 3 (<i>T5</i>) (&gt;= 0).  Typical value =
+          0.
+      t6:
+        slot_uri: cim:GovHydroR.t6
+        range: Seconds
+        multivalued: false
+        required: true
+        description: Lag time constant 3 (<i>T6</i>) (&gt;= 0).  Typical value = 0,05.
+      t7:
+        slot_uri: cim:GovHydroR.t7
+        range: Seconds
+        multivalued: false
+        required: true
+        description: Lead time constant 4 (<i>T7</i>) (&gt;= 0).  Typical value =
+          0.
+      t8:
+        slot_uri: cim:GovHydroR.t8
+        range: Seconds
+        multivalued: false
+        required: true
+        description: Lag time constant 4 (<i>T8</i>) (&gt;= 0).  Typical value = 0,05.
+      tp:
+        slot_uri: cim:GovHydroR.tp
+        range: Seconds
+        multivalued: false
+        required: true
+        description: Gate servo time constant (<i>Tp</i>) (&gt;= 0).  Typical value
+          = 0,05.
+      velop:
+        slot_uri: cim:GovHydroR.velop
+        range: float
+        multivalued: false
+        required: true
+        description: Maximum gate opening velocity (<i>Velop</i>).  Unit = PU / s.  Typical
+          value = 0,2.
+      velcl:
+        slot_uri: cim:GovHydroR.velcl
+        range: float
+        multivalued: false
+        required: true
+        description: Maximum gate closing velocity (<i>Velcl</i>).  Unit = PU / s.  Typical
+          value = -0,2.
+      ki:
+        slot_uri: cim:GovHydroR.ki
+        range: PU
+        multivalued: false
+        required: true
+        description: Integral gain (<i>Ki</i>).  Typical value = 0,5.
+      kg:
+        slot_uri: cim:GovHydroR.kg
+        range: PU
+        multivalued: false
+        required: true
+        description: Gate servo gain (<i>Kg</i>).  Typical value = 2.
+      gmax:
+        slot_uri: cim:GovHydroR.gmax
+        range: PU
+        multivalued: false
+        required: true
+        description: Maximum governor output (<i>Gmax</i>) (&gt; GovHydroR.gmin).  Typical
+          value = 1,05.
+      gmin:
+        slot_uri: cim:GovHydroR.gmin
+        range: PU
+        multivalued: false
+        required: true
+        description: Minimum governor output (<i>Gmin</i>) (&lt; GovHydroR.gmax).  Typical
+          value = -0,05.
+      tt:
+        slot_uri: cim:GovHydroR.tt
+        range: Seconds
+        multivalued: false
+        required: true
+        description: Power feedback time constant (<i>Tt</i>) (&gt;= 0).  Typical
+          value = 0.
+      inputSignal:
+        slot_uri: cim:GovHydroR.inputSignal
+        range: boolean
+        multivalued: false
+        required: true
+        description: "Input signal switch (<i>Flag</i>).\ntrue = <i>Pe</i> input is\
+          \ used\nfalse = feedback is received from <i>CV</i>.\n<i>Flag</i> is normally\
+          \ dependent on <i>Tt</i>.  If <i>Tt </i>is zero, <i>Flag</i> is set to false.\
+          \ If <i>Tt</i> is not zero, <i>Flag</i> is set to true.  \nTypical value\
+          \ = true."
+      db1:
+        slot_uri: cim:GovHydroR.db1
+        range: Frequency
+        multivalued: false
+        required: true
+        description: Intentional dead-band width (<i>db1</i>).  Unit = Hz.  Typical
+          value = 0.
+      eps:
+        slot_uri: cim:GovHydroR.eps
+        range: Frequency
+        multivalued: false
+        required: true
+        description: Intentional db hysteresis (<i>eps</i>).  Unit = Hz.  Typical
+          value = 0.
+      db2:
+        slot_uri: cim:GovHydroR.db2
+        range: ActivePower
+        multivalued: false
+        required: true
+        description: Unintentional dead-band (<i>db2</i>).  Unit = MW.  Typical value
+          = 0.
+      tw:
+        slot_uri: cim:GovHydroR.tw
+        range: Seconds
+        multivalued: false
+        required: true
+        description: Water inertia time constant (<i>Tw</i>) (&gt; 0).  Typical value
+          = 1.
+      at:
+        slot_uri: cim:GovHydroR.at
+        range: PU
+        multivalued: false
+        required: true
+        description: Turbine gain (<i>At</i>).  Typical value = 1,2.
+      dturb:
+        slot_uri: cim:GovHydroR.dturb
+        range: PU
+        multivalued: false
+        required: true
+        description: Turbine damping factor (<i>Dturb</i>).  Typical value = 0,2.
+      qnl:
+        slot_uri: cim:GovHydroR.qnl
+        range: PU
+        multivalued: false
+        required: true
+        description: No-load turbine flow at nominal head (<i>Qnl</i>).  Typical value
+          = 0,08.
+      h0:
+        slot_uri: cim:GovHydroR.h0
+        range: PU
+        multivalued: false
+        required: true
+        description: Turbine nominal head (<i>H0</i>).  Typical value = 1.
+      gv1:
+        slot_uri: cim:GovHydroR.gv1
+        range: PU
+        multivalued: false
+        required: true
+        description: Nonlinear gain point 1, PU gv (<i>Gv1</i>).  Typical value =
+          0.
+      pgv1:
+        slot_uri: cim:GovHydroR.pgv1
+        range: PU
+        multivalued: false
+        required: true
+        description: Nonlinear gain point 1, PU power (<i>Pgv1</i>).  Typical value
+          = 0.
+      gv2:
+        slot_uri: cim:GovHydroR.gv2
+        range: PU
+        multivalued: false
+        required: true
+        description: Nonlinear gain point 2, PU gv (<i>Gv2</i>).  Typical value =
+          0.
+      pgv2:
+        slot_uri: cim:GovHydroR.pgv2
+        range: PU
+        multivalued: false
+        required: true
+        description: Nonlinear gain point 2, PU power (<i>Pgv2</i>).  Typical value
+          = 0.
+      gv3:
+        slot_uri: cim:GovHydroR.gv3
+        range: PU
+        multivalued: false
+        required: true
+        description: Nonlinear gain point 3, PU gv (<i>Gv3</i>).  Typical value =
+          0.
+      pgv3:
+        slot_uri: cim:GovHydroR.pgv3
+        range: PU
+        multivalued: false
+        required: true
+        description: Nonlinear gain point 3, PU power (<i>Pgv3</i>).  Typical value
+          = 0.
+      gv4:
+        slot_uri: cim:GovHydroR.gv4
+        range: PU
+        multivalued: false
+        required: true
+        description: Nonlinear gain point 4, PU gv (<i>Gv4</i>).  Typical value =
+          0.
+      pgv4:
+        slot_uri: cim:GovHydroR.pgv4
+        range: PU
+        multivalued: false
+        required: true
+        description: Nonlinear gain point 4, PU power (<i>Pgv4</i>).  Typical value
+          = 0.
+      gv5:
+        slot_uri: cim:GovHydroR.gv5
+        range: PU
+        multivalued: false
+        required: true
+        description: Nonlinear gain point 5, PU gv (<i>Gv5</i>).  Typical value =
+          0.
+      pgv5:
+        slot_uri: cim:GovHydroR.pgv5
+        range: PU
+        multivalued: false
+        required: true
+        description: Nonlinear gain point 5, PU power (<i>Pgv5</i>).  Typical value
+          = 0.
+      gv6:
+        slot_uri: cim:GovHydroR.gv6
+        range: PU
+        multivalued: false
+        required: true
+        description: Nonlinear gain point 6, PU gv (<i>Gv6</i>).  Typical value =
+          0.
+      pgv6:
+        slot_uri: cim:GovHydroR.pgv6
+        range: PU
+        multivalued: false
+        required: true
+        description: Nonlinear gain point 6, PU power (<i>Pgv6</i>).  Typical value
+          = 0.
+    is_a: TurbineGovernorDynamics
+    description: Fourth order lead-lag governor and hydro turbine.
+  GovHydroWEH:
+    class_uri: cim:GovHydroWEH
+    attributes:
+      mwbase:
+        slot_uri: cim:GovHydroWEH.mwbase
+        range: ActivePower
+        multivalued: false
+        required: true
+        description: Base for power values (<i>MWbase</i>) (&gt; 0).  Unit = MW.
+      rpg:
+        slot_uri: cim:GovHydroWEH.rpg
+        range: float
+        multivalued: false
+        required: true
+        description: Permanent droop for governor output feedback (<i>R-Perm-Gate</i>).
+      rpp:
+        slot_uri: cim:GovHydroWEH.rpp
+        range: float
+        multivalued: false
+        required: true
+        description: Permanent droop for electrical power feedback (<i>R-Perm-Pe</i>).
+      tpe:
+        slot_uri: cim:GovHydroWEH.tpe
+        range: Seconds
+        multivalued: false
+        required: true
+        description: Electrical power droop time constant (<i>Tpe</i>) (&gt;= 0).
+      kp:
+        slot_uri: cim:GovHydroWEH.kp
+        range: PU
+        multivalued: false
+        required: true
+        description: Derivative control gain (<i>Kp</i>).
+      ki:
+        slot_uri: cim:GovHydroWEH.ki
+        range: PU
+        multivalued: false
+        required: true
+        description: Derivative controller Integral gain (<i>Ki</i>).
+      kd:
+        slot_uri: cim:GovHydroWEH.kd
+        range: PU
+        multivalued: false
+        required: true
+        description: Derivative controller derivative gain (<i>Kd</i>).
+      td:
+        slot_uri: cim:GovHydroWEH.td
+        range: Seconds
+        multivalued: false
+        required: true
+        description: Derivative controller time constant (<i>Td</i>) (&gt;= 0).  Limits
+          the derivative characteristic beyond a breakdown frequency to avoid amplification
+          of high-frequency noise.
+      tp:
+        slot_uri: cim:GovHydroWEH.tp
+        range: Seconds
+        multivalued: false
+        required: true
+        description: Pilot valve time lag time constant (<i>Tp</i>) (&gt;= 0).
+      tdv:
+        slot_uri: cim:GovHydroWEH.tdv
+        range: Seconds
+        multivalued: false
+        required: true
+        description: Distributive valve time lag time constant (<i>Tdv</i>) (&gt;=
+          0).
+      tg:
+        slot_uri: cim:GovHydroWEH.tg
+        range: Seconds
+        multivalued: false
+        required: true
+        description: Value to allow the distribution valve controller to advance beyond
+          the gate movement rate limit (<i>Tg</i>) (&gt;= 0).
+      gtmxop:
+        slot_uri: cim:GovHydroWEH.gtmxop
+        range: PU
+        multivalued: false
+        required: true
+        description: Maximum gate opening rate (<i>Gtmxop</i>).
+      gtmxcl:
+        slot_uri: cim:GovHydroWEH.gtmxcl
+        range: PU
+        multivalued: false
+        required: true
+        description: Maximum gate closing rate (<i>Gtmxcl</i>).
+      gmax:
+        slot_uri: cim:GovHydroWEH.gmax
+        range: PU
+        multivalued: false
+        required: true
+        description: Maximum gate position (<i>Gmax</i>) (&gt; GovHydroWEH.gmin).
+      gmin:
+        slot_uri: cim:GovHydroWEH.gmin
+        range: PU
+        multivalued: false
+        required: true
+        description: Minimum gate position (<i>Gmin</i>) (&lt; GovHydroWEH.gmax).
+      dturb:
+        slot_uri: cim:GovHydroWEH.dturb
+        range: PU
+        multivalued: false
+        required: true
+        description: Turbine damping factor (<i>Dturb</i>).  Unit = delta P (PU of
+          <i>MWbase</i>) / delta speed (PU).
+      tw:
+        slot_uri: cim:GovHydroWEH.tw
+        range: Seconds
+        multivalued: false
+        required: true
+        description: Water inertia time constant (<i>Tw</i>) (&gt; 0).
+      db:
+        slot_uri: cim:GovHydroWEH.db
+        range: PU
+        multivalued: false
+        required: true
+        description: Speed deadband (<i>db</i>).
+      dpv:
+        slot_uri: cim:GovHydroWEH.dpv
+        range: PU
+        multivalued: false
+        required: true
+        description: Value to allow the pilot valve controller to advance beyond the
+          gate limits (<i>Dpv</i>).
+      dicn:
+        slot_uri: cim:GovHydroWEH.dicn
+        range: PU
+        multivalued: false
+        required: true
+        description: Value to allow the integral controller to advance beyond the
+          gate limits (<i>Dicn</i>).
+      feedbackSignal:
+        slot_uri: cim:GovHydroWEH.feedbackSignal
+        range: boolean
+        multivalued: false
+        required: true
+        description: 'Feedback signal selection (<i>Sw</i>).
+
+          true = PID output (if <i>R-Perm-Gate </i>= droop and <i>R-Perm-Pe </i>=
+          0)
+
+          false = electrical power (if <i>R-Perm-Gate </i>= 0 and <i>R-Perm-Pe </i>=
+          droop) or
+
+          false = gate position (if R<i>-Perm-Gate </i>= droop and <i>R-Perm-Pe </i>=
+          0).
+
+          Typical value = false.'
+      gv1:
+        slot_uri: cim:GovHydroWEH.gv1
+        range: PU
+        multivalued: false
+        required: true
+        description: Gate 1 (<i>Gv1</i>).  Gate Position value for point 1 for lookup
+          table representing water flow through the turbine as a function of gate
+          position to produce steady state flow.
+      gv2:
+        slot_uri: cim:GovHydroWEH.gv2
+        range: PU
+        multivalued: false
+        required: true
+        description: Gate 2 (<i>Gv2</i>).  Gate Position value for point 2 for lookup
+          table representing water flow through the turbine as a function of gate
+          position to produce steady state flow.
+      gv3:
+        slot_uri: cim:GovHydroWEH.gv3
+        range: PU
+        multivalued: false
+        required: true
+        description: Gate 3 (<i>Gv3</i>).  Gate Position value for point 3 for lookup
+          table representing water flow through the turbine as a function of gate
+          position to produce steady state flow.
+      gv4:
+        slot_uri: cim:GovHydroWEH.gv4
+        range: PU
+        multivalued: false
+        required: true
+        description: Gate 4 (<i>Gv4</i>).  Gate Position value for point 4 for lookup
+          table representing water flow through the turbine as a function of gate
+          position to produce steady state flow.
+      gv5:
+        slot_uri: cim:GovHydroWEH.gv5
+        range: PU
+        multivalued: false
+        required: true
+        description: Gate 5 (<i>Gv5</i>).  Gate Position value for point 5 for lookup
+          table representing water flow through the turbine as a function of gate
+          position to produce steady state flow.
+      fl1:
+        slot_uri: cim:GovHydroWEH.fl1
+        range: PU
+        multivalued: false
+        required: true
+        description: Flowgate 1 (<i>Fl1</i>).  Flow value for gate position point
+          1 for lookup table representing water flow through the turbine as a function
+          of gate position to produce steady state flow.
+      fl2:
+        slot_uri: cim:GovHydroWEH.fl2
+        range: PU
+        multivalued: false
+        required: true
+        description: Flowgate 2 (<i>Fl2</i>).  Flow value for gate position point
+          2 for lookup table representing water flow through the turbine as a function
+          of gate position to produce steady state flow.
+      fl3:
+        slot_uri: cim:GovHydroWEH.fl3
+        range: PU
+        multivalued: false
+        required: true
+        description: Flowgate 3 (<i>Fl3</i>).  Flow value for gate position point
+          3 for lookup table representing water flow through the turbine as a function
+          of gate position to produce steady state flow.
+      fl4:
+        slot_uri: cim:GovHydroWEH.fl4
+        range: PU
+        multivalued: false
+        required: true
+        description: Flowgate 4 (<i>Fl4</i>).  Flow value for gate position point
+          4 for lookup table representing water flow through the turbine as a function
+          of gate position to produce steady state flow.
+      fl5:
+        slot_uri: cim:GovHydroWEH.fl5
+        range: PU
+        multivalued: false
+        required: true
+        description: Flowgate 5 (<i>Fl5</i>).  Flow value for gate position point
+          5 for lookup table representing water flow through the turbine as a function
+          of gate position to produce steady state flow.
+      fp1:
+        slot_uri: cim:GovHydroWEH.fp1
+        range: PU
+        multivalued: false
+        required: true
+        description: Flow P1 (<i>Fp1</i>).  Turbine flow value for point 1 for lookup
+          table representing PU mechanical power on machine MVA rating as a function
+          of turbine flow.
+      fp2:
+        slot_uri: cim:GovHydroWEH.fp2
+        range: PU
+        multivalued: false
+        required: true
+        description: Flow P2 (<i>Fp2</i>).  Turbine flow value for point 2 for lookup
+          table representing PU mechanical power on machine MVA rating as a function
+          of turbine flow.
+      fp3:
+        slot_uri: cim:GovHydroWEH.fp3
+        range: PU
+        multivalued: false
+        required: true
+        description: Flow P3 (<i>Fp3</i>).  Turbine flow value for point 3 for lookup
+          table representing PU mechanical power on machine MVA rating as a function
+          of turbine flow.
+      fp4:
+        slot_uri: cim:GovHydroWEH.fp4
+        range: PU
+        multivalued: false
+        required: true
+        description: Flow P4 (<i>Fp4</i>).  Turbine flow value for point 4 for lookup
+          table representing PU mechanical power on machine MVA rating as a function
+          of turbine flow.
+      fp5:
+        slot_uri: cim:GovHydroWEH.fp5
+        range: PU
+        multivalued: false
+        required: true
+        description: Flow P5 (<i>Fp5</i>).  Turbine flow value for point 5 for lookup
+          table representing PU mechanical power on machine MVA rating as a function
+          of turbine flow.
+      fp6:
+        slot_uri: cim:GovHydroWEH.fp6
+        range: PU
+        multivalued: false
+        required: true
+        description: Flow P6 (<i>Fp6</i>).  Turbine flow value for point 6 for lookup
+          table representing PU mechanical power on machine MVA rating as a function
+          of turbine flow.
+      fp7:
+        slot_uri: cim:GovHydroWEH.fp7
+        range: PU
+        multivalued: false
+        required: true
+        description: Flow P7 (<i>Fp7</i>).  Turbine flow value for point 7 for lookup
+          table representing PU mechanical power on machine MVA rating as a function
+          of turbine flow.
+      fp8:
+        slot_uri: cim:GovHydroWEH.fp8
+        range: PU
+        multivalued: false
+        required: true
+        description: Flow P8 (<i>Fp8</i>).  Turbine flow value for point 8 for lookup
+          table representing PU mechanical power on machine MVA rating as a function
+          of turbine flow.
+      fp9:
+        slot_uri: cim:GovHydroWEH.fp9
+        range: PU
+        multivalued: false
+        required: true
+        description: Flow P9 (<i>Fp9</i>).  Turbine flow value for point 9 for lookup
+          table representing PU mechanical power on machine MVA rating as a function
+          of turbine flow.
+      fp10:
+        slot_uri: cim:GovHydroWEH.fp10
+        range: PU
+        multivalued: false
+        required: true
+        description: Flow P10 (<i>Fp10</i>).  Turbine flow value for point 10 for
+          lookup table representing PU mechanical power on machine MVA rating as a
+          function of turbine flow.
+      pmss1:
+        slot_uri: cim:GovHydroWEH.pmss1
+        range: PU
+        multivalued: false
+        required: true
+        description: Pmss flow P1 (<i>Pmss1</i>).  Mechanical power output for turbine
+          flow point 1 for lookup table representing PU mechanical power on machine
+          MVA rating as a function of turbine flow.
+      pmss2:
+        slot_uri: cim:GovHydroWEH.pmss2
+        range: PU
+        multivalued: false
+        required: true
+        description: Pmss flow P2 (<i>Pmss2</i>).  Mechanical power output for turbine
+          flow point 2 for lookup table representing PU mechanical power on machine
+          MVA rating as a function of turbine flow.
+      pmss3:
+        slot_uri: cim:GovHydroWEH.pmss3
+        range: PU
+        multivalued: false
+        required: true
+        description: Pmss flow P3 (<i>Pmss3</i>).  Mechanical power output for turbine
+          flow point 3 for lookup table representing PU mechanical power on machine
+          MVA rating as a function of turbine flow.
+      pmss4:
+        slot_uri: cim:GovHydroWEH.pmss4
+        range: PU
+        multivalued: false
+        required: true
+        description: Pmss flow P4 (<i>Pmss4</i>).  Mechanical power output for turbine
+          flow point 4 for lookup table representing PU mechanical power on machine
+          MVA rating as a function of turbine flow.
+      pmss5:
+        slot_uri: cim:GovHydroWEH.pmss5
+        range: PU
+        multivalued: false
+        required: true
+        description: Pmss flow P5 (<i>Pmss5</i>).  Mechanical power output for turbine
+          flow point 5 for lookup table representing PU mechanical power on machine
+          MVA rating as a function of turbine flow.
+      pmss6:
+        slot_uri: cim:GovHydroWEH.pmss6
+        range: PU
+        multivalued: false
+        required: true
+        description: Pmss flow P6 (<i>Pmss6</i>).  Mechanical power output for turbine
+          flow point 6 for lookup table representing PU mechanical power on machine
+          MVA rating as a function of turbine flow.
+      pmss7:
+        slot_uri: cim:GovHydroWEH.pmss7
+        range: PU
+        multivalued: false
+        required: true
+        description: Pmss flow P7 (<i>Pmss7</i>).  Mechanical power output for turbine
+          flow point 7 for lookup table representing PU mechanical power on machine
+          MVA rating as a function of turbine flow.
+      pmss8:
+        slot_uri: cim:GovHydroWEH.pmss8
+        range: PU
+        multivalued: false
+        required: true
+        description: Pmss flow P8 (<i>Pmss8</i>).  Mechanical power output for turbine
+          flow point 8 for lookup table representing PU mechanical power on machine
+          MVA rating as a function of turbine flow.
+      pmss9:
+        slot_uri: cim:GovHydroWEH.pmss9
+        range: PU
+        multivalued: false
+        required: true
+        description: Pmss flow P9 (<i>Pmss9</i>).  Mechanical power output for turbine
+          flow point 9 for lookup table representing PU mechanical power on machine
+          MVA rating as a function of turbine flow.
+      pmss10:
+        slot_uri: cim:GovHydroWEH.pmss10
+        range: PU
+        multivalued: false
+        required: true
+        description: Pmss flow P10 (<i>Pmss10</i>).  Mechanical power output for turbine
+          flow point 10 for lookup table representing PU mechanical power on machine
+          MVA rating as a function of turbine flow.
+    is_a: TurbineGovernorDynamics
+    description: "Woodward<sup>TM </sup>electric hydro governor. \n[Footnote: Woodward\
+      \ electric hydro governors are an example of suitable products available commercially.\
+      \ This information is given for the convenience of users of this document and\
+      \ does not constitute an endorsement by IEC of these products.]"
+  GovHydroWPID:
+    class_uri: cim:GovHydroWPID
+    attributes:
+      mwbase:
+        slot_uri: cim:GovHydroWPID.mwbase
+        range: ActivePower
+        multivalued: false
+        required: true
+        description: Base for power values  (<i>MWbase</i>) (&gt; 0).  Unit = MW.
+      treg:
+        slot_uri: cim:GovHydroWPID.treg
+        range: Seconds
+        multivalued: false
+        required: true
+        description: Speed detector time constant (<i>Treg</i>) (&gt;= 0).
+      reg:
+        slot_uri: cim:GovHydroWPID.reg
+        range: PU
+        multivalued: false
+        required: true
+        description: Permanent drop (<i>Reg</i>).
+      kp:
+        slot_uri: cim:GovHydroWPID.kp
+        range: PU
+        multivalued: false
+        required: true
+        description: Proportional gain (<i>Kp</i>).  Typical value = 0,1.
+      ki:
+        slot_uri: cim:GovHydroWPID.ki
+        range: PU
+        multivalued: false
+        required: true
+        description: Reset gain (<i>Ki</i>).  Typical value = 0,36.
+      kd:
+        slot_uri: cim:GovHydroWPID.kd
+        range: PU
+        multivalued: false
+        required: true
+        description: Derivative gain (<i>Kd</i>).  Typical value = 1,11.
+      ta:
+        slot_uri: cim:GovHydroWPID.ta
+        range: Seconds
+        multivalued: false
+        required: true
+        description: Controller time constant (<i>Ta</i>) (&gt;= 0).  Typical value
+          = 0.
+      tb:
+        slot_uri: cim:GovHydroWPID.tb
+        range: Seconds
+        multivalued: false
+        required: true
+        description: Gate servo time constant (<i>Tb</i>) (&gt;= 0).  Typical value
+          = 0.
+      velmax:
+        slot_uri: cim:GovHydroWPID.velmax
+        range: PU
+        multivalued: false
+        required: true
+        description: Maximum gate opening velocity (<i>Velmax</i>) (&gt; GovHydroWPID.velmin).  Unit
+          = PU / s.  Typical value = 0.
+      velmin:
+        slot_uri: cim:GovHydroWPID.velmin
+        range: PU
+        multivalued: false
+        required: true
+        description: Maximum gate closing velocity (<i>Velmin</i>) (&lt; GovHydroWPID.velmax).  Unit
+          = PU / s.  Typical value = 0.
+      gatmax:
+        slot_uri: cim:GovHydroWPID.gatmax
+        range: PU
+        multivalued: false
+        required: true
+        description: Gate opening limit maximum (<i>Gatmax</i>) (&gt; GovHydroWPID.gatmin).
+      gatmin:
+        slot_uri: cim:GovHydroWPID.gatmin
+        range: PU
+        multivalued: false
+        required: true
+        description: Gate opening limit minimum (<i>Gatmin</i>) (&lt; GovHydroWPID.gatmax).
+      tw:
+        slot_uri: cim:GovHydroWPID.tw
+        range: Seconds
+        multivalued: false
+        required: true
+        description: Water inertia time constant (<i>Tw</i>) (&gt;= 0).  Typical value
+          = 0.
+      pmax:
+        slot_uri: cim:GovHydroWPID.pmax
+        range: PU
+        multivalued: false
+        required: true
+        description: Maximum power output (<i>Pmax</i>) (&gt; GovHydroWPID.pmin).
+      pmin:
+        slot_uri: cim:GovHydroWPID.pmin
+        range: PU
+        multivalued: false
+        required: true
+        description: Minimum power output (<i>Pmin</i>) (&lt; GovHydroWPID.pmax).
+      d:
+        slot_uri: cim:GovHydroWPID.d
+        range: PU
+        multivalued: false
+        required: true
+        description: Turbine damping factor (<i>D</i>).  Unit = delta P / delta speed.
+      gv3:
+        slot_uri: cim:GovHydroWPID.gv3
+        range: PU
+        multivalued: false
+        required: true
+        description: Gate position 3 (<i>Gv3</i>) (= 1,0).
+      gv1:
+        slot_uri: cim:GovHydroWPID.gv1
+        range: PU
+        multivalued: false
+        required: true
+        description: Gate position 1 (<i>Gv1</i>).
+      pgv1:
+        slot_uri: cim:GovHydroWPID.pgv1
+        range: PU
+        multivalued: false
+        required: true
+        description: Output at <i>Gv1</i> PU of <i>MWbase</i> (<i>Pgv1</i>).
+      gv2:
+        slot_uri: cim:GovHydroWPID.gv2
+        range: PU
+        multivalued: false
+        required: true
+        description: Gate position 2 (<i>Gv2</i>).
+      pgv2:
+        slot_uri: cim:GovHydroWPID.pgv2
+        range: PU
+        multivalued: false
+        required: true
+        description: Output at <i>Gv2</i> PU of <i>MWbase</i> (<i>Pgv2</i>).
+      pgv3:
+        slot_uri: cim:GovHydroWPID.pgv3
+        range: PU
+        multivalued: false
+        required: true
+        description: Output at <i>Gv3</i> PU of <i>MWbase</i> (<i>Pgv3</i>).
+    is_a: TurbineGovernorDynamics
+    description: 'Woodward<sup>TM</sup> PID hydro governor.
+
+      [Footnote: Woodward PID hydro governors are an example of suitable products
+      available commercially. This information is given for the convenience of users
+      of this document and does not constitute an endorsement by IEC of these products.]'
+  GovSteam0:
+    class_uri: cim:GovSteam0
+    attributes:
+      mwbase:
+        slot_uri: cim:GovSteam0.mwbase
+        range: ActivePower
+        multivalued: false
+        required: true
+        description: Base for power values (<i>MWbase</i>) (&gt; 0).  Unit = MW.
+      r:
+        slot_uri: cim:GovSteam0.r
+        range: PU
+        multivalued: false
+        required: true
+        description: Permanent droop (<i>R</i>).  Typical value = 0,05.
+      t1:
+        slot_uri: cim:GovSteam0.t1
+        range: Seconds
+        multivalued: false
+        required: true
+        description: Steam bowl time constant (<i>T1</i>) (&gt; 0).  Typical value
+          = 0,5.
+      vmax:
+        slot_uri: cim:GovSteam0.vmax
+        range: PU
+        multivalued: false
+        required: true
+        description: Maximum valve position, PU of <i>mwcap</i> (<i>Vmax</i>) (&gt;
+          GovSteam0.vmin).  Typical value = 1.
+      vmin:
+        slot_uri: cim:GovSteam0.vmin
+        range: PU
+        multivalued: false
+        required: true
+        description: Minimum valve position, PU of <i>mwcap</i> (<i>Vmin</i>) (&lt;
+          GovSteam0.vmax).  Typical value = 0.
+      t2:
+        slot_uri: cim:GovSteam0.t2
+        range: Seconds
+        multivalued: false
+        required: true
+        description: Numerator time constant of <i>T2</i>/<i>T3</i> block (<i>T2</i>)
+          (&gt;= 0).  Typical value = 3.
+      t3:
+        slot_uri: cim:GovSteam0.t3
+        range: Seconds
+        multivalued: false
+        required: true
+        description: Reheater time constant (<i>T3</i>) (&gt; 0).  Typical value =
+          10.
+      dt:
+        slot_uri: cim:GovSteam0.dt
+        range: PU
+        multivalued: false
+        required: true
+        description: Turbine damping coefficient (<i>Dt</i>).  Unit = delta P / delta
+          speed. Typical value = 0.
+    is_a: TurbineGovernorDynamics
+    description: A simplified steam turbine governor.
+  GovSteam1:
+    class_uri: cim:GovSteam1
+    attributes:
+      mwbase:
+        slot_uri: cim:GovSteam1.mwbase
+        range: ActivePower
+        multivalued: false
+        required: true
+        description: Base for power values (<i>MWbase</i>) (&gt; 0).  Unit = MW.
+      k:
+        slot_uri: cim:GovSteam1.k
+        range: PU
+        multivalued: false
+        required: true
+        description: Governor gain (reciprocal of droop) (<i>K</i>) (&gt; 0).  Typical
+          value = 25.
+      t1:
+        slot_uri: cim:GovSteam1.t1
+        range: Seconds
+        multivalued: false
+        required: true
+        description: Governor lag time constant (<i>T1</i>) (&gt;= 0).  Typical value
+          = 0.
+      t2:
+        slot_uri: cim:GovSteam1.t2
+        range: Seconds
+        multivalued: false
+        required: true
+        description: Governor lead time constant (<i>T2</i>) (&gt;= 0).  Typical value
+          = 0.
+      t3:
+        slot_uri: cim:GovSteam1.t3
+        range: Seconds
+        multivalued: false
+        required: true
+        description: Valve positioner time constant (<i>T3) </i>(&gt; 0).  Typical
+          value = 0,1.
+      uo:
+        slot_uri: cim:GovSteam1.uo
+        range: float
+        multivalued: false
+        required: true
+        description: Maximum valve opening velocity (<i>Uo</i>) (&gt; 0).  Unit =
+          PU / s.  Typical value = 1.
+      uc:
+        slot_uri: cim:GovSteam1.uc
+        range: float
+        multivalued: false
+        required: true
+        description: Maximum valve closing velocity (<i>Uc</i>) (&lt; 0).  Unit =
+          PU / s.  Typical value = -10.
+      pmax:
+        slot_uri: cim:GovSteam1.pmax
+        range: PU
+        multivalued: false
+        required: true
+        description: Maximum valve opening (<i>Pmax</i>) (&gt; GovSteam1.pmin).  Typical
+          value = 1.
+      pmin:
+        slot_uri: cim:GovSteam1.pmin
+        range: PU
+        multivalued: false
+        required: true
+        description: Minimum valve opening (<i>Pmin</i>) (&gt;= 0 and &lt; GovSteam1.pmax).  Typical
+          value = 0.
+      t4:
+        slot_uri: cim:GovSteam1.t4
+        range: Seconds
+        multivalued: false
+        required: true
+        description: Inlet piping/steam bowl time constant (<i>T4</i>) (&gt;= 0).  Typical
+          value = 0,3.
+      k1:
+        slot_uri: cim:GovSteam1.k1
+        range: float
+        multivalued: false
+        required: true
+        description: Fraction of HP shaft power after first boiler pass (<i>K1</i>).  Typical
+          value = 0,2.
+      k2:
+        slot_uri: cim:GovSteam1.k2
+        range: float
+        multivalued: false
+        required: true
+        description: Fraction of LP shaft power after first boiler pass (<i>K2</i>).  Typical
+          value = 0.
+      t5:
+        slot_uri: cim:GovSteam1.t5
+        range: Seconds
+        multivalued: false
+        required: true
+        description: Time constant of second boiler pass (<i>T5</i>) (&gt;= 0).  Typical
+          value = 5.
+      k3:
+        slot_uri: cim:GovSteam1.k3
+        range: float
+        multivalued: false
+        required: true
+        description: Fraction of HP shaft power after second boiler pass (<i>K3</i>).  Typical
+          value = 0,3.
+      k4:
+        slot_uri: cim:GovSteam1.k4
+        range: float
+        multivalued: false
+        required: true
+        description: Fraction of LP shaft power after second boiler pass (<i>K4</i>).  Typical
+          value = 0.
+      t6:
+        slot_uri: cim:GovSteam1.t6
+        range: Seconds
+        multivalued: false
+        required: true
+        description: Time constant of third boiler pass (<i>T6</i>) (&gt;= 0).  Typical
+          value = 0,5.
+      k5:
+        slot_uri: cim:GovSteam1.k5
+        range: float
+        multivalued: false
+        required: true
+        description: Fraction of HP shaft power after third boiler pass (<i>K5</i>).  Typical
+          value = 0,5.
+      k6:
+        slot_uri: cim:GovSteam1.k6
+        range: float
+        multivalued: false
+        required: true
+        description: Fraction of LP shaft power after third boiler pass (<i>K6</i>).  Typical
+          value = 0.
+      t7:
+        slot_uri: cim:GovSteam1.t7
+        range: Seconds
+        multivalued: false
+        required: true
+        description: Time constant of fourth boiler pass (<i>T7</i>) (&gt;= 0).  Typical
+          value = 0.
+      k7:
+        slot_uri: cim:GovSteam1.k7
+        range: float
+        multivalued: false
+        required: true
+        description: Fraction of HP shaft power after fourth boiler pass (<i>K7</i>).  Typical
+          value = 0.
+      k8:
+        slot_uri: cim:GovSteam1.k8
+        range: float
+        multivalued: false
+        required: true
+        description: Fraction of LP shaft power after fourth boiler pass (<i>K8</i>).  Typical
+          value = 0.
+      db1:
+        slot_uri: cim:GovSteam1.db1
+        range: Frequency
+        multivalued: false
+        required: true
+        description: Intentional deadband width (<i>db1</i>).  Unit = Hz.  Typical
+          value = 0.
+      eps:
+        slot_uri: cim:GovSteam1.eps
+        range: Frequency
+        multivalued: false
+        required: true
+        description: Intentional db hysteresis (<i>eps</i>).  Unit = Hz.  Typical
+          value = 0.
+      sdb1:
+        slot_uri: cim:GovSteam1.sdb1
+        range: boolean
+        multivalued: false
+        required: true
+        description: 'Intentional deadband indicator.
+
+          true = intentional deadband is applied
+
+          false = intentional deadband is not applied.
+
+          Typical value = true.'
+      sdb2:
+        slot_uri: cim:GovSteam1.sdb2
+        range: boolean
+        multivalued: false
+        required: true
+        description: 'Unintentional deadband location.
+
+          true = intentional deadband is applied before point "A"
+
+          false = intentional deadband is applied after point "A".
+
+          Typical value = true.'
+      db2:
+        slot_uri: cim:GovSteam1.db2
+        range: ActivePower
+        multivalued: false
+        required: true
+        description: Unintentional deadband (<i>db2</i>).  Unit = MW.  Typical value
+          = 0.
+      valve:
+        slot_uri: cim:GovSteam1.valve
+        range: boolean
+        multivalued: false
+        required: true
+        description: 'Nonlinear valve characteristic.
+
+          true = nonlinear valve characteristic is used
+
+          false = nonlinear valve characteristic is not used.
+
+          Typical value = true.'
+      gv1:
+        slot_uri: cim:GovSteam1.gv1
+        range: PU
+        multivalued: false
+        required: true
+        description: Nonlinear gain valve position point 1 (<i>GV1</i>).  Typical
+          value = 0.
+      pgv1:
+        slot_uri: cim:GovSteam1.pgv1
+        range: PU
+        multivalued: false
+        required: true
+        description: Nonlinear gain power value point 1 (<i>Pgv1</i>).  Typical value
+          = 0.
+      gv2:
+        slot_uri: cim:GovSteam1.gv2
+        range: PU
+        multivalued: false
+        required: true
+        description: Nonlinear gain valve position point 2 (<i>GV2</i>).  Typical
+          value = 0,4.
+      pgv2:
+        slot_uri: cim:GovSteam1.pgv2
+        range: PU
+        multivalued: false
+        required: true
+        description: Nonlinear gain power value point 2 (<i>Pgv2</i>).  Typical value
+          = 0,75.
+      gv3:
+        slot_uri: cim:GovSteam1.gv3
+        range: PU
+        multivalued: false
+        required: true
+        description: Nonlinear gain valve position point 3 (<i>GV3</i>).  Typical
+          value = 0,5.
+      pgv3:
+        slot_uri: cim:GovSteam1.pgv3
+        range: PU
+        multivalued: false
+        required: true
+        description: Nonlinear gain power value point 3 (<i>Pgv3</i>).  Typical value
+          = 0,91.
+      gv4:
+        slot_uri: cim:GovSteam1.gv4
+        range: PU
+        multivalued: false
+        required: true
+        description: Nonlinear gain valve position point 4 (<i>GV4</i>).  Typical
+          value = 0,6.
+      pgv4:
+        slot_uri: cim:GovSteam1.pgv4
+        range: PU
+        multivalued: false
+        required: true
+        description: Nonlinear gain power value point 4 (<i>Pgv4</i>).  Typical value
+          = 0,98.
+      gv5:
+        slot_uri: cim:GovSteam1.gv5
+        range: PU
+        multivalued: false
+        required: true
+        description: Nonlinear gain valve position point 5 (<i>GV5</i>).  Typical
+          value = 1.
+      pgv5:
+        slot_uri: cim:GovSteam1.pgv5
+        range: PU
+        multivalued: false
+        required: true
+        description: Nonlinear gain power value point 5 (<i>Pgv5</i>).  Typical value
+          = 1.
+      gv6:
+        slot_uri: cim:GovSteam1.gv6
+        range: PU
+        multivalued: false
+        required: true
+        description: Nonlinear gain valve position point 6 (<i>GV6</i>).  Typical
+          value = 0.
+      pgv6:
+        slot_uri: cim:GovSteam1.pgv6
+        range: PU
+        multivalued: false
+        required: true
+        description: Nonlinear gain power value point 6 (<i>Pgv6</i>).  Typical value
+          = 0.
+    is_a: TurbineGovernorDynamics
+    description: Steam turbine governor, based on the GovSteamIEEE1 (with optional
+      deadband and nonlinear valve gain added).
+  GovSteam2:
+    class_uri: cim:GovSteam2
+    attributes:
+      k:
+        slot_uri: cim:GovSteam2.k
+        range: float
+        multivalued: false
+        required: true
+        description: Governor gain (reciprocal of droop) (<i>K</i>).  Typical value
+          = 20.
+      dbf:
+        slot_uri: cim:GovSteam2.dbf
+        range: PU
+        multivalued: false
+        required: true
+        description: Frequency deadband (<i>DBF</i>).  Typical value = 0.
+      t1:
+        slot_uri: cim:GovSteam2.t1
+        range: Seconds
+        multivalued: false
+        required: true
+        description: Governor lag time constant (<i>T</i><i><sub>1</sub></i>) (&gt;
+          0).  Typical value = 0,45.
+      t2:
+        slot_uri: cim:GovSteam2.t2
+        range: Seconds
+        multivalued: false
+        required: true
+        description: Governor lead time constant (<i>T</i><i><sub>2</sub></i>) (&gt;=
+          0).  Typical value = 0.
+      pmax:
+        slot_uri: cim:GovSteam2.pmax
+        range: PU
+        multivalued: false
+        required: true
+        description: Maximum fuel flow (<i>P</i><i><sub>MAX</sub></i>) (&gt; GovSteam2.pmin).  Typical
+          value = 1.
+      pmin:
+        slot_uri: cim:GovSteam2.pmin
+        range: PU
+        multivalued: false
+        required: true
+        description: Minimum fuel flow (<i>P</i><i><sub>MIN</sub></i>) (&lt; GovSteam2.pmax).  Typical
+          value = 0.
+      mxef:
+        slot_uri: cim:GovSteam2.mxef
+        range: PU
+        multivalued: false
+        required: true
+        description: Fuel flow maximum positive error value (<i>MX</i><i><sub>EF</sub></i>).  Typical
+          value = 1.
+      mnef:
+        slot_uri: cim:GovSteam2.mnef
+        range: PU
+        multivalued: false
+        required: true
+        description: Fuel flow maximum negative error value (<i>MN</i><i><sub>EF</sub></i>).  Typical
+          value = -1.
+    is_a: TurbineGovernorDynamics
+    description: Simplified governor.
+  GovSteamBB:
+    class_uri: cim:GovSteamBB
+    attributes:
+      fcut:
+        slot_uri: cim:GovSteamBB.fcut
+        range: PU
+        multivalued: false
+        required: true
+        description: Frequency deadband (<i>f</i><i><sub>cut</sub></i>) (&gt;= 0).  Typical
+          value = 0,002.
+      ks:
+        slot_uri: cim:GovSteamBB.ks
+        range: PU
+        multivalued: false
+        required: true
+        description: Gain (<i>Ks</i>).  Typical value = 21,0.
+      kls:
+        slot_uri: cim:GovSteamBB.kls
+        range: PU
+        multivalued: false
+        required: true
+        description: Gain (<i>Kls</i>) (&gt; 0).  Typical value = 0,1.
+      kg:
+        slot_uri: cim:GovSteamBB.kg
+        range: PU
+        multivalued: false
+        required: true
+        description: Gain (<i>Kg</i>).  Typical value = 1,0.
+      t1:
+        slot_uri: cim:GovSteamBB.t1
+        range: Seconds
+        multivalued: false
+        required: true
+        description: Time constant (<i>T1</i>).  Typical value = 0,05.
+      kp:
+        slot_uri: cim:GovSteamBB.kp
+        range: PU
+        multivalued: false
+        required: true
+        description: Gain (<i>Kp</i>).  Typical value = 1,0.
+      tn:
+        slot_uri: cim:GovSteamBB.tn
+        range: Seconds
+        multivalued: false
+        required: true
+        description: Time constant (<i>Tn</i>) (&gt; 0).  Typical value = 1,0.
+      kd:
+        slot_uri: cim:GovSteamBB.kd
+        range: PU
+        multivalued: false
+        required: true
+        description: Gain (<i>Kd</i>).  Typical value = 1,0.
+      td:
+        slot_uri: cim:GovSteamBB.td
+        range: Seconds
+        multivalued: false
+        required: true
+        description: Time constant (<i>Td</i>) (&gt; 0).  Typical value = 1,0.
+      pmax:
+        slot_uri: cim:GovSteamBB.pmax
+        range: PU
+        multivalued: false
+        required: true
+        description: High power limit (<i>Pmax</i>) (&gt; GovSteamBB.pmin).  Typical
+          value = 1,0.
+      pmin:
+        slot_uri: cim:GovSteamBB.pmin
+        range: PU
+        multivalued: false
+        required: true
+        description: Low power limit (<i>Pmin</i>) (&lt; GovSteamBB.pmax).  Typical
+          value = 0.
+      t4:
+        slot_uri: cim:GovSteamBB.t4
+        range: Seconds
+        multivalued: false
+        required: true
+        description: Time constant (<i>T4</i>).  Typical value = 0,15.
+      k2:
+        slot_uri: cim:GovSteamBB.k2
+        range: PU
+        multivalued: false
+        required: true
+        description: Gain (<i>K2</i>).  Typical value = 0,75.
+      t5:
+        slot_uri: cim:GovSteamBB.t5
+        range: Seconds
+        multivalued: false
+        required: true
+        description: Time constant (<i>T5</i>).  Typical value = 12,0.
+      k3:
+        slot_uri: cim:GovSteamBB.k3
+        range: PU
+        multivalued: false
+        required: true
+        description: Gain (<i>K3</i>).  Typical value = 0,5.
+      t6:
+        slot_uri: cim:GovSteamBB.t6
+        range: Seconds
+        multivalued: false
+        required: true
+        description: Time constant (<i>T6</i>).  Typical value = 0,75.
+      peflag:
+        slot_uri: cim:GovSteamBB.peflag
+        range: boolean
+        multivalued: false
+        required: true
+        description: "Electric power input selection (Peflag).  \ntrue = electric\
+          \ power input\nfalse = feedback signal.\nTypical value = false."
+    is_a: TurbineGovernorDynamics
+    description: European governor model.
+  GovSteamCC:
+    class_uri: cim:GovSteamCC
+    attributes:
+      mwbase:
+        slot_uri: cim:GovSteamCC.mwbase
+        range: ActivePower
+        multivalued: false
+        required: true
+        description: Base for power values (<i>MWbase</i>) (&gt; 0).  Unit = MW.
+      pmaxhp:
+        slot_uri: cim:GovSteamCC.pmaxhp
+        range: PU
+        multivalued: false
+        required: true
+        description: Maximum HP value position (<i>Pmaxhp</i>).  Typical value = 1.
+      rhp:
+        slot_uri: cim:GovSteamCC.rhp
+        range: PU
+        multivalued: false
+        required: true
+        description: HP governor droop (<i>Rhp</i>) (&gt; 0).  Typical value = 0,05.
+      t1hp:
+        slot_uri: cim:GovSteamCC.t1hp
+        range: Seconds
+        multivalued: false
+        required: true
+        description: HP governor time constant (<i>T1hp</i>) (&gt;= 0).  Typical value
+          = 0,1.
+      t3hp:
+        slot_uri: cim:GovSteamCC.t3hp
+        range: Seconds
+        multivalued: false
+        required: true
+        description: HP turbine time constant (<i>T3hp</i>) (&gt;= 0).  Typical value
+          = 0,1.
+      t4hp:
+        slot_uri: cim:GovSteamCC.t4hp
+        range: Seconds
+        multivalued: false
+        required: true
+        description: HP turbine time constant (<i>T4hp</i>) (&gt;= 0).  Typical value
+          = 0,1.
+      t5hp:
+        slot_uri: cim:GovSteamCC.t5hp
+        range: Seconds
+        multivalued: false
+        required: true
+        description: HP reheater time constant (<i>T5hp</i>) (&gt;= 0).  Typical value
+          = 10.
+      fhp:
+        slot_uri: cim:GovSteamCC.fhp
+        range: PU
+        multivalued: false
+        required: true
+        description: Fraction of HP power ahead of reheater (<i>Fhp</i>).  Typical
+          value = 0,3.
+      dhp:
+        slot_uri: cim:GovSteamCC.dhp
+        range: PU
+        multivalued: false
+        required: true
+        description: HP damping factor (<i>Dhp</i>).  Typical value = 0.
+      pmaxlp:
+        slot_uri: cim:GovSteamCC.pmaxlp
+        range: PU
+        multivalued: false
+        required: true
+        description: Maximum LP value position (<i>Pmaxlp</i>).  Typical value = 1.
+      rlp:
+        slot_uri: cim:GovSteamCC.rlp
+        range: PU
+        multivalued: false
+        required: true
+        description: LP governor droop (<i>Rlp</i>) (&gt; 0).  Typical value = 0,05.
+      t1lp:
+        slot_uri: cim:GovSteamCC.t1lp
+        range: Seconds
+        multivalued: false
+        required: true
+        description: LP governor time constant (<i>T1lp</i>) (&gt;= 0).  Typical value
+          = 0,1.
+      t3lp:
+        slot_uri: cim:GovSteamCC.t3lp
+        range: Seconds
+        multivalued: false
+        required: true
+        description: LP turbine time constant (<i>T3lp</i>) (&gt;= 0).  Typical value
+          = 0,1.
+      t4lp:
+        slot_uri: cim:GovSteamCC.t4lp
+        range: Seconds
+        multivalued: false
+        required: true
+        description: LP turbine time constant (<i>T4lp</i>) (&gt;= 0).  Typical value
+          = 0,1.
+      t5lp:
+        slot_uri: cim:GovSteamCC.t5lp
+        range: Seconds
+        multivalued: false
+        required: true
+        description: LP reheater time constant (<i>T5lp</i>) (&gt;= 0).  Typical value
+          = 10.
+      flp:
+        slot_uri: cim:GovSteamCC.flp
+        range: PU
+        multivalued: false
+        required: true
+        description: Fraction of LP power ahead of reheater (<i>Flp</i>).  Typical
+          value = 0,7.
+      dlp:
+        slot_uri: cim:GovSteamCC.dlp
+        range: PU
+        multivalued: false
+        required: true
+        description: LP damping factor (<i>Dlp</i>).  Typical value = 0.
+    is_a: CrossCompoundTurbineGovernorDynamics
+    description: Cross compound turbine governor.  Unlike tandem compound units, cross
+      compound units are not on the same shaft.
+  GovSteamEU:
+    class_uri: cim:GovSteamEU
+    attributes:
+      mwbase:
+        slot_uri: cim:GovSteamEU.mwbase
+        range: ActivePower
+        multivalued: false
+        required: true
+        description: Base for power values (<i>MWbase</i>) (&gt; 0).  Unit = MW.
+      tp:
+        slot_uri: cim:GovSteamEU.tp
+        range: Seconds
+        multivalued: false
+        required: true
+        description: Power transducer time constant (<i>Tp</i>) (&gt;= 0).  Typical
+          value = 0,07.
+      ke:
+        slot_uri: cim:GovSteamEU.ke
+        range: PU
+        multivalued: false
+        required: true
+        description: Gain of the power controller (<i>Ke</i>).  Typical value = 0,65.
+      tip:
+        slot_uri: cim:GovSteamEU.tip
+        range: Seconds
+        multivalued: false
+        required: true
+        description: Integral time constant of the power controller (<i>Tip</i>) (&gt;=
+          0).  Typical value = 2.
+      tdp:
+        slot_uri: cim:GovSteamEU.tdp
+        range: Seconds
+        multivalued: false
+        required: true
+        description: Derivative time constant of the power controller (<i>Tdp</i>)
+          (&gt;= 0).  Typical value = 0.
+      tfp:
+        slot_uri: cim:GovSteamEU.tfp
+        range: Seconds
+        multivalued: false
+        required: true
+        description: Time constant of the power controller (<i>Tfp</i>) (&gt;= 0).  Typical
+          value = 0.
+      tf:
+        slot_uri: cim:GovSteamEU.tf
+        range: Seconds
+        multivalued: false
+        required: true
+        description: Frequency transducer time constant (<i>Tf</i>) (&gt;= 0).  Typical
+          value = 0.
+      kfcor:
+        slot_uri: cim:GovSteamEU.kfcor
+        range: PU
+        multivalued: false
+        required: true
+        description: Gain of the frequency corrector (<i>Kfcor</i>).  Typical value
+          = 20.
+      db1:
+        slot_uri: cim:GovSteamEU.db1
+        range: PU
+        multivalued: false
+        required: true
+        description: Deadband of the frequency corrector (<i>db1</i>).  Typical value
+          = 0.
+      wfmax:
+        slot_uri: cim:GovSteamEU.wfmax
+        range: PU
+        multivalued: false
+        required: true
+        description: Upper limit for frequency correction (<i>Wfmax</i>) (&gt; GovSteamEU.wfmin).  Typical
+          value = 0,05.
+      wfmin:
+        slot_uri: cim:GovSteamEU.wfmin
+        range: PU
+        multivalued: false
+        required: true
+        description: Lower limit for frequency correction (<i>Wfmin</i>) (&lt; GovSteamEU.wfmax).  Typical
+          value = -0,05.
+      pmax:
+        slot_uri: cim:GovSteamEU.pmax
+        range: PU
+        multivalued: false
+        required: true
+        description: Maximal active power of the turbine (<i>Pmax</i>).  Typical value
+          = 1.
+      ten:
+        slot_uri: cim:GovSteamEU.ten
+        range: Seconds
+        multivalued: false
+        required: true
+        description: Electro hydraulic transducer (<i>Ten</i>) (&gt;= 0).  Typical
+          value = 0,1.
+      tw:
+        slot_uri: cim:GovSteamEU.tw
+        range: Seconds
+        multivalued: false
+        required: true
+        description: Speed transducer time constant (<i>Tw</i>) (&gt;= 0).  Typical
+          value = 0,02.
+      komegacor:
+        slot_uri: cim:GovSteamEU.komegacor
+        range: PU
+        multivalued: false
+        required: true
+        description: Gain of the speed governor (<i>Kwcor</i>).  Typical value = 20.
+      db2:
+        slot_uri: cim:GovSteamEU.db2
+        range: PU
+        multivalued: false
+        required: true
+        description: Deadband of the speed governor (<i>db2</i>).  Typical value =
+          0,0004.
+      wwmax:
+        slot_uri: cim:GovSteamEU.wwmax
+        range: PU
+        multivalued: false
+        required: true
+        description: Upper limit for the speed governor (<i>Wwmax</i>) (&gt; GovSteamEU.wwmin).  Typical
+          value = 0,1.
+      wwmin:
+        slot_uri: cim:GovSteamEU.wwmin
+        range: PU
+        multivalued: false
+        required: true
+        description: Lower limit for the speed governor frequency correction (<i>Wwmin</i>)
+          (&lt; GovSteamEU.wwmax).  Typical value = -1.
+      wmax1:
+        slot_uri: cim:GovSteamEU.wmax1
+        range: PU
+        multivalued: false
+        required: true
+        description: Emergency speed control lower limit (<i>wmax1</i>).  Typical
+          value = 1,025.
+      wmax2:
+        slot_uri: cim:GovSteamEU.wmax2
+        range: PU
+        multivalued: false
+        required: true
+        description: Emergency speed control upper limit (<i>wmax2</i>).  Typical
+          value = 1,05.
+      tvhp:
+        slot_uri: cim:GovSteamEU.tvhp
+        range: Seconds
+        multivalued: false
+        required: true
+        description: Control valves servo time constant (<i>Tvhp</i>) (&gt;= 0).  Typical
+          value = 0,1.
+      cho:
+        slot_uri: cim:GovSteamEU.cho
+        range: float
+        multivalued: false
+        required: true
+        description: Control valves rate opening limit (<i>Cho</i>).  Unit = PU /
+          s.  Typical value = 0,17.
+      chc:
+        slot_uri: cim:GovSteamEU.chc
+        range: float
+        multivalued: false
+        required: true
+        description: Control valves rate closing limit (<i>Chc</i>).  Unit = PU /
+          s.  Typical value = -3,3.
+      hhpmax:
+        slot_uri: cim:GovSteamEU.hhpmax
+        range: PU
+        multivalued: false
+        required: true
+        description: Maximum control valve position (<i>Hhpmax</i>).  Typical value
+          = 1.
+      tvip:
+        slot_uri: cim:GovSteamEU.tvip
+        range: Seconds
+        multivalued: false
+        required: true
+        description: Intercept valves servo time constant (<i>Tvip</i>) (&gt;= 0).  Typical
+          value = 0,15.
+      cio:
+        slot_uri: cim:GovSteamEU.cio
+        range: PU
+        multivalued: false
+        required: true
+        description: Intercept valves rate opening limit (<i>Cio</i>).  Typical value
+          = 0,123.
+      cic:
+        slot_uri: cim:GovSteamEU.cic
+        range: PU
+        multivalued: false
+        required: true
+        description: Intercept valves rate closing limit (<i>Cic</i>).  Typical value
+          = -2,2.
+      simx:
+        slot_uri: cim:GovSteamEU.simx
+        range: PU
+        multivalued: false
+        required: true
+        description: Intercept valves transfer limit (<i>Simx</i>).  Typical value
+          = 0,425.
+      thp:
+        slot_uri: cim:GovSteamEU.thp
+        range: Seconds
+        multivalued: false
+        required: true
+        description: High pressure (HP) time constant of the turbine (<i>Thp</i>)
+          (&gt;= 0).  Typical value = 0,31.
+      trh:
+        slot_uri: cim:GovSteamEU.trh
+        range: Seconds
+        multivalued: false
+        required: true
+        description: Reheater  time constant of the turbine (<i>Trh</i>) (&gt;= 0).  Typical
+          value = 8.
+      tlp:
+        slot_uri: cim:GovSteamEU.tlp
+        range: Seconds
+        multivalued: false
+        required: true
+        description: Low pressure (LP) time constant of the turbine (<i>Tlp</i>) (&gt;=
+          0).  Typical value = 0,45.
+      prhmax:
+        slot_uri: cim:GovSteamEU.prhmax
+        range: PU
+        multivalued: false
+        required: true
+        description: Maximum low pressure limit (<i>Prhmax</i>).  Typical value =
+          1,4.
+      khp:
+        slot_uri: cim:GovSteamEU.khp
+        range: PU
+        multivalued: false
+        required: true
+        description: Fraction of total turbine output generated by HP part (<i>Khp</i>).  Typical
+          value = 0,277.
+      klp:
+        slot_uri: cim:GovSteamEU.klp
+        range: PU
+        multivalued: false
+        required: true
+        description: Fraction of total turbine output generated by HP part (<i>Klp</i>).  Typical
+          value = 0,723.
+      tb:
+        slot_uri: cim:GovSteamEU.tb
+        range: Seconds
+        multivalued: false
+        required: true
+        description: Boiler time constant (<i>Tb</i>) (&gt;= 0).  Typical value =
+          100.
+    is_a: TurbineGovernorDynamics
+    description: Simplified boiler and steam turbine with PID governor.
+  GovSteamFV2:
+    class_uri: cim:GovSteamFV2
+    attributes:
+      mwbase:
+        slot_uri: cim:GovSteamFV2.mwbase
+        range: ActivePower
+        multivalued: false
+        required: true
+        description: Alternate base used instead of machine base in equipment model
+          if necessary (<i>MWbase</i>) (&gt; 0).  Unit = MW.
+      t1:
+        slot_uri: cim:GovSteamFV2.t1
+        range: Seconds
+        multivalued: false
+        required: true
+        description: Governor time constant (<i>T1</i>) (&gt;= 0).
+      vmax:
+        slot_uri: cim:GovSteamFV2.vmax
+        range: PU
+        multivalued: false
+        required: true
+        description: (<i>Vmax</i>) (&gt; GovSteamFV2.vmin).
+      vmin:
+        slot_uri: cim:GovSteamFV2.vmin
+        range: PU
+        multivalued: false
+        required: true
+        description: (<i>Vmin</i>) (&lt; GovSteamFV2.vmax).
+      k:
+        slot_uri: cim:GovSteamFV2.k
+        range: PU
+        multivalued: false
+        required: true
+        description: Fraction of the turbine power developed by turbine sections not
+          involved in fast valving (<i>K</i>).
+      t3:
+        slot_uri: cim:GovSteamFV2.t3
+        range: Seconds
+        multivalued: false
+        required: true
+        description: Reheater time constant (<i>T3</i>) (&gt;= 0).
+      dt:
+        slot_uri: cim:GovSteamFV2.dt
+        range: PU
+        multivalued: false
+        required: true
+        description: (<i>Dt</i>).
+      tt:
+        slot_uri: cim:GovSteamFV2.tt
+        range: Seconds
+        multivalued: false
+        required: true
+        description: Time constant with which power falls off after intercept valve
+          closure (<i>Tt</i>) (&gt;= 0).
+      r:
+        slot_uri: cim:GovSteamFV2.r
+        range: PU
+        multivalued: false
+        required: true
+        description: (<i>R</i>).
+      ta:
+        slot_uri: cim:GovSteamFV2.ta
+        range: Seconds
+        multivalued: false
+        required: true
+        description: Time after initial time for valve to close (<i>Ta</i>) (&gt;=
+          0).
+      tb:
+        slot_uri: cim:GovSteamFV2.tb
+        range: Seconds
+        multivalued: false
+        required: true
+        description: Time after initial time for valve to begin opening (<i>Tb</i>)
+          (&gt;= 0).
+      tc:
+        slot_uri: cim:GovSteamFV2.tc
+        range: Seconds
+        multivalued: false
+        required: true
+        description: Time after initial time for valve to become fully open (<i>Tc</i>)
+          (&gt;= 0).
+    is_a: TurbineGovernorDynamics
+    description: Steam turbine governor with reheat time constants and modelling of
+      the effects of fast valve closing to reduce mechanical power.
+  GovSteamFV3:
+    class_uri: cim:GovSteamFV3
+    attributes:
+      mwbase:
+        slot_uri: cim:GovSteamFV3.mwbase
+        range: ActivePower
+        multivalued: false
+        required: true
+        description: Base for power values (<i>MWbase</i>) (&gt; 0).  Unit = MW.
+      k:
+        slot_uri: cim:GovSteamFV3.k
+        range: PU
+        multivalued: false
+        required: true
+        description: Governor gain, (reciprocal of droop) (<i>K</i>).  Typical value
+          = 20.
+      t1:
+        slot_uri: cim:GovSteamFV3.t1
+        range: Seconds
+        multivalued: false
+        required: true
+        description: Governor lead time constant (<i>T1</i>) (&gt;= 0).  Typical value
+          = 0.
+      t2:
+        slot_uri: cim:GovSteamFV3.t2
+        range: Seconds
+        multivalued: false
+        required: true
+        description: Governor lag time constant (<i>T2</i>) (&gt;= 0).  Typical value
+          = 0.
+      t3:
+        slot_uri: cim:GovSteamFV3.t3
+        range: Seconds
+        multivalued: false
+        required: true
+        description: Valve positioner time constant (<i>T3</i>) (&gt; 0).  Typical
+          value = 0.
+      uo:
+        slot_uri: cim:GovSteamFV3.uo
+        range: float
+        multivalued: false
+        required: true
+        description: Maximum valve opening velocity (<i>Uo</i>).  Unit = PU / s.  Typical
+          value = 0,1.
+      uc:
+        slot_uri: cim:GovSteamFV3.uc
+        range: float
+        multivalued: false
+        required: true
+        description: Maximum valve closing velocity (<i>Uc</i>).  Unit = PU / s.  Typical
+          value = -1.
+      pmax:
+        slot_uri: cim:GovSteamFV3.pmax
+        range: PU
+        multivalued: false
+        required: true
+        description: Maximum valve opening, PU of <i>MWbase</i> (<i>Pmax</i>) (&gt;
+          GovSteamFV3.pmin).  Typical value = 1.
+      pmin:
+        slot_uri: cim:GovSteamFV3.pmin
+        range: PU
+        multivalued: false
+        required: true
+        description: Minimum valve opening, PU of <i>MWbase</i> (<i>Pmin</i>) (&lt;
+          GovSteamFV3.pmax).  Typical value = 0.
+      t4:
+        slot_uri: cim:GovSteamFV3.t4
+        range: Seconds
+        multivalued: false
+        required: true
+        description: Inlet piping/steam bowl time constant (<i>T4</i>) (&gt;= 0).  Typical
+          value = 0,2.
+      k1:
+        slot_uri: cim:GovSteamFV3.k1
+        range: PU
+        multivalued: false
+        required: true
+        description: Fraction of turbine power developed after first boiler pass (<i>K1</i>).  Typical
+          value = 0,2.
+      t5:
+        slot_uri: cim:GovSteamFV3.t5
+        range: Seconds
+        multivalued: false
+        required: true
+        description: Time constant of second boiler pass (i.e. reheater) (<i>T5</i>)
+          (&gt; 0 if fast valving is used, otherwise &gt;= 0).  Typical value = 0,5.
+      k2:
+        slot_uri: cim:GovSteamFV3.k2
+        range: PU
+        multivalued: false
+        required: true
+        description: Fraction of turbine power developed after second boiler pass
+          (<i>K2</i>).  Typical value = 0,2.
+      t6:
+        slot_uri: cim:GovSteamFV3.t6
+        range: Seconds
+        multivalued: false
+        required: true
+        description: Time constant of crossover or third boiler pass (<i>T6</i>) (&gt;=
+          0).  Typical value = 10.
+      k3:
+        slot_uri: cim:GovSteamFV3.k3
+        range: PU
+        multivalued: false
+        required: true
+        description: Fraction of hp turbine power developed after crossover or third
+          boiler pass (<i>K3</i>). Typical value = 0,6.
+      ta:
+        slot_uri: cim:GovSteamFV3.ta
+        range: Seconds
+        multivalued: false
+        required: true
+        description: Time to close intercept valve (IV) (<i>Ta</i>) (&gt;= 0).  Typical
+          value = 0,97.
+      tb:
+        slot_uri: cim:GovSteamFV3.tb
+        range: Seconds
+        multivalued: false
+        required: true
+        description: Time until IV starts to reopen (<i>Tb</i>) (&gt;= 0).  Typical
+          value = 0,98.
+      tc:
+        slot_uri: cim:GovSteamFV3.tc
+        range: Seconds
+        multivalued: false
+        required: true
+        description: Time until IV is fully open (<i>Tc</i>) (&gt;= 0).  Typical value
+          = 0,99.
+      prmax:
+        slot_uri: cim:GovSteamFV3.prmax
+        range: PU
+        multivalued: false
+        required: true
+        description: Max. pressure in reheater (<i>Prmax</i>).  Typical value = 1.
+      gv1:
+        slot_uri: cim:GovSteamFV3.gv1
+        range: PU
+        multivalued: false
+        required: true
+        description: Nonlinear gain valve position point 1 (<i>GV1</i>).  Typical
+          value = 0.
+      pgv1:
+        slot_uri: cim:GovSteamFV3.pgv1
+        range: PU
+        multivalued: false
+        required: true
+        description: Nonlinear gain power value point 1 (<i>Pgv1</i>).  Typical value
+          = 0.
+      gv2:
+        slot_uri: cim:GovSteamFV3.gv2
+        range: PU
+        multivalued: false
+        required: true
+        description: Nonlinear gain valve position point 2 (<i>GV2</i>).  Typical
+          value = 0,4.
+      pgv2:
+        slot_uri: cim:GovSteamFV3.pgv2
+        range: PU
+        multivalued: false
+        required: true
+        description: Nonlinear gain power value point 2 (<i>Pgv2</i>).  Typical value
+          = 0,75.
+      gv3:
+        slot_uri: cim:GovSteamFV3.gv3
+        range: PU
+        multivalued: false
+        required: true
+        description: Nonlinear gain valve position point 3 (<i>GV3</i>).  Typical
+          value = 0,5.
+      pgv3:
+        slot_uri: cim:GovSteamFV3.pgv3
+        range: PU
+        multivalued: false
+        required: true
+        description: Nonlinear gain power value point 3 (<i>Pgv3</i>).  Typical value
+          = 0,91.
+      gv4:
+        slot_uri: cim:GovSteamFV3.gv4
+        range: PU
+        multivalued: false
+        required: true
+        description: Nonlinear gain valve position point 4 (<i>GV4</i>).  Typical
+          value = 0,6.
+      pgv4:
+        slot_uri: cim:GovSteamFV3.pgv4
+        range: PU
+        multivalued: false
+        required: true
+        description: Nonlinear gain power value point 4 (<i>Pgv4</i>).  Typical value
+          = 0,98.
+      gv5:
+        slot_uri: cim:GovSteamFV3.gv5
+        range: PU
+        multivalued: false
+        required: true
+        description: Nonlinear gain valve position point 5 (<i>GV5</i>).  Typical
+          value = 1.
+      pgv5:
+        slot_uri: cim:GovSteamFV3.pgv5
+        range: PU
+        multivalued: false
+        required: true
+        description: Nonlinear gain power value point 5 (<i>Pgv5</i>).  Typical value
+          = 1.
+      gv6:
+        slot_uri: cim:GovSteamFV3.gv6
+        range: PU
+        multivalued: false
+        required: true
+        description: Nonlinear gain valve position point 6 (<i>GV6</i>).  Typical
+          value = 0.
+      pgv6:
+        slot_uri: cim:GovSteamFV3.pgv6
+        range: PU
+        multivalued: false
+        required: true
+        description: Nonlinear gain power value point 6 (<i>Pgv6</i>).  Typical value
+          = 0.
+    is_a: TurbineGovernorDynamics
+    description: Simplified GovSteamIEEE1 steam turbine governor with Prmax limit
+      and fast valving.
+  GovSteamFV4:
+    class_uri: cim:GovSteamFV4
+    attributes:
+      kf1:
+        slot_uri: cim:GovSteamFV4.kf1
+        range: PU
+        multivalued: false
+        required: true
+        description: Frequency bias (reciprocal of droop) (<i>Kf1</i>).  Typical value
+          = 20.
+      kf3:
+        slot_uri: cim:GovSteamFV4.kf3
+        range: PU
+        multivalued: false
+        required: true
+        description: Frequency control (reciprocal of droop) (<i>Kf3</i>).  Typical
+          value = 20.
+      lps:
+        slot_uri: cim:GovSteamFV4.lps
+        range: PU
+        multivalued: false
+        required: true
+        description: Maximum positive power error (<i>Lps</i>).  Typical value = 0,03.
+      lpi:
+        slot_uri: cim:GovSteamFV4.lpi
+        range: PU
+        multivalued: false
+        required: true
+        description: Maximum negative power error (<i>Lpi</i>).  Typical value = -0,15.
+      mxef:
+        slot_uri: cim:GovSteamFV4.mxef
+        range: PU
+        multivalued: false
+        required: true
+        description: Upper limit for frequency correction (<i>MX</i><i><sub>EF</sub></i>).  Typical
+          value = 0,05.
+      mnef:
+        slot_uri: cim:GovSteamFV4.mnef
+        range: PU
+        multivalued: false
+        required: true
+        description: Lower limit for frequency correction (<i>MN</i><i><sub>EF</sub></i>).  Typical
+          value = -0,05.
+      crmx:
+        slot_uri: cim:GovSteamFV4.crmx
+        range: PU
+        multivalued: false
+        required: true
+        description: Maximum value of regulator set-point (<i>Crmx</i>).  Typical
+          value = 1,2.
+      crmn:
+        slot_uri: cim:GovSteamFV4.crmn
+        range: PU
+        multivalued: false
+        required: true
+        description: Minimum value of regulator set-point (<i>Crmn</i>).  Typical
+          value = 0.
+      kpt:
+        slot_uri: cim:GovSteamFV4.kpt
+        range: PU
+        multivalued: false
+        required: true
+        description: Proportional gain of electro-hydraulic regulator (<i>Kpt</i>).  Typical
+          value = 0,3.
+      kit:
+        slot_uri: cim:GovSteamFV4.kit
+        range: PU
+        multivalued: false
+        required: true
+        description: Integral gain of electro-hydraulic regulator (<i>Kit</i>).  Typical
+          value = 0,04.
+      rvgmx:
+        slot_uri: cim:GovSteamFV4.rvgmx
+        range: PU
+        multivalued: false
+        required: true
+        description: Maximum value of integral regulator (<i>Rvgmx</i>).  Typical
+          value = 1,2.
+      rvgmn:
+        slot_uri: cim:GovSteamFV4.rvgmn
+        range: PU
+        multivalued: false
+        required: true
+        description: Minimum value of integral regulator (<i>Rvgmn</i>).  Typical
+          value = 0.
+      svmx:
+        slot_uri: cim:GovSteamFV4.svmx
+        range: float
+        multivalued: false
+        required: true
+        description: Maximum regulator gate opening velocity (<i>Svmx</i>).  Typical
+          value = 0,0333.
+      svmn:
+        slot_uri: cim:GovSteamFV4.svmn
+        range: float
+        multivalued: false
+        required: true
+        description: Maximum regulator gate closing velocity (<i>Svmn</i>).  Typical
+          value = -0,0333.
+      srmx:
+        slot_uri: cim:GovSteamFV4.srmx
+        range: PU
+        multivalued: false
+        required: true
+        description: Maximum valve opening (<i>Srmx</i>).  Typical value = 1,1.
+      srmn:
+        slot_uri: cim:GovSteamFV4.srmn
+        range: PU
+        multivalued: false
+        required: true
+        description: Minimum valve opening (<i>Srmn</i>).  Typical value = 0.
+      kpp:
+        slot_uri: cim:GovSteamFV4.kpp
+        range: PU
+        multivalued: false
+        required: true
+        description: Proportional gain of pressure feedback regulator (<i>Kpp</i>).  Typical
+          value = 1.
+      kip:
+        slot_uri: cim:GovSteamFV4.kip
+        range: PU
+        multivalued: false
+        required: true
+        description: Integral gain of pressure feedback regulator (<i>Kip</i>).  Typical
+          value = 0,5.
+      rsmimx:
+        slot_uri: cim:GovSteamFV4.rsmimx
+        range: PU
+        multivalued: false
+        required: true
+        description: Maximum value of integral regulator (<i>Rsmimx</i>).  Typical
+          value = 1,1.
+      rsmimn:
+        slot_uri: cim:GovSteamFV4.rsmimn
+        range: PU
+        multivalued: false
+        required: true
+        description: Minimum value of integral regulator (<i>Rsmimn</i>).  Typical
+          value = 0.
+      kmp1:
+        slot_uri: cim:GovSteamFV4.kmp1
+        range: PU
+        multivalued: false
+        required: true
+        description: First gain coefficient of  intercept valves characteristic (<i>Kmp1</i>).  Typical
+          value = 0,5.
+      kmp2:
+        slot_uri: cim:GovSteamFV4.kmp2
+        range: PU
+        multivalued: false
+        required: true
+        description: Second gain coefficient of intercept valves characteristic (<i>Kmp2</i>).  Typical
+          value = 3,5.
+      srsmp:
+        slot_uri: cim:GovSteamFV4.srsmp
+        range: PU
+        multivalued: false
+        required: true
+        description: Intercept valves characteristic discontinuity point (<i>Srsmp</i>).  Typical
+          value = 0,43.
+      ta:
+        slot_uri: cim:GovSteamFV4.ta
+        range: Seconds
+        multivalued: false
+        required: true
+        description: Control valves rate opening time (<i>Ta</i>) (&gt;= 0).  Typical
+          value = 0,8.
+      tc:
+        slot_uri: cim:GovSteamFV4.tc
+        range: Seconds
+        multivalued: false
+        required: true
+        description: Control valves rate closing time (<i>Tc</i>) (&gt;= 0).  Typical
+          value = 0,5.
+      ty:
+        slot_uri: cim:GovSteamFV4.ty
+        range: Seconds
+        multivalued: false
+        required: true
+        description: Control valves servo time constant (<i>Ty</i>) (&gt;= 0).  Typical
+          value = 0,1.
+      yhpmx:
+        slot_uri: cim:GovSteamFV4.yhpmx
+        range: PU
+        multivalued: false
+        required: true
+        description: Maximum control valve position (<i>Yhpmx</i>).  Typical value
+          = 1,1.
+      yhpmn:
+        slot_uri: cim:GovSteamFV4.yhpmn
+        range: PU
+        multivalued: false
+        required: true
+        description: Minimum control valve position (<i>Yhpmn</i>).  Typical value
+          = 0.
+      tam:
+        slot_uri: cim:GovSteamFV4.tam
+        range: Seconds
+        multivalued: false
+        required: true
+        description: Intercept valves rate opening time (<i>Tam</i>) (&gt;= 0).  Typical
+          value = 0,8.
+      tcm:
+        slot_uri: cim:GovSteamFV4.tcm
+        range: Seconds
+        multivalued: false
+        required: true
+        description: Intercept valves rate closing time (<i>Tcm</i>) (&gt;= 0).  Typical
+          value = 0,5.
+      ympmx:
+        slot_uri: cim:GovSteamFV4.ympmx
+        range: PU
+        multivalued: false
+        required: true
+        description: Maximum intercept valve position (<i>Ympmx</i>).  Typical value
+          = 1,1.
+      ympmn:
+        slot_uri: cim:GovSteamFV4.ympmn
+        range: PU
+        multivalued: false
+        required: true
+        description: Minimum intercept valve position (<i>Ympmn</i>).  Typical value
+          = 0.
+      y:
+        slot_uri: cim:GovSteamFV4.y
+        range: PU
+        multivalued: false
+        required: true
+        description: Coefficient of linearized equations of turbine (Stodola formulation)
+          (<i>Y</i>).  Typical value = 0,13.
+      thp:
+        slot_uri: cim:GovSteamFV4.thp
+        range: Seconds
+        multivalued: false
+        required: true
+        description: High pressure (HP) time constant of the turbine (<i>Thp</i>)
+          (&gt;= 0).  Typical value = 0,15.
+      trh:
+        slot_uri: cim:GovSteamFV4.trh
+        range: Seconds
+        multivalued: false
+        required: true
+        description: Reheater  time constant of the turbine (<i>Trh</i>) (&gt;= 0).  Typical
+          value = 10.
+      tmp:
+        slot_uri: cim:GovSteamFV4.tmp
+        range: Seconds
+        multivalued: false
+        required: true
+        description: Low pressure (LP) time constant of the turbine (<i>Tmp</i>) (&gt;=
+          0).  Typical value = 0,4.
+      khp:
+        slot_uri: cim:GovSteamFV4.khp
+        range: PU
+        multivalued: false
+        required: true
+        description: Fraction  of total turbine output generated by HP part (<i>Khp</i>).  Typical
+          value = 0,35.
+      pr1:
+        slot_uri: cim:GovSteamFV4.pr1
+        range: PU
+        multivalued: false
+        required: true
+        description: First value of pressure set point static characteristic (<i>Pr1</i>).  Typical
+          value = 0,2.
+      pr2:
+        slot_uri: cim:GovSteamFV4.pr2
+        range: PU
+        multivalued: false
+        required: true
+        description: Second value of pressure set point static characteristic, corresponding
+          to <i>Ps0</i> = 1,0 PU (<i>Pr2</i>).  Typical value = 0,75.
+      psmn:
+        slot_uri: cim:GovSteamFV4.psmn
+        range: PU
+        multivalued: false
+        required: true
+        description: Minimum value of pressure set point static characteristic (<i>Psmn</i>).  Typical
+          value = 1.
+      kpc:
+        slot_uri: cim:GovSteamFV4.kpc
+        range: PU
+        multivalued: false
+        required: true
+        description: Proportional gain of pressure regulator (<i>Kpc</i>).  Typical
+          value = 0,5.
+      kic:
+        slot_uri: cim:GovSteamFV4.kic
+        range: PU
+        multivalued: false
+        required: true
+        description: Integral gain of pressure regulator (<i>Kic</i>).  Typical value
+          = 0,0033.
+      kdc:
+        slot_uri: cim:GovSteamFV4.kdc
+        range: PU
+        multivalued: false
+        required: true
+        description: Derivative gain of pressure regulator (<i>Kdc</i>).  Typical
+          value = 1.
+      tdc:
+        slot_uri: cim:GovSteamFV4.tdc
+        range: Seconds
+        multivalued: false
+        required: true
+        description: Derivative time constant of pressure regulator (<i>Tdc</i>) (&gt;=
+          0).  Typical value = 90.
+      cpsmx:
+        slot_uri: cim:GovSteamFV4.cpsmx
+        range: PU
+        multivalued: false
+        required: true
+        description: Maximum value of pressure regulator output (<i>Cpsmx</i>).  Typical
+          value = 1.
+      cpsmn:
+        slot_uri: cim:GovSteamFV4.cpsmn
+        range: PU
+        multivalued: false
+        required: true
+        description: Minimum value of pressure regulator output (<i>Cpsmn</i>).  Typical
+          value = -1.
+      krc:
+        slot_uri: cim:GovSteamFV4.krc
+        range: PU
+        multivalued: false
+        required: true
+        description: Maximum variation of fuel flow (<i>Krc</i>).  Typical value =
+          0,05.
+      tf1:
+        slot_uri: cim:GovSteamFV4.tf1
+        range: Seconds
+        multivalued: false
+        required: true
+        description: Time constant of fuel regulation (<i>Tf1</i>) (&gt;= 0).  Typical
+          value = 10.
+      tf2:
+        slot_uri: cim:GovSteamFV4.tf2
+        range: Seconds
+        multivalued: false
+        required: true
+        description: Time constant of steam chest (<i>Tf2</i>) (&gt;= 0).  Typical
+          value = 10.
+      tv:
+        slot_uri: cim:GovSteamFV4.tv
+        range: Seconds
+        multivalued: false
+        required: true
+        description: Boiler time constant (<i>Tv</i>) (&gt;= 0).  Typical value =
+          60.
+      ksh:
+        slot_uri: cim:GovSteamFV4.ksh
+        range: PU
+        multivalued: false
+        required: true
+        description: Pressure loss due to flow friction in the boiler tubes (<i>Ksh</i>).  Typical
+          value = 0,08.
+    is_a: TurbineGovernorDynamics
+    description: Detailed electro-hydraulic governor for steam unit.
+  GovSteamSGO:
+    class_uri: cim:GovSteamSGO
+    attributes:
+      mwbase:
+        slot_uri: cim:GovSteamSGO.mwbase
+        range: ActivePower
+        multivalued: false
+        required: true
+        description: Base for power values (<i>MWbase</i>) (&gt; 0).  Unit = MW.
+      t1:
+        slot_uri: cim:GovSteamSGO.t1
+        range: Seconds
+        multivalued: false
+        required: true
+        description: Controller lag (<i>T1</i>) (&gt;= 0).
+      t2:
+        slot_uri: cim:GovSteamSGO.t2
+        range: Seconds
+        multivalued: false
+        required: true
+        description: Controller lead compensation (<i>T2</i>) (&gt;= 0).
+      t3:
+        slot_uri: cim:GovSteamSGO.t3
+        range: Seconds
+        multivalued: false
+        required: true
+        description: Governor lag (<i>T3</i>) (&gt; 0).
+      t4:
+        slot_uri: cim:GovSteamSGO.t4
+        range: Seconds
+        multivalued: false
+        required: true
+        description: Delay due to steam inlet volumes associated with steam chest
+          and inlet piping (<i>T4</i>) (&gt;= 0).
+      t5:
+        slot_uri: cim:GovSteamSGO.t5
+        range: Seconds
+        multivalued: false
+        required: true
+        description: Reheater delay including hot and cold leads (<i>T5</i>) (&gt;=
+          0).
+      t6:
+        slot_uri: cim:GovSteamSGO.t6
+        range: Seconds
+        multivalued: false
+        required: true
+        description: Delay due to IP-LP turbine, crossover pipes and LP end hoods
+          (<i>T6</i>) (&gt;= 0).
+      k1:
+        slot_uri: cim:GovSteamSGO.k1
+        range: PU
+        multivalued: false
+        required: true
+        description: One / PU regulation (<i>K1</i>).
+      k2:
+        slot_uri: cim:GovSteamSGO.k2
+        range: PU
+        multivalued: false
+        required: true
+        description: Fraction (<i>K2</i>).
+      k3:
+        slot_uri: cim:GovSteamSGO.k3
+        range: PU
+        multivalued: false
+        required: true
+        description: Fraction (<i>K3</i>).
+      pmax:
+        slot_uri: cim:GovSteamSGO.pmax
+        range: PU
+        multivalued: false
+        required: true
+        description: Upper power limit (<i>Pmax</i>) (&gt; GovSteamSGO.pmin).
+      pmin:
+        slot_uri: cim:GovSteamSGO.pmin
+        range: Seconds
+        multivalued: false
+        required: true
+        description: Lower power limit (<i>Pmin</i>) (&gt;= 0 and &lt; GovSteamSGO.pmax).
+    is_a: TurbineGovernorDynamics
+    description: Simplified steam turbine governor.
+  TurbineLoadControllerDynamics:
+    class_uri: cim:TurbineLoadControllerDynamics
+    attributes:
+      TurbineGovernorDynamics:
+        slot_uri: cim:TurbineLoadControllerDynamics.TurbineGovernorDynamics
+        range: TurbineGovernorDynamics
+        multivalued: false
+        required: true
+        description: Turbine-governor controlled by this turbine load controller.
+    is_a: DynamicsFunctionBlock
+    description: Turbine load controller function block whose behaviour is described
+      by reference to a standard model <font color="#0f0f0f">or by definition of a
+      user-defined model.</font>
+  TurbLCFB1:
+    class_uri: cim:TurbLCFB1
+    attributes:
+      mwbase:
+        slot_uri: cim:TurbLCFB1.mwbase
+        range: ActivePower
+        multivalued: false
+        required: true
+        description: Base for power values (<i>MWbase</i>) (&gt; 0).  Unit = MW.
+      speedReferenceGovernor:
+        slot_uri: cim:TurbLCFB1.speedReferenceGovernor
+        range: boolean
+        multivalued: false
+        required: true
+        description: 'Type of turbine governor reference (<i>Type</i>).
+
+          true = speed reference governor
+
+          false = load reference governor.
+
+          Typical value = true.'
+      db:
+        slot_uri: cim:TurbLCFB1.db
+        range: PU
+        multivalued: false
+        required: true
+        description: Controller deadband (<i>db</i>).  Typical value = 0.
+      emax:
+        slot_uri: cim:TurbLCFB1.emax
+        range: PU
+        multivalued: false
+        required: true
+        description: Maximum control error (<i>Emax</i>) (see parameter detail 4).  Typical
+          value = 0,02.
+      fb:
+        slot_uri: cim:TurbLCFB1.fb
+        range: PU
+        multivalued: false
+        required: true
+        description: Frequency bias gain (<i>Fb</i>).  Typical value = 0.
+      kp:
+        slot_uri: cim:TurbLCFB1.kp
+        range: PU
+        multivalued: false
+        required: true
+        description: Proportional gain (<i>Kp</i>).  Typical value = 0.
+      ki:
+        slot_uri: cim:TurbLCFB1.ki
+        range: PU
+        multivalued: false
+        required: true
+        description: Integral gain (<i>Ki</i>).  Typical value = 0.
+      fbf:
+        slot_uri: cim:TurbLCFB1.fbf
+        range: boolean
+        multivalued: false
+        required: true
+        description: 'Frequency bias flag (<i>Fbf</i>).
+
+          true = enable frequency bias
+
+          false = disable frequency bias.
+
+          Typical value = false.'
+      pbf:
+        slot_uri: cim:TurbLCFB1.pbf
+        range: boolean
+        multivalued: false
+        required: true
+        description: 'Power controller flag (<i>Pbf</i>).
+
+          true = enable load controller
+
+          false = disable load controller.
+
+          Typical value = false.'
+      tpelec:
+        slot_uri: cim:TurbLCFB1.tpelec
+        range: Seconds
+        multivalued: false
+        required: true
+        description: Power transducer time constant (<i>Tpelec</i>) (&gt;= 0).  Typical
+          value = 0.
+      irmax:
+        slot_uri: cim:TurbLCFB1.irmax
+        range: PU
+        multivalued: false
+        required: true
+        description: Maximum turbine speed/load reference bias (<i>Irmax</i>) (see
+          parameter detail 3).  Typical value = 0.
+      pmwset:
+        slot_uri: cim:TurbLCFB1.pmwset
+        range: ActivePower
+        multivalued: false
+        required: true
+        description: Power controller setpoint (<i>Pmwset</i>) (see parameter detail
+          1).  Unit = MW. Typical value = 0.
+    is_a: TurbineLoadControllerDynamics
+    description: Turbine load controller model developed by WECC.  This model represents
+      a supervisory turbine load controller that acts to maintain turbine power at
+      a set value by continuous adjustment of the turbine governor speed-load reference.
+      This model is intended to represent slow reset 'outer loop' controllers managing
+      the action of the turbine governor.
+  MechanicalLoadDynamics:
+    class_uri: cim:MechanicalLoadDynamics
+    attributes:
+      SynchronousMachineDynamics:
+        slot_uri: cim:MechanicalLoadDynamics.SynchronousMachineDynamics
+        range: SynchronousMachineDynamics
+        multivalued: false
+        required: false
+        description: Synchronous machine model with which this mechanical load model
+          is associated. MechanicalLoadDynamics shall have either an association to
+          SynchronousMachineDynamics or AsynchronousMachineDyanmics.
+      AsynchronousMachineDynamics:
+        slot_uri: cim:MechanicalLoadDynamics.AsynchronousMachineDynamics
+        range: AsynchronousMachineDynamics
+        multivalued: false
+        required: false
+        description: Asynchronous machine model with which this mechanical load model
+          is associated. MechanicalLoadDynamics shall have either an association to
+          SynchronousMachineDynamics or to AsynchronousMachineDynamics.
+    is_a: DynamicsFunctionBlock
+    description: Mechanical load function block whose behaviour is described by reference
+      to a standard model <font color="#0f0f0f">or by definition of a user-defined
+      model.</font>
+  MechLoad1:
+    class_uri: cim:MechLoad1
+    attributes:
+      a:
+        slot_uri: cim:MechLoad1.a
+        range: float
+        multivalued: false
+        required: true
+        description: Speed squared coefficient (<i>a</i>).
+      b:
+        slot_uri: cim:MechLoad1.b
+        range: float
+        multivalued: false
+        required: true
+        description: Speed coefficient (<i>b</i>).
+      d:
+        slot_uri: cim:MechLoad1.d
+        range: float
+        multivalued: false
+        required: true
+        description: Speed to the exponent coefficient (<i>d</i>).
+      e:
+        slot_uri: cim:MechLoad1.e
+        range: float
+        multivalued: false
+        required: true
+        description: Exponent (<i>e</i>).
+    is_a: MechanicalLoadDynamics
+    description: Mechanical load model type 1.
+  ExcitationSystemDynamics:
+    class_uri: cim:ExcitationSystemDynamics
+    attributes:
+      SynchronousMachineDynamics:
+        slot_uri: cim:ExcitationSystemDynamics.SynchronousMachineDynamics
+        range: SynchronousMachineDynamics
+        multivalued: false
+        required: true
+        description: Synchronous machine model with which this excitation system model
+          is associated.
+      VoltageCompensatorDynamics:
+        slot_uri: cim:ExcitationSystemDynamics.VoltageCompensatorDynamics
+        range: VoltageCompensatorDynamics
+        multivalued: false
+        required: true
+        description: Voltage compensator model associated with this excitation system
+          model.
+      OverexcitationLimiterDynamics:
+        slot_uri: cim:ExcitationSystemDynamics.OverexcitationLimiterDynamics
+        range: OverexcitationLimiterDynamics
+        multivalued: false
+        required: false
+        description: Overexcitation limiter model associated with this excitation
+          system model.
+      PFVArControllerType2Dynamics:
+        slot_uri: cim:ExcitationSystemDynamics.PFVArControllerType2Dynamics
+        range: PFVArControllerType2Dynamics
+        multivalued: false
+        required: false
+        description: Power factor or VAr controller type 2 model associated with this
+          excitation system model.
+      DiscontinuousExcitationControlDynamics:
+        slot_uri: cim:ExcitationSystemDynamics.DiscontinuousExcitationControlDynamics
+        range: DiscontinuousExcitationControlDynamics
+        multivalued: false
+        required: false
+        description: Discontinuous excitation control model associated with this excitation
+          system model.
+      PowerSystemStabilizerDynamics:
+        slot_uri: cim:ExcitationSystemDynamics.PowerSystemStabilizerDynamics
+        range: PowerSystemStabilizerDynamics
+        multivalued: false
+        required: false
+        description: Power system stabilizer model associated with this excitation
+          system model.
+      UnderexcitationLimiterDynamics:
+        slot_uri: cim:ExcitationSystemDynamics.UnderexcitationLimiterDynamics
+        range: UnderexcitationLimiterDynamics
+        multivalued: false
+        required: false
+        description: Undrexcitation limiter model associated with this excitation
+          system model.
+      PFVArControllerType1Dynamics:
+        slot_uri: cim:ExcitationSystemDynamics.PFVArControllerType1Dynamics
+        range: PFVArControllerType1Dynamics
+        multivalued: false
+        required: false
+        description: Power factor or VAr controller type 1 model associated with this
+          excitation system model.
+    is_a: DynamicsFunctionBlock
+    description: Excitation system function block whose behaviour is described by
+      reference to a standard model <font color="#0f0f0f">or by definition of a user-defined
+      model.</font>
+  ExcIEEEAC1A:
+    class_uri: cim:ExcIEEEAC1A
+    attributes:
+      tb:
+        slot_uri: cim:ExcIEEEAC1A.tb
+        range: Seconds
+        multivalued: false
+        required: true
+        description: Voltage regulator time constant (<i>T</i><i><sub>B</sub></i>)
+          (&gt;= 0).  Typical value = 0.
+      tc:
+        slot_uri: cim:ExcIEEEAC1A.tc
+        range: Seconds
+        multivalued: false
+        required: true
+        description: Voltage regulator time constant (<i>T</i><i><sub>C</sub></i>)
+          (&gt;= 0).  Typical value = 0.
+      ka:
+        slot_uri: cim:ExcIEEEAC1A.ka
+        range: PU
+        multivalued: false
+        required: true
+        description: Voltage regulator gain (<i>K</i><i><sub>A</sub></i>) (&gt; 0).  Typical
+          value = 400.
+      ta:
+        slot_uri: cim:ExcIEEEAC1A.ta
+        range: Seconds
+        multivalued: false
+        required: true
+        description: Voltage regulator time constant (<i>T</i><i><sub>A</sub></i>)
+          (&gt; 0).  Typical value = 0,02.
+      vamax:
+        slot_uri: cim:ExcIEEEAC1A.vamax
+        range: PU
+        multivalued: false
+        required: true
+        description: Maximum voltage regulator output (<i>V</i><i><sub>AMAX</sub></i>)
+          (&gt; 0).  Typical value = 14,5.
+      vamin:
+        slot_uri: cim:ExcIEEEAC1A.vamin
+        range: PU
+        multivalued: false
+        required: true
+        description: Minimum voltage regulator output (<i>V</i><i><sub>AMIN</sub></i>)
+          (&lt; 0).  Typical value = -14,5.
+      te:
+        slot_uri: cim:ExcIEEEAC1A.te
+        range: Seconds
+        multivalued: false
+        required: true
+        description: Exciter time constant, integration rate associated with exciter
+          control (<i>T</i><i><sub>E</sub></i>) (&gt; 0).  Typical value = 0,8.
+      kf:
+        slot_uri: cim:ExcIEEEAC1A.kf
+        range: PU
+        multivalued: false
+        required: true
+        description: Excitation control system stabilizer gains (<i>K</i><i><sub>F</sub></i>)
+          (&gt;= 0).  Typical value = 0,03.
+      tf:
+        slot_uri: cim:ExcIEEEAC1A.tf
+        range: Seconds
+        multivalued: false
+        required: true
+        description: Excitation control system stabilizer time constant (<i>T</i><i><sub>F</sub></i>)
+          (&gt; 0).  Typical value = 1.
+      kc:
+        slot_uri: cim:ExcIEEEAC1A.kc
+        range: PU
+        multivalued: false
+        required: true
+        description: Rectifier loading factor proportional to commutating reactance
+          (<i>K</i><i><sub>C</sub></i>) (&gt;= 0).  Typical value = 0,2.
+      kd:
+        slot_uri: cim:ExcIEEEAC1A.kd
+        range: PU
+        multivalued: false
+        required: true
+        description: Demagnetizing factor, a function of exciter alternator reactances
+          (<i>K</i><i><sub>D</sub></i>) (&gt;= 0).  Typical value = 0,38.
+      ke:
+        slot_uri: cim:ExcIEEEAC1A.ke
+        range: PU
+        multivalued: false
+        required: true
+        description: Exciter constant related to self-excited field (<i>K</i><i><sub>E</sub></i>).  Typical
+          value = 1.
+      ve1:
+        slot_uri: cim:ExcIEEEAC1A.ve1
+        range: PU
+        multivalued: false
+        required: true
+        description: Exciter alternator output voltages back of commutating reactance
+          at which saturation is defined (<i>V</i><i><sub>E1</sub></i>) (&gt; 0).  Typical
+          value = 4,18.
+      seve1:
+        slot_uri: cim:ExcIEEEAC1A.seve1
+        range: float
+        multivalued: false
+        required: true
+        description: Exciter saturation function value at the corresponding exciter
+          voltage, <i>V</i><i><sub>E1</sub></i>, back of commutating reactance (<i>S</i><i><sub>E</sub></i><i>[V</i><i><sub>E1</sub></i><i>]</i>)
+          (&gt;= 0).  Typical value = 0,1.
+      ve2:
+        slot_uri: cim:ExcIEEEAC1A.ve2
+        range: PU
+        multivalued: false
+        required: true
+        description: Exciter alternator output voltages back of commutating reactance
+          at which saturation is defined (<i>V</i><i><sub>E2</sub></i>) (&gt; 0).  Typical
+          value = 3,14.
+      seve2:
+        slot_uri: cim:ExcIEEEAC1A.seve2
+        range: float
+        multivalued: false
+        required: true
+        description: Exciter saturation function value at the corresponding exciter
+          voltage, <i>V</i><i><sub>E2</sub></i>, back of commutating reactance (<i>S</i><i><sub>E</sub></i><i>[V</i><i><sub>E2</sub></i><i>]</i>)
+          (&gt;= 0).  Typical value = 0,03.
+      vrmax:
+        slot_uri: cim:ExcIEEEAC1A.vrmax
+        range: PU
+        multivalued: false
+        required: true
+        description: Maximum voltage regulator outputs (<i>V</i><i><sub>RMAX</sub></i>)
+          (&gt; 0).  Typical value = 6,03.
+      vrmin:
+        slot_uri: cim:ExcIEEEAC1A.vrmin
+        range: PU
+        multivalued: false
+        required: true
+        description: Minimum voltage regulator outputs (<i>V</i><i><sub>RMIN</sub></i>)
+          (&lt; 0).  Typical value = -5,43.
+    is_a: ExcitationSystemDynamics
+    description: 'IEEE 421.5-2005 type AC1A model. The model represents the field-controlled
+      alternator-rectifier excitation systems designated type AC1A. These excitation
+      systems consist of an alternator main exciter with non-controlled rectifiers.
+
+      Reference: IEEE 421.5-2005, 6.1.'
+  ExcIEEEAC2A:
+    class_uri: cim:ExcIEEEAC2A
+    attributes:
+      tb:
+        slot_uri: cim:ExcIEEEAC2A.tb
+        range: Seconds
+        multivalued: false
+        required: true
+        description: Voltage regulator time constant (<i>T</i><i><sub>B</sub></i>)
+          (&gt;= 0).  Typical value = 0.
+      tc:
+        slot_uri: cim:ExcIEEEAC2A.tc
+        range: Seconds
+        multivalued: false
+        required: true
+        description: Voltage regulator time constant (<i>T</i><i><sub>C</sub></i>)
+          (&gt;= 0).  Typical value = 0.
+      ka:
+        slot_uri: cim:ExcIEEEAC2A.ka
+        range: PU
+        multivalued: false
+        required: true
+        description: Voltage regulator gain (<i>K</i><i><sub>A</sub></i>) (&gt; 0).  Typical
+          value = 400.
+      ta:
+        slot_uri: cim:ExcIEEEAC2A.ta
+        range: Seconds
+        multivalued: false
+        required: true
+        description: Voltage regulator time constant (<i>T</i><i><sub>A</sub></i>)
+          (&gt; 0).  Typical value = 0,02.
+      vamax:
+        slot_uri: cim:ExcIEEEAC2A.vamax
+        range: PU
+        multivalued: false
+        required: true
+        description: Maximum voltage regulator output (<i>V</i><i><sub>AMAX</sub></i>)
+          (&gt; 0).  Typical value = 8.
+      vamin:
+        slot_uri: cim:ExcIEEEAC2A.vamin
+        range: PU
+        multivalued: false
+        required: true
+        description: Minimum voltage regulator output (<i>V</i><i><sub>AMIN</sub></i>)
+          (&lt; 0).  Typical value = -8.
+      kb:
+        slot_uri: cim:ExcIEEEAC2A.kb
+        range: PU
+        multivalued: false
+        required: true
+        description: Second stage regulator gain (<i>K</i><i><sub>B</sub></i>) (&gt;
+          0).  Typical value = 25.
+      vrmax:
+        slot_uri: cim:ExcIEEEAC2A.vrmax
+        range: PU
+        multivalued: false
+        required: true
+        description: Maximum voltage regulator outputs (<i>V</i><i><sub>RMAX</sub></i>)
+          (&gt; 0).  Typical value = 105.
+      vrmin:
+        slot_uri: cim:ExcIEEEAC2A.vrmin
+        range: PU
+        multivalued: false
+        required: true
+        description: Minimum voltage regulator outputs (<i>V</i><i><sub>RMIN</sub></i>)
+          (&lt; 0).  Typical value = -95.
+      te:
+        slot_uri: cim:ExcIEEEAC2A.te
+        range: Seconds
+        multivalued: false
+        required: true
+        description: Exciter time constant, integration rate associated with exciter
+          control (<i>T</i><i><sub>E</sub></i>) (&gt; 0).  Typical value = 0,6.
+      vfemax:
+        slot_uri: cim:ExcIEEEAC2A.vfemax
+        range: PU
+        multivalued: false
+        required: true
+        description: Exciter field current limit reference (<i>V</i><i><sub>FEMAX</sub></i>)
+          (&gt; 0).  Typical value = 4,4.
+      kh:
+        slot_uri: cim:ExcIEEEAC2A.kh
+        range: PU
+        multivalued: false
+        required: true
+        description: Exciter field current feedback gain (<i>K</i><i><sub>H</sub></i>)
+          (&gt;= 0).  Typical value = 1.
+      kf:
+        slot_uri: cim:ExcIEEEAC2A.kf
+        range: PU
+        multivalued: false
+        required: true
+        description: Excitation control system stabilizer gains (<i>K</i><i><sub>F</sub></i>)
+          (&gt;= 0).  Typical value = 0,03.
+      tf:
+        slot_uri: cim:ExcIEEEAC2A.tf
+        range: Seconds
+        multivalued: false
+        required: true
+        description: Excitation control system stabilizer time constant (<i>T</i><i><sub>F</sub></i>)
+          (&gt; 0).  Typical value = 1.
+      kc:
+        slot_uri: cim:ExcIEEEAC2A.kc
+        range: PU
+        multivalued: false
+        required: true
+        description: Rectifier loading factor proportional to commutating reactance
+          (<i>K</i><i><sub>C</sub></i>) (&gt;= 0).  Typical value = 0,28.
+      kd:
+        slot_uri: cim:ExcIEEEAC2A.kd
+        range: PU
+        multivalued: false
+        required: true
+        description: Demagnetizing factor, a function of exciter alternator reactances
+          (<i>K</i><i><sub>D</sub></i>) (&gt;= 0).  Typical value = 0,35.
+      ke:
+        slot_uri: cim:ExcIEEEAC2A.ke
+        range: PU
+        multivalued: false
+        required: true
+        description: Exciter constant related to self-excited field (<i>K</i><i><sub>E</sub></i>)
+          (&gt;= 0).  Typical value = 1.
+      ve1:
+        slot_uri: cim:ExcIEEEAC2A.ve1
+        range: PU
+        multivalued: false
+        required: true
+        description: Exciter alternator output voltages back of commutating reactance
+          at which saturation is defined (<i>V</i><i><sub>E1</sub></i>) (&gt; 0).  Typical
+          value = 4,4.
+      seve1:
+        slot_uri: cim:ExcIEEEAC2A.seve1
+        range: float
+        multivalued: false
+        required: true
+        description: Exciter saturation function value at the corresponding exciter
+          voltage, <i>V</i><i><sub>E1</sub></i>, back of commutating reactance (<i>S</i><i><sub>E</sub></i><i>[V</i><i><sub>E1</sub></i><i>]</i>)
+          (&gt;= 0).  Typical value = 0,037.
+      ve2:
+        slot_uri: cim:ExcIEEEAC2A.ve2
+        range: PU
+        multivalued: false
+        required: true
+        description: Exciter alternator output voltages back of commutating reactance
+          at which saturation is defined (<i>V</i><i><sub>E2</sub></i>) (&gt; 0).  Typical
+          value = 3,3.
+      seve2:
+        slot_uri: cim:ExcIEEEAC2A.seve2
+        range: float
+        multivalued: false
+        required: true
+        description: Exciter saturation function value at the corresponding exciter
+          voltage, <i>V</i><i><sub>E2</sub></i>, back of commutating reactance (<i>S</i><i><sub>E</sub></i><i>[V</i><i><sub>E2</sub></i><i>]</i>)
+          (&gt;= 0).  Typical value = 0,012.
+    is_a: ExcitationSystemDynamics
+    description: 'IEEE 421.5-2005 type AC2A model. The model represents a high initial
+      response field-controlled alternator-rectifier excitation system. The alternator
+      main exciter is used with non-controlled rectifiers. The type AC2A model is
+      similar to that of type AC1A except for the inclusion of exciter time constant
+      compensation and exciter field current limiting elements.
+
+      Reference: IEEE 421.5-2005, 6.2.'
+  ExcIEEEAC3A:
+    class_uri: cim:ExcIEEEAC3A
+    attributes:
+      tb:
+        slot_uri: cim:ExcIEEEAC3A.tb
+        range: Seconds
+        multivalued: false
+        required: true
+        description: Voltage regulator time constant (<i>T</i><i><sub>B</sub></i>)
+          (&gt;= 0).  Typical value = 0.
+      tc:
+        slot_uri: cim:ExcIEEEAC3A.tc
+        range: Seconds
+        multivalued: false
+        required: true
+        description: Voltage regulator time constant (<i>T</i><i><sub>C</sub></i>)
+          (&gt;= 0).  Typical value = 0.
+      ka:
+        slot_uri: cim:ExcIEEEAC3A.ka
+        range: PU
+        multivalued: false
+        required: true
+        description: Voltage regulator gain (<i>K</i><i><sub>A</sub></i>) (&gt; 0).  Typical
+          value = 45,62.
+      ta:
+        slot_uri: cim:ExcIEEEAC3A.ta
+        range: Seconds
+        multivalued: false
+        required: true
+        description: Voltage regulator time constant (<i>T</i><i><sub>A</sub></i>)
+          (&gt; 0).  Typical value = 0,013.
+      vamax:
+        slot_uri: cim:ExcIEEEAC3A.vamax
+        range: PU
+        multivalued: false
+        required: true
+        description: Maximum voltage regulator output (<i>V</i><i><sub>AMAX</sub></i>)
+          (&gt; 0).  Typical value = 1.
+      vamin:
+        slot_uri: cim:ExcIEEEAC3A.vamin
+        range: PU
+        multivalued: false
+        required: true
+        description: Minimum voltage regulator output (<i>V</i><i><sub>AMIN</sub></i>)
+          (&lt; 0).  Typical value = -0,95.
+      te:
+        slot_uri: cim:ExcIEEEAC3A.te
+        range: Seconds
+        multivalued: false
+        required: true
+        description: Exciter time constant, integration rate associated with exciter
+          control (<i>T</i><i><sub>E</sub></i>) (&gt; 0).  Typical value = 1,17.
+      vemin:
+        slot_uri: cim:ExcIEEEAC3A.vemin
+        range: PU
+        multivalued: false
+        required: true
+        description: Minimum exciter voltage output (<i>V</i><i><sub>EMIN</sub></i>)
+          (&lt;= 0).  Typical value = 0.
+      kr:
+        slot_uri: cim:ExcIEEEAC3A.kr
+        range: PU
+        multivalued: false
+        required: true
+        description: Constant associated with regulator and alternator field power
+          supply (<i>K</i><i><sub>R</sub></i>) (&gt; 0).  Typical value = 3,77.
+      kf:
+        slot_uri: cim:ExcIEEEAC3A.kf
+        range: PU
+        multivalued: false
+        required: true
+        description: Excitation control system stabilizer gains (<i>K</i><i><sub>F</sub></i>)
+          (&gt;= 0).  Typical value = 0,143.
+      tf:
+        slot_uri: cim:ExcIEEEAC3A.tf
+        range: Seconds
+        multivalued: false
+        required: true
+        description: Excitation control system stabilizer time constant (<i>T</i><i><sub>F</sub></i>)
+          (&gt; 0).  Typical value = 1.
+      kn:
+        slot_uri: cim:ExcIEEEAC3A.kn
+        range: PU
+        multivalued: false
+        required: true
+        description: Excitation control system stabilizer gain (<i>K</i><i><sub>N</sub></i>)
+          (&gt;= 0).  Typical value = 0,05.
+      efdn:
+        slot_uri: cim:ExcIEEEAC3A.efdn
+        range: PU
+        multivalued: false
+        required: true
+        description: Value of <i>Efd </i>at which feedback gain changes (<i>E</i><i><sub>FDN</sub></i>)
+          (&gt; 0).  Typical value = 2,36.
+      kc:
+        slot_uri: cim:ExcIEEEAC3A.kc
+        range: PU
+        multivalued: false
+        required: true
+        description: Rectifier loading factor proportional to commutating reactance
+          (<i>K</i><i><sub>C</sub></i>) (&gt;= 0).  Typical value = 0,104.
+      kd:
+        slot_uri: cim:ExcIEEEAC3A.kd
+        range: PU
+        multivalued: false
+        required: true
+        description: Demagnetizing factor, a function of exciter alternator reactances
+          (<i>K</i><i><sub>D</sub></i>) (&gt;= 0).  Typical value = 0,499.
+      ke:
+        slot_uri: cim:ExcIEEEAC3A.ke
+        range: PU
+        multivalued: false
+        required: true
+        description: Exciter constant related to self-excited field (<i>K</i><i><sub>E</sub></i>).  Typical
+          value = 1.
+      vfemax:
+        slot_uri: cim:ExcIEEEAC3A.vfemax
+        range: PU
+        multivalued: false
+        required: true
+        description: Exciter field current limit reference (<i>V</i><i><sub>FEMAX</sub></i>)
+          (&gt;= 0).  Typical value = 16.
+      ve1:
+        slot_uri: cim:ExcIEEEAC3A.ve1
+        range: PU
+        multivalued: false
+        required: true
+        description: Exciter alternator output voltages back of commutating reactance
+          at which saturation is defined (<i>V</i><i><sub>E1</sub></i>) (&gt; 0).  Typical
+          value = 6,24.
+      seve1:
+        slot_uri: cim:ExcIEEEAC3A.seve1
+        range: float
+        multivalued: false
+        required: true
+        description: Exciter saturation function value at the corresponding exciter
+          voltage, <i>V</i><i><sub>E1</sub></i>, back of commutating reactance (<i>S</i><i><sub>E</sub></i><i>[V</i><i><sub>E1</sub></i><i>]</i>)
+          (&gt;= 0).  Typical value = 1,143.
+      ve2:
+        slot_uri: cim:ExcIEEEAC3A.ve2
+        range: PU
+        multivalued: false
+        required: true
+        description: Exciter alternator output voltages back of commutating reactance
+          at which saturation is defined (<i>V</i><i><sub>E2</sub></i>) (&gt; 0).  Typical
+          value = 4,68.
+      seve2:
+        slot_uri: cim:ExcIEEEAC3A.seve2
+        range: float
+        multivalued: false
+        required: true
+        description: Exciter saturation function value at the corresponding exciter
+          voltage, <i>V</i><i><sub>E2</sub></i>, back of commutating reactance (<i>S</i><i><sub>E</sub></i><i>[V</i><i><sub>E2</sub></i><i>]</i>)
+          (&gt;= 0).  Typical value = 0,1.
+    is_a: ExcitationSystemDynamics
+    description: 'IEEE 421.5-2005 type AC3A model. The model represents the field-controlled
+      alternator-rectifier excitation systems designated type AC3A. These excitation
+      systems include an alternator main exciter with non-controlled rectifiers. The
+      exciter employs self-excitation, and the voltage regulator power is derived
+      from the exciter output voltage.  Therefore, this system has an additional nonlinearity,
+      simulated by the use of a multiplier whose inputs are the voltage regulator
+      command signal, <i>Va</i>, and the exciter output voltage, <i>Efd</i>, times
+      <i>K</i><i><sub>R</sub></i>.  This model is applicable to excitation systems
+      employing static voltage regulators.
+
+      Reference: IEEE 421.5-2005, 6.3.'
+  ExcIEEEAC4A:
+    class_uri: cim:ExcIEEEAC4A
+    attributes:
+      vimax:
+        slot_uri: cim:ExcIEEEAC4A.vimax
+        range: PU
+        multivalued: false
+        required: true
+        description: Maximum voltage regulator input limit (<i>V</i><i><sub>IMAX</sub></i>)
+          (&gt; 0).  Typical value = 10.
+      vimin:
+        slot_uri: cim:ExcIEEEAC4A.vimin
+        range: PU
+        multivalued: false
+        required: true
+        description: Minimum voltage regulator input limit (<i>V</i><i><sub>IMIN</sub></i>)
+          (&lt; 0).  Typical value = -10.
+      tc:
+        slot_uri: cim:ExcIEEEAC4A.tc
+        range: Seconds
+        multivalued: false
+        required: true
+        description: Voltage regulator time constant (<i>T</i><i><sub>C</sub></i>)
+          (&gt;= 0).  Typical value = 1.
+      tb:
+        slot_uri: cim:ExcIEEEAC4A.tb
+        range: Seconds
+        multivalued: false
+        required: true
+        description: Voltage regulator time constant (<i>T</i><i><sub>B</sub></i>)
+          (&gt;= 0).  Typical value = 10.
+      ka:
+        slot_uri: cim:ExcIEEEAC4A.ka
+        range: PU
+        multivalued: false
+        required: true
+        description: Voltage regulator gain (<i>K</i><i><sub>A</sub></i>) (&gt; 0).  Typical
+          value = 200.
+      ta:
+        slot_uri: cim:ExcIEEEAC4A.ta
+        range: Seconds
+        multivalued: false
+        required: true
+        description: Voltage regulator time constant (<i>T</i><i><sub>A</sub></i>)
+          (&gt; 0).  Typical value = 0,015.
+      vrmax:
+        slot_uri: cim:ExcIEEEAC4A.vrmax
+        range: PU
+        multivalued: false
+        required: true
+        description: Maximum voltage regulator output (<i>V</i><i><sub>RMAX</sub></i>)
+          (&gt; 0).  Typical value = 5,64.
+      vrmin:
+        slot_uri: cim:ExcIEEEAC4A.vrmin
+        range: PU
+        multivalued: false
+        required: true
+        description: Minimum voltage regulator output (<i>V</i><i><sub>RMIN</sub></i>)
+          (&lt; 0).  Typical value = -4,53.
+      kc:
+        slot_uri: cim:ExcIEEEAC4A.kc
+        range: PU
+        multivalued: false
+        required: true
+        description: Rectifier loading factor proportional to commutating reactance
+          (<i>K</i><i><sub>C</sub></i>) (&gt;= 0).  Typical value = 0.
+    is_a: ExcitationSystemDynamics
+    description: 'IEEE 421.5-2005 type AC4A model. The model represents type AC4A
+      alternator-supplied controlled-rectifier excitation system which is quite different
+      from the other types of AC systems. This high initial response excitation system
+      utilizes a full thyristor bridge in the exciter output circuit.  The voltage
+      regulator controls the firing of the thyristor bridges. The exciter alternator
+      uses an independent voltage regulator to control its output voltage to a constant
+      value. These effects are not modelled; however, transient loading effects on
+      the exciter alternator are included.
+
+      Reference: IEEE 421.5-2005, 6.4.'
+  ExcIEEEAC5A:
+    class_uri: cim:ExcIEEEAC5A
+    attributes:
+      ka:
+        slot_uri: cim:ExcIEEEAC5A.ka
+        range: PU
+        multivalued: false
+        required: true
+        description: Voltage regulator gain (<i>K</i><i><sub>A</sub></i>) (&gt; 0).  Typical
+          value = 400.
+      ta:
+        slot_uri: cim:ExcIEEEAC5A.ta
+        range: Seconds
+        multivalued: false
+        required: true
+        description: Voltage regulator time constant (<i>T</i><i><sub>A</sub></i>)
+          (&gt; 0).  Typical value = 0,02.
+      vrmax:
+        slot_uri: cim:ExcIEEEAC5A.vrmax
+        range: PU
+        multivalued: false
+        required: true
+        description: Maximum voltage regulator output (<i>V</i><i><sub>RMAX</sub></i>)
+          (&gt; 0).  Typical value = 7,3.
+      vrmin:
+        slot_uri: cim:ExcIEEEAC5A.vrmin
+        range: PU
+        multivalued: false
+        required: true
+        description: Minimum voltage regulator output (<i>V</i><i><sub>RMIN</sub></i>)
+          (&lt; 0).  Typical value = -7,3.
+      ke:
+        slot_uri: cim:ExcIEEEAC5A.ke
+        range: PU
+        multivalued: false
+        required: true
+        description: Exciter constant related to self-excited field (<i>K</i><i><sub>E</sub></i>).  Typical
+          value = 1.
+      te:
+        slot_uri: cim:ExcIEEEAC5A.te
+        range: Seconds
+        multivalued: false
+        required: true
+        description: Exciter time constant, integration rate associated with exciter
+          control (<i>T</i><i><sub>E</sub></i>) (&gt; 0).  Typical value = 0,8.
+      kf:
+        slot_uri: cim:ExcIEEEAC5A.kf
+        range: PU
+        multivalued: false
+        required: true
+        description: Excitation control system stabilizer gains (<i>K</i><i><sub>F</sub></i>)
+          (&gt;= 0).  Typical value = 0,03.
+      tf1:
+        slot_uri: cim:ExcIEEEAC5A.tf1
+        range: Seconds
+        multivalued: false
+        required: true
+        description: Excitation control system stabilizer time constant (<i>T</i><i><sub>F1</sub></i>)
+          (&gt; 0).  Typical value = 1.
+      tf2:
+        slot_uri: cim:ExcIEEEAC5A.tf2
+        range: Seconds
+        multivalued: false
+        required: true
+        description: Excitation control system stabilizer time constant (<i>T</i><i><sub>F2</sub></i>)
+          (&gt;= 0).  Typical value = 1.
+      tf3:
+        slot_uri: cim:ExcIEEEAC5A.tf3
+        range: Seconds
+        multivalued: false
+        required: true
+        description: Excitation control system stabilizer time constant (<i>T</i><i><sub>F3</sub></i>)
+          (&gt;= 0).  Typical value = 1.
+      efd1:
+        slot_uri: cim:ExcIEEEAC5A.efd1
+        range: PU
+        multivalued: false
+        required: true
+        description: Exciter voltage at which exciter saturation is defined (<i>E</i><i><sub>FD1</sub></i>)
+          (&gt; 0).  Typical value = 5,6.
+      seefd1:
+        slot_uri: cim:ExcIEEEAC5A.seefd1
+        range: float
+        multivalued: false
+        required: true
+        description: Exciter saturation function value at the corresponding exciter
+          voltage, <i>E</i><i><sub>FD1</sub></i> (<i>S</i><i><sub>E</sub></i><i>[E</i><i><sub>FD1</sub></i><i>]</i>)
+          (&gt;= 0).  Typical value = 0,86.
+      efd2:
+        slot_uri: cim:ExcIEEEAC5A.efd2
+        range: PU
+        multivalued: false
+        required: true
+        description: Exciter voltage at which exciter saturation is defined (<i>E</i><i><sub>FD2</sub></i>)
+          (&gt; 0).  Typical value = 4,2.
+      seefd2:
+        slot_uri: cim:ExcIEEEAC5A.seefd2
+        range: float
+        multivalued: false
+        required: true
+        description: Exciter saturation function value at the corresponding exciter
+          voltage, <i>E</i><i><sub>FD2</sub></i> (<i>S</i><i><sub>E</sub></i><i>[E</i><i><sub>FD2</sub></i><i>]</i>)
+          (&gt;= 0).  Typical value = 0,5.
+    is_a: ExcitationSystemDynamics
+    description: 'IEEE 421.5-2005 type AC5A model. The model represents a simplified
+      model for brushless excitation systems. The regulator is supplied from a source,
+      such as a permanent magnet generator, which is not affected by system disturbances.  Unlike
+      other AC models, this model uses loaded rather than open circuit exciter saturation
+      data in the same way as it is used for the DC models.  Because the model has
+      been widely implemented by the industry, it is sometimes used to represent other
+      types of systems when either detailed data for them are not available or simplified
+      models are required.
+
+      Reference: IEEE 421.5-2005, 6.5.'
+  ExcIEEEAC6A:
+    class_uri: cim:ExcIEEEAC6A
+    attributes:
+      ka:
+        slot_uri: cim:ExcIEEEAC6A.ka
+        range: PU
+        multivalued: false
+        required: true
+        description: Voltage regulator gain (<i>K</i><i><sub>A</sub></i>) (&gt; 0).  Typical
+          value = 536.
+      ta:
+        slot_uri: cim:ExcIEEEAC6A.ta
+        range: Seconds
+        multivalued: false
+        required: true
+        description: Voltage regulator time constant (<i>T</i><i><sub>A</sub></i>)
+          (&gt;= 0).  Typical value = 0,086.
+      tk:
+        slot_uri: cim:ExcIEEEAC6A.tk
+        range: Seconds
+        multivalued: false
+        required: true
+        description: Voltage regulator time constant (<i>T</i><i><sub>K</sub></i>)
+          (&gt;= 0).  Typical value = 0,18.
+      tb:
+        slot_uri: cim:ExcIEEEAC6A.tb
+        range: Seconds
+        multivalued: false
+        required: true
+        description: Voltage regulator time constant (<i>T</i><i><sub>B</sub></i>)
+          (&gt;= 0).  Typical value = 9.
+      tc:
+        slot_uri: cim:ExcIEEEAC6A.tc
+        range: Seconds
+        multivalued: false
+        required: true
+        description: Voltage regulator time constant (<i>T</i><i><sub>C</sub></i>)
+          (&gt;= 0).  Typical value = 3.
+      vamax:
+        slot_uri: cim:ExcIEEEAC6A.vamax
+        range: PU
+        multivalued: false
+        required: true
+        description: Maximum voltage regulator output (<i>V</i><i><sub>AMAX</sub></i>)
+          (&gt; 0).  Typical value = 75.
+      vamin:
+        slot_uri: cim:ExcIEEEAC6A.vamin
+        range: PU
+        multivalued: false
+        required: true
+        description: Minimum voltage regulator output (V<sub>AMIN</sub>) (&lt; 0).  Typical
+          value = -75.
+      vrmax:
+        slot_uri: cim:ExcIEEEAC6A.vrmax
+        range: PU
+        multivalued: false
+        required: true
+        description: Maximum voltage regulator output (<i>V</i><i><sub>RMAX</sub></i>)
+          (&gt; 0).  Typical value = 44.
+      vrmin:
+        slot_uri: cim:ExcIEEEAC6A.vrmin
+        range: PU
+        multivalued: false
+        required: true
+        description: Minimum voltage regulator output (<i>V</i><i><sub>RMIN</sub></i>)
+          (&lt; 0).  Typical value = -36.
+      te:
+        slot_uri: cim:ExcIEEEAC6A.te
+        range: Seconds
+        multivalued: false
+        required: true
+        description: Exciter time constant, integration rate associated with exciter
+          control (<i>T</i><i><sub>E</sub></i>) (&gt; 0).  Typical value = 1.
+      kh:
+        slot_uri: cim:ExcIEEEAC6A.kh
+        range: PU
+        multivalued: false
+        required: true
+        description: Exciter field current limiter gain (<i>K</i><i><sub>H</sub></i>)
+          (&gt;= 0).  Typical value = 92.
+      tj:
+        slot_uri: cim:ExcIEEEAC6A.tj
+        range: Seconds
+        multivalued: false
+        required: true
+        description: Exciter field current limiter time constant (<i>T</i><i><sub>J</sub></i>)
+          (&gt;= 0).  Typical value = 0,02.
+      th:
+        slot_uri: cim:ExcIEEEAC6A.th
+        range: Seconds
+        multivalued: false
+        required: true
+        description: Exciter field current limiter time constant (<i>T</i><i><sub>H</sub></i>)
+          (&gt; 0).  Typical value = 0,08.
+      vfelim:
+        slot_uri: cim:ExcIEEEAC6A.vfelim
+        range: PU
+        multivalued: false
+        required: true
+        description: Exciter field current limit reference (<i>V</i><i><sub>FELIM</sub></i>)
+          (&gt; 0).  Typical value = 19.
+      vhmax:
+        slot_uri: cim:ExcIEEEAC6A.vhmax
+        range: PU
+        multivalued: false
+        required: true
+        description: Maximum field current limiter signal reference (<i>V</i><i><sub>HMAX</sub></i>)
+          (&gt; 0).  Typical value = 75.
+      kc:
+        slot_uri: cim:ExcIEEEAC6A.kc
+        range: PU
+        multivalued: false
+        required: true
+        description: Rectifier loading factor proportional to commutating reactance
+          (<i>K</i><i><sub>C</sub></i>) (&gt;= 0). Typical value = 0,173.
+      kd:
+        slot_uri: cim:ExcIEEEAC6A.kd
+        range: PU
+        multivalued: false
+        required: true
+        description: Demagnetizing factor, a function of exciter alternator reactances
+          (<i>K</i><i><sub>D</sub></i>) (&gt;= 0).  Typical value = 1,91.
+      ke:
+        slot_uri: cim:ExcIEEEAC6A.ke
+        range: PU
+        multivalued: false
+        required: true
+        description: Exciter constant related to self-excited field (<i>K</i><i><sub>E</sub></i>).  Typical
+          value = 1,6.
+      ve1:
+        slot_uri: cim:ExcIEEEAC6A.ve1
+        range: PU
+        multivalued: false
+        required: true
+        description: Exciter alternator output voltages back of commutating reactance
+          at which saturation is defined (<i>V</i><i><sub>E1</sub></i>) (&gt; 0).  Typical
+          value = 7,4.
+      seve1:
+        slot_uri: cim:ExcIEEEAC6A.seve1
+        range: float
+        multivalued: false
+        required: true
+        description: Exciter saturation function value at the corresponding exciter
+          voltage, <i>V</i><i><sub>E1</sub></i>, back of commutating reactance (<i>S</i><i><sub>E</sub></i><i>[V</i><i><sub>E1</sub></i><i>])</i>
+          (&gt;= 0).  Typical value = 0,214.
+      ve2:
+        slot_uri: cim:ExcIEEEAC6A.ve2
+        range: PU
+        multivalued: false
+        required: true
+        description: Exciter alternator output voltages back of commutating reactance
+          at which saturation is defined (<i>V</i><i><sub>E2</sub></i>) (&gt; 0).  Typical
+          value = 5,55.
+      seve2:
+        slot_uri: cim:ExcIEEEAC6A.seve2
+        range: float
+        multivalued: false
+        required: true
+        description: Exciter saturation function value at the corresponding exciter
+          voltage, <i>V</i><i><sub>E2</sub></i>, back of commutating reactance (<i>S</i><i><sub>E</sub></i><i>[V</i><i><sub>E2</sub></i><i>]</i>)
+          (&gt;= 0).  Typical value = 0,044.
+    is_a: ExcitationSystemDynamics
+    description: 'IEEE 421.5-2005 type AC6A model. The model represents field-controlled
+      alternator-rectifier excitation systems with system-supplied electronic voltage
+      regulators.  The maximum output of the regulator, <i>V</i><i><sub>R</sub></i>,
+      is a function of terminal voltage, <i>V</i><i><sub>T</sub></i>. The field current
+      limiter included in the original model AC6A remains in the 2005 update.
+
+      Reference: IEEE 421.5-2005, 6.6.'
+  ExcIEEEAC7B:
+    class_uri: cim:ExcIEEEAC7B
+    attributes:
+      kpr:
+        slot_uri: cim:ExcIEEEAC7B.kpr
+        range: PU
+        multivalued: false
+        required: true
+        description: Voltage regulator proportional gain (<i>K</i><i><sub>PR</sub></i>)
+          (&gt; 0 if ExcIEEEAC7B.kir = 0).  Typical value = 4,24.
+      kir:
+        slot_uri: cim:ExcIEEEAC7B.kir
+        range: PU
+        multivalued: false
+        required: true
+        description: Voltage regulator integral gain (<i>K</i><i><sub>IR</sub></i>)
+          (&gt;= 0).  Typical value = 4,24.
+      kdr:
+        slot_uri: cim:ExcIEEEAC7B.kdr
+        range: PU
+        multivalued: false
+        required: true
+        description: Voltage regulator derivative gain (<i>K</i><i><sub>DR</sub></i>)
+          (&gt;= 0).  Typical value = 0.
+      tdr:
+        slot_uri: cim:ExcIEEEAC7B.tdr
+        range: Seconds
+        multivalued: false
+        required: true
+        description: Lag time constant (<i>T</i><i><sub>DR</sub></i>) (&gt;= 0).  Typical
+          value = 0.
+      vrmax:
+        slot_uri: cim:ExcIEEEAC7B.vrmax
+        range: PU
+        multivalued: false
+        required: true
+        description: Maximum voltage regulator output (<i>V</i><i><sub>RMAX</sub></i>)
+          (&gt; 0).  Typical value = 5,79.
+      vrmin:
+        slot_uri: cim:ExcIEEEAC7B.vrmin
+        range: PU
+        multivalued: false
+        required: true
+        description: Minimum voltage regulator output (<i>V</i><i><sub>RMIN</sub></i>)
+          (&lt; 0).  Typical value = -5,79.
+      kpa:
+        slot_uri: cim:ExcIEEEAC7B.kpa
+        range: PU
+        multivalued: false
+        required: true
+        description: Voltage regulator proportional gain (<i>K</i><i><sub>PA</sub></i>)
+          (&gt; 0 if ExcIEEEAC7B.kia = 0).  Typical value = 65,36.
+      kia:
+        slot_uri: cim:ExcIEEEAC7B.kia
+        range: PU
+        multivalued: false
+        required: true
+        description: Voltage regulator integral gain (<i>K</i><i><sub>IA</sub></i>)
+          (&gt;= 0).  Typical value = 59,69.
+      vamax:
+        slot_uri: cim:ExcIEEEAC7B.vamax
+        range: PU
+        multivalued: false
+        required: true
+        description: Maximum voltage regulator output (<i>V</i><i><sub>AMAX</sub></i>)
+          (&gt; 0).  Typical value = 1.
+      vamin:
+        slot_uri: cim:ExcIEEEAC7B.vamin
+        range: PU
+        multivalued: false
+        required: true
+        description: Minimum voltage regulator output (<i>V</i><i><sub>AMIN</sub></i>)
+          (&lt; 0).  Typical value = -0,95.
+      kp:
+        slot_uri: cim:ExcIEEEAC7B.kp
+        range: PU
+        multivalued: false
+        required: true
+        description: Potential circuit gain coefficient (<i>K</i><i><sub>P</sub></i>)
+          (&gt; 0).  Typical value = 4,96.
+      kl:
+        slot_uri: cim:ExcIEEEAC7B.kl
+        range: PU
+        multivalued: false
+        required: true
+        description: Exciter field voltage lower limit parameter (<i>K</i><i><sub>L</sub></i>).  Typical
+          value = 10.
+      te:
+        slot_uri: cim:ExcIEEEAC7B.te
+        range: Seconds
+        multivalued: false
+        required: true
+        description: Exciter time constant, integration rate associated with exciter
+          control (<i>T</i><i><sub>E</sub></i>) (&gt; 0).  Typical value = 1,1.
+      vfemax:
+        slot_uri: cim:ExcIEEEAC7B.vfemax
+        range: PU
+        multivalued: false
+        required: true
+        description: Exciter field current limit reference (<i>V</i><i><sub>FEMAX</sub></i>).  Typical
+          value = 6,9.
+      vemin:
+        slot_uri: cim:ExcIEEEAC7B.vemin
+        range: PU
+        multivalued: false
+        required: true
+        description: Minimum exciter voltage output (<i>V</i><i><sub>EMIN</sub></i>)
+          (&lt;= 0).  Typical value = 0.
+      ke:
+        slot_uri: cim:ExcIEEEAC7B.ke
+        range: PU
+        multivalued: false
+        required: true
+        description: Exciter constant related to self-excited field (<i>K</i><i><sub>E</sub></i>).  Typical
+          value = 1.
+      kc:
+        slot_uri: cim:ExcIEEEAC7B.kc
+        range: PU
+        multivalued: false
+        required: true
+        description: Rectifier loading factor proportional to commutating reactance
+          (<i>K</i><i><sub>C</sub></i>) (&gt;= 0). Typical value = 0,18.
+      kd:
+        slot_uri: cim:ExcIEEEAC7B.kd
+        range: PU
+        multivalued: false
+        required: true
+        description: Demagnetizing factor, a function of exciter alternator reactances
+          (<i>K</i><i><sub>D</sub></i>) (&gt;= 0).  Typical value = 0,02.
+      kf1:
+        slot_uri: cim:ExcIEEEAC7B.kf1
+        range: PU
+        multivalued: false
+        required: true
+        description: Excitation control system stabilizer gain (<i>K</i><i><sub>F1</sub></i>)
+          (&gt;= 0).  Typical value = 0,212.
+      kf2:
+        slot_uri: cim:ExcIEEEAC7B.kf2
+        range: PU
+        multivalued: false
+        required: true
+        description: Excitation control system stabilizer gain (<i>K</i><i><sub>F2</sub></i>)
+          (&gt;= 0).  Typical value = 0.
+      kf3:
+        slot_uri: cim:ExcIEEEAC7B.kf3
+        range: PU
+        multivalued: false
+        required: true
+        description: Excitation control system stabilizer gain (<i>K</i><i><sub>F3</sub></i>)
+          (&gt;= 0).  Typical value = 0.
+      tf:
+        slot_uri: cim:ExcIEEEAC7B.tf
+        range: Seconds
+        multivalued: false
+        required: true
+        description: Excitation control system stabilizer time constant (<i>T</i><i><sub>F</sub></i>)
+          (&gt; 0).  Typical value = 1.
+      ve1:
+        slot_uri: cim:ExcIEEEAC7B.ve1
+        range: PU
+        multivalued: false
+        required: true
+        description: Exciter alternator output voltages back of commutating reactance
+          at which saturation is defined (<i>V</i><i><sub>E1</sub></i>) (&gt; 0).  Typical
+          value = 6,3.
+      seve1:
+        slot_uri: cim:ExcIEEEAC7B.seve1
+        range: float
+        multivalued: false
+        required: true
+        description: Exciter saturation function value at the corresponding exciter
+          voltage, <i>V</i><i><sub>E1</sub></i>, back of commutating reactance (<i>S</i><i><sub>E</sub></i><i>[V</i><i><sub>E1</sub></i><i>]</i>)
+          (&gt;= 0).  Typical value = 0,44.
+      ve2:
+        slot_uri: cim:ExcIEEEAC7B.ve2
+        range: PU
+        multivalued: false
+        required: true
+        description: Exciter alternator output voltages back of commutating reactance
+          at which saturation is defined (<i>V</i><i><sub>E2</sub></i>) (&gt; 0).  Typical
+          value = 3,02.
+      seve2:
+        slot_uri: cim:ExcIEEEAC7B.seve2
+        range: float
+        multivalued: false
+        required: true
+        description: Exciter saturation function value at the corresponding exciter
+          voltage, <i>V</i><i><sub>E2</sub></i>, back of commutating reactance (<i>S</i><i><sub>E</sub></i><i>[V</i><i><sub>E2</sub></i><i>]</i>)
+          (&gt;= 0).  Typical value = 0,075.
+    is_a: ExcitationSystemDynamics
+    description: 'IEEE 421.5-2005 type AC7B model. The model represents excitation
+      systems which consist of an AC alternator with either stationary or rotating
+      rectifiers to produce the DC field requirements. It is an upgrade to earlier
+      AC excitation systems, which replace only the controls but retain the AC alternator
+      and diode rectifier bridge.
+
+      Reference: IEEE 421.5-2005, 6.7. Note, however, that in IEEE 421.5-2005, the
+      [1 / <i>sT</i><i><sub>E</sub></i>] block is shown as [1 / (1 + <i>sT</i><i><sub>E</sub></i>)],
+      which is incorrect.'
+  ExcIEEEAC8B:
+    class_uri: cim:ExcIEEEAC8B
+    attributes:
+      kpr:
+        slot_uri: cim:ExcIEEEAC8B.kpr
+        range: PU
+        multivalued: false
+        required: true
+        description: Voltage regulator proportional gain (<i>K</i><i><sub>PR</sub></i>)
+          (&gt; 0 if ExcIEEEAC8B.kir = 0).  Typical value = 80.
+      kir:
+        slot_uri: cim:ExcIEEEAC8B.kir
+        range: PU
+        multivalued: false
+        required: true
+        description: Voltage regulator integral gain (<i>K</i><i><sub>IR</sub></i>)
+          (&gt;= 0).  Typical value = 5.
+      kdr:
+        slot_uri: cim:ExcIEEEAC8B.kdr
+        range: PU
+        multivalued: false
+        required: true
+        description: Voltage regulator derivative gain (<i>K</i><i><sub>DR</sub></i>)
+          (&gt;= 0).  Typical value = 10.
+      tdr:
+        slot_uri: cim:ExcIEEEAC8B.tdr
+        range: Seconds
+        multivalued: false
+        required: true
+        description: Lag time constant (<i>T</i><i><sub>DR</sub></i>) (&gt; 0).  Typical
+          value = 0,1.
+      vrmax:
+        slot_uri: cim:ExcIEEEAC8B.vrmax
+        range: PU
+        multivalued: false
+        required: true
+        description: Maximum voltage regulator output (<i>V</i><i><sub>RMAX</sub></i>)
+          (&gt; 0).  Typical value = 35.
+      vrmin:
+        slot_uri: cim:ExcIEEEAC8B.vrmin
+        range: PU
+        multivalued: false
+        required: true
+        description: Minimum voltage regulator output (<i>V</i><i><sub>RMIN</sub></i>)
+          (&lt;= 0).  Typical value = 0.
+      ka:
+        slot_uri: cim:ExcIEEEAC8B.ka
+        range: PU
+        multivalued: false
+        required: true
+        description: Voltage regulator gain (<i>K</i><i><sub>A</sub></i>) (&gt; 0).  Typical
+          value = 1.
+      ta:
+        slot_uri: cim:ExcIEEEAC8B.ta
+        range: Seconds
+        multivalued: false
+        required: true
+        description: Voltage regulator time constant (<i>T</i><i><sub>A</sub></i>)
+          (&gt;= 0).  Typical value = 0.
+      te:
+        slot_uri: cim:ExcIEEEAC8B.te
+        range: Seconds
+        multivalued: false
+        required: true
+        description: Exciter time constant, integration rate associated with exciter
+          control (<i>T</i><i><sub>E</sub></i>) (&gt; 0).  Typical value = 1,2.
+      vfemax:
+        slot_uri: cim:ExcIEEEAC8B.vfemax
+        range: PU
+        multivalued: false
+        required: true
+        description: Exciter field current limit reference (<i>V</i><i><sub>FEMAX</sub></i>).  Typical
+          value = 6.
+      vemin:
+        slot_uri: cim:ExcIEEEAC8B.vemin
+        range: PU
+        multivalued: false
+        required: true
+        description: Minimum exciter voltage output (<i>V</i><i><sub>EMIN</sub></i>)
+          (&lt;= 0).  Typical value = 0.
+      ke:
+        slot_uri: cim:ExcIEEEAC8B.ke
+        range: PU
+        multivalued: false
+        required: true
+        description: Exciter constant related to self-excited field (<i>K</i><i><sub>E</sub></i>).  Typical
+          value = 1.
+      kc:
+        slot_uri: cim:ExcIEEEAC8B.kc
+        range: PU
+        multivalued: false
+        required: true
+        description: Rectifier loading factor proportional to commutating reactance
+          (<i>K</i><i><sub>C</sub></i>) (&gt;= 0). Typical value = 0,55.
+      kd:
+        slot_uri: cim:ExcIEEEAC8B.kd
+        range: PU
+        multivalued: false
+        required: true
+        description: Demagnetizing factor, a function of exciter alternator reactances
+          (<i>K</i><i><sub>D</sub></i>) (&gt;= 0).  Typical value = 1,1.
+      ve1:
+        slot_uri: cim:ExcIEEEAC8B.ve1
+        range: PU
+        multivalued: false
+        required: true
+        description: Exciter alternator output voltages back of commutating reactance
+          at which saturation is defined (<i>V</i><i><sub>E1</sub></i>) (&gt; 0).  Typical
+          value = 6,5.
+      seve1:
+        slot_uri: cim:ExcIEEEAC8B.seve1
+        range: float
+        multivalued: false
+        required: true
+        description: Exciter saturation function value at the corresponding exciter
+          voltage, <i>V</i><i><sub>E1</sub></i>, back of commutating reactance (<i>S</i><i><sub>E</sub></i><i>[V</i><i><sub>E1</sub></i><i>]</i>)
+          (&gt;= 0).  Typical value = 0,3.
+      ve2:
+        slot_uri: cim:ExcIEEEAC8B.ve2
+        range: PU
+        multivalued: false
+        required: true
+        description: Exciter alternator output voltages back of commutating reactance
+          at which saturation is defined (<i>V</i><i><sub>E2</sub></i>) (&gt; 0).  Typical
+          value = 9.
+      seve2:
+        slot_uri: cim:ExcIEEEAC8B.seve2
+        range: float
+        multivalued: false
+        required: true
+        description: Exciter saturation function value at the corresponding exciter
+          voltage, <i>V</i><i><sub>E2</sub></i>, back of commutating reactance (<i>S</i><i><sub>E</sub></i><i>[V</i><i><sub>E2</sub></i><i>]</i>)
+          (&gt;= 0).  Typical value = 3.
+    is_a: ExcitationSystemDynamics
+    description: 'IEEE 421.5-2005 type AC8B model. This model represents a PID voltage
+      regulator with either a brushless exciter or DC exciter. The AVR in this model
+      consists of PID control, with separate constants for the proportional (<i>K</i><i><sub>PR</sub></i>),
+      integral (<i>K</i><i><sub>IR</sub></i>), and derivative (<i>K</i><i><sub>DR</sub></i>)
+      gains. The representation of the brushless exciter (<i>T</i><i><sub>E</sub></i>,
+      <i>K</i><i><sub>E</sub></i>, <i>S</i><i><sub>E</sub></i>, <i>K</i><i><sub>C</sub></i>,
+      <i>K</i><i><sub>D</sub></i>) is similar to the model type AC2A. The type AC8B
+      model can be used to represent static voltage regulators applied to brushless
+      excitation systems. Digitally based voltage regulators feeding DC rotating main
+      exciters can be represented with the AC type AC8B model with the parameters
+      <i>K</i><i><sub>C</sub></i> and <i>K</i><i><sub>D</sub></i> set to 0.  For thyristor
+      power stages fed from the generator terminals, the limits <i>V</i><i><sub>RMAX</sub></i>
+      and <i>V</i><i><sub>RMIN</sub></i><i> </i>should be a function of terminal voltage:
+      V<i><sub>T</sub></i> x <i>V</i><i><sub>RMAX</sub></i><sub> </sub>and <i>V</i><i><sub>T</sub></i>
+      x <i>V</i><i><sub>RMIN</sub></i>.
+
+      Reference: IEEE 421.5-2005, 6.8.'
+  ExcIEEEDC1A:
+    class_uri: cim:ExcIEEEDC1A
+    attributes:
+      ka:
+        slot_uri: cim:ExcIEEEDC1A.ka
+        range: PU
+        multivalued: false
+        required: true
+        description: Voltage regulator gain (<i>K</i><i><sub>A</sub></i>) (&gt; 0).  Typical
+          value = 46.
+      ta:
+        slot_uri: cim:ExcIEEEDC1A.ta
+        range: Seconds
+        multivalued: false
+        required: true
+        description: Voltage regulator time constant (<i>T</i><i><sub>A</sub></i>)
+          (&gt; 0).  Typical value = 0,06.
+      tb:
+        slot_uri: cim:ExcIEEEDC1A.tb
+        range: Seconds
+        multivalued: false
+        required: true
+        description: Voltage regulator time constant (<i>T</i><i><sub>B</sub></i>)
+          (&gt;= 0).  Typical value = 0.
+      tc:
+        slot_uri: cim:ExcIEEEDC1A.tc
+        range: Seconds
+        multivalued: false
+        required: true
+        description: Voltage regulator time constant (<i>T</i><i><sub>C</sub></i>)
+          (&gt;= 0).  Typical value = 0.
+      vrmax:
+        slot_uri: cim:ExcIEEEDC1A.vrmax
+        range: PU
+        multivalued: false
+        required: true
+        description: Maximum voltage regulator output (<i>V</i><i><sub>RMAX</sub></i>)
+          (&gt; ExcIEEEDC1A.vrmin).  Typical value = 1.
+      vrmin:
+        slot_uri: cim:ExcIEEEDC1A.vrmin
+        range: PU
+        multivalued: false
+        required: true
+        description: Minimum voltage regulator output (<i>V</i><i><sub>RMIN</sub></i>)
+          (&lt; 0 and &lt; ExcIEEEDC1A.vrmax).  Typical value = -0,9.
+      ke:
+        slot_uri: cim:ExcIEEEDC1A.ke
+        range: PU
+        multivalued: false
+        required: true
+        description: Exciter constant related to self-excited field (<i>K</i><i><sub>E</sub></i>).  Typical
+          value = 0.
+      te:
+        slot_uri: cim:ExcIEEEDC1A.te
+        range: Seconds
+        multivalued: false
+        required: true
+        description: Exciter time constant, integration rate associated with exciter
+          control (<i>T</i><i><sub>E</sub></i>) (&gt; 0).  Typical value = 0,46.
+      kf:
+        slot_uri: cim:ExcIEEEDC1A.kf
+        range: PU
+        multivalued: false
+        required: true
+        description: Excitation control system stabilizer gain (<i>K</i><i><sub>F</sub></i>)
+          (&gt;= 0).  Typical value = 0.1.
+      tf:
+        slot_uri: cim:ExcIEEEDC1A.tf
+        range: Seconds
+        multivalued: false
+        required: true
+        description: Excitation control system stabilizer time constant (<i>T</i><i><sub>F</sub></i>)
+          (&gt; 0).  Typical value = 1.
+      efd1:
+        slot_uri: cim:ExcIEEEDC1A.efd1
+        range: PU
+        multivalued: false
+        required: true
+        description: Exciter voltage at which exciter saturation is defined (<i>E</i><i><sub>FD1</sub></i>)
+          (&gt; 0).  Typical value = 3,1.
+      seefd1:
+        slot_uri: cim:ExcIEEEDC1A.seefd1
+        range: float
+        multivalued: false
+        required: true
+        description: Exciter saturation function value at the corresponding exciter
+          voltage, <i>E</i><i><sub>FD1</sub></i> (<i>S</i><i><sub>E</sub></i><i>[E</i><i><sub>FD1</sub></i><i>]</i>)
+          (&gt;= 0).  Typical value = 0.33.
+      efd2:
+        slot_uri: cim:ExcIEEEDC1A.efd2
+        range: PU
+        multivalued: false
+        required: true
+        description: Exciter voltage at which exciter saturation is defined (<i>E</i><i><sub>FD2</sub></i>)
+          (&gt; 0).  Typical value = 2,3.
+      seefd2:
+        slot_uri: cim:ExcIEEEDC1A.seefd2
+        range: float
+        multivalued: false
+        required: true
+        description: Exciter saturation function value at the corresponding exciter
+          voltage, <i>E</i><i><sub>FD2</sub></i> (<i>S</i><i><sub>E</sub></i><i>[E</i><i><sub>FD2</sub></i><i>]</i>)
+          (&gt;= 0).  Typical value = 0,1.
+      uelin:
+        slot_uri: cim:ExcIEEEDC1A.uelin
+        range: boolean
+        multivalued: false
+        required: true
+        description: 'UEL input (<i>uelin</i>).
+
+          true = input is connected to the HV gate
+
+          false = input connects to the error signal.
+
+          Typical value = true.'
+      exclim:
+        slot_uri: cim:ExcIEEEDC1A.exclim
+        range: boolean
+        multivalued: false
+        required: true
+        description: '(<i>exclim</i>).  IEEE standard is ambiguous about lower limit
+          on exciter output.
+
+          true = a lower limit of zero is applied to integrator output
+
+          false = a lower limit of zero is not applied to integrator output.
+
+          Typical value = true.'
+    is_a: ExcitationSystemDynamics
+    description: 'IEEE 421.5-2005 type DC1A model. This model represents field-controlled
+      DC commutator exciters with continuously acting voltage regulators (especially
+      the direct-acting rheostatic, rotating amplifier, and magnetic amplifier types).  Because
+      this model has been widely implemented by the industry, it is sometimes used
+      to represent other types of systems when detailed data for them are not available
+      or when a simplified model is required.
+
+      Reference: IEEE 421.5-2005, 5.1.'
+  ExcIEEEDC2A:
+    class_uri: cim:ExcIEEEDC2A
+    attributes:
+      efd1:
+        slot_uri: cim:ExcIEEEDC2A.efd1
+        range: PU
+        multivalued: false
+        required: true
+        description: Exciter voltage at which exciter saturation is defined (<i>E</i><i><sub>FD1</sub></i>)
+          (&gt; 0).  Typical value = 3,05.
+      efd2:
+        slot_uri: cim:ExcIEEEDC2A.efd2
+        range: PU
+        multivalued: false
+        required: true
+        description: Exciter voltage at which exciter saturation is defined (<i>E</i><i><sub>FD2</sub></i>)
+          (&gt; 0).  Typical value = 2,29.
+      exclim:
+        slot_uri: cim:ExcIEEEDC2A.exclim
+        range: PU
+        multivalued: false
+        required: true
+        description: (<i>exclim</i>).  IEEE standard is ambiguous about lower limit
+          on exciter output. Typical value = - 999  which means that there is no limit
+          applied.
+      ka:
+        slot_uri: cim:ExcIEEEDC2A.ka
+        range: PU
+        multivalued: false
+        required: true
+        description: Voltage regulator gain (<i>K</i><i><sub>A</sub></i>) (&gt; 0).  Typical
+          value = 300.
+      ke:
+        slot_uri: cim:ExcIEEEDC2A.ke
+        range: PU
+        multivalued: false
+        required: true
+        description: Exciter constant related to self-excited field (<i>K</i><i><sub>E</sub></i>).  Typical
+          value = 1.
+      kf:
+        slot_uri: cim:ExcIEEEDC2A.kf
+        range: PU
+        multivalued: false
+        required: true
+        description: Excitation control system stabilizer gain (<i>K</i><i><sub>F</sub></i>)
+          (&gt;= 0).  Typical value = 0,1.
+      seefd1:
+        slot_uri: cim:ExcIEEEDC2A.seefd1
+        range: float
+        multivalued: false
+        required: true
+        description: Exciter saturation function value at the corresponding exciter
+          voltage, <i>E</i><i><sub>FD1</sub></i> (<i>S</i><i><sub>E</sub></i><i>[E</i><i><sub>FD1</sub></i><i>]</i>)
+          (&gt;= 0).  Typical value = 0,279.
+      seefd2:
+        slot_uri: cim:ExcIEEEDC2A.seefd2
+        range: float
+        multivalued: false
+        required: true
+        description: Exciter saturation function value at the corresponding exciter
+          voltage, <i>E</i><i><sub>FD2</sub></i> (<i>S</i><i><sub>E</sub></i><i>[E</i><i><sub>FD2</sub></i><i>]</i>)
+          (&gt;= 0).  Typical value = 0,117.
+      ta:
+        slot_uri: cim:ExcIEEEDC2A.ta
+        range: Seconds
+        multivalued: false
+        required: true
+        description: Voltage regulator time constant (<i>T</i><i><sub>A</sub></i>)
+          (&gt; 0).  Typical value = 0,01.
+      tb:
+        slot_uri: cim:ExcIEEEDC2A.tb
+        range: Seconds
+        multivalued: false
+        required: true
+        description: Voltage regulator time constant (<i>T</i><i><sub>B</sub></i>)
+          (&gt;= 0).  Typical value = 0.
+      tc:
+        slot_uri: cim:ExcIEEEDC2A.tc
+        range: Seconds
+        multivalued: false
+        required: true
+        description: Voltage regulator time constant (<i>T</i><i><sub>C</sub></i>)
+          (&gt;= 0).  Typical value = 0.
+      te:
+        slot_uri: cim:ExcIEEEDC2A.te
+        range: Seconds
+        multivalued: false
+        required: true
+        description: Exciter time constant, integration rate associated with exciter
+          control (<i>T</i><i><sub>E</sub></i>) (&gt; 0).  Typical value = 1,33.
+      tf:
+        slot_uri: cim:ExcIEEEDC2A.tf
+        range: Seconds
+        multivalued: false
+        required: true
+        description: Excitation control system stabilizer time constant (<i>T</i><i><sub>F</sub></i>)
+          (&gt; 0).  Typical value = 0,675.
+      uelin:
+        slot_uri: cim:ExcIEEEDC2A.uelin
+        range: boolean
+        multivalued: false
+        required: true
+        description: 'UEL input (<i>uelin</i>).
+
+          true = input is connected to the HV gate
+
+          false = input connects to the error signal.
+
+          Typical value = true.'
+      vrmax:
+        slot_uri: cim:ExcIEEEDC2A.vrmax
+        range: PU
+        multivalued: false
+        required: true
+        description: Maximum voltage regulator output (<i>V</i><i><sub>RMAX</sub></i>)(&gt;
+          ExcIEEEDC2A.vrmin).  Typical value = 4,95.
+      vrmin:
+        slot_uri: cim:ExcIEEEDC2A.vrmin
+        range: PU
+        multivalued: false
+        required: true
+        description: Minimum voltage regulator output (<i>V</i><i><sub>RMIN</sub></i>)
+          (&lt; 0 and &lt; ExcIEEEDC2A.vrmax).  Typical value = -4,9.
+    is_a: ExcitationSystemDynamics
+    description: 'IEEE 421.5-2005 type DC2A model. This model represents field-controlled
+      DC commutator exciters with continuously acting voltage regulators having supplies
+      obtained from the generator or auxiliary bus.  It differs from the type DC1A
+      model only in the voltage regulator output limits, which are now proportional
+      to terminal voltage <i>V</i><i><sub>T</sub></i>.
+
+      It is representative of solid-state replacements for various forms of older
+      mechanical and rotating amplifier regulating equipment connected to DC commutator
+      exciters.
+
+      Reference: IEEE 421.5-2005, 5.2.'
+  ExcIEEEDC3A:
+    class_uri: cim:ExcIEEEDC3A
+    attributes:
+      trh:
+        slot_uri: cim:ExcIEEEDC3A.trh
+        range: Seconds
+        multivalued: false
+        required: true
+        description: Rheostat travel time (<i>T</i><i><sub>RH</sub></i>) (&gt; 0).  Typical
+          value = 20.
+      kv:
+        slot_uri: cim:ExcIEEEDC3A.kv
+        range: PU
+        multivalued: false
+        required: true
+        description: Fast raise/lower contact setting (<i>K</i><i><sub>V</sub></i>)
+          (&gt; 0).  Typical value = 0,05.
+      vrmax:
+        slot_uri: cim:ExcIEEEDC3A.vrmax
+        range: PU
+        multivalued: false
+        required: true
+        description: Maximum voltage regulator output (<i>V</i><i><sub>RMAX</sub></i>)
+          (&gt; 0).  Typical value = 1.
+      vrmin:
+        slot_uri: cim:ExcIEEEDC3A.vrmin
+        range: PU
+        multivalued: false
+        required: true
+        description: Minimum voltage regulator output (<i>V</i><i><sub>RMIN</sub></i>)
+          (&lt;= 0).  Typical value = 0.
+      te:
+        slot_uri: cim:ExcIEEEDC3A.te
+        range: Seconds
+        multivalued: false
+        required: true
+        description: Exciter time constant, integration rate associated with exciter
+          control (<i>T</i><i><sub>E</sub></i>) (&gt; 0).  Typical value = 0,5.
+      ke:
+        slot_uri: cim:ExcIEEEDC3A.ke
+        range: PU
+        multivalued: false
+        required: true
+        description: Exciter constant related to self-excited field (<i>K</i><i><sub>E</sub></i>).  Typical
+          value = 0,05.
+      efd1:
+        slot_uri: cim:ExcIEEEDC3A.efd1
+        range: PU
+        multivalued: false
+        required: true
+        description: Exciter voltage at which exciter saturation is defined (<i>E</i><i><sub>FD1</sub></i>)
+          (&gt; 0).  Typical value = 3,375.
+      seefd1:
+        slot_uri: cim:ExcIEEEDC3A.seefd1
+        range: float
+        multivalued: false
+        required: true
+        description: Exciter saturation function value at the corresponding exciter
+          voltage, <i>E</i><i><sub>FD1</sub></i> (<i>S</i><i><sub>E</sub></i><i>[E</i><i><sub>FD1</sub></i><i>]</i>)
+          (&gt;= 0).  Typical value = 0,267.
+      efd2:
+        slot_uri: cim:ExcIEEEDC3A.efd2
+        range: PU
+        multivalued: false
+        required: true
+        description: Exciter voltage at which exciter saturation is defined (<i>E</i><i><sub>FD2</sub></i>)
+          (&gt; 0).  Typical value = 3,15.
+      seefd2:
+        slot_uri: cim:ExcIEEEDC3A.seefd2
+        range: float
+        multivalued: false
+        required: true
+        description: Exciter saturation function value at the corresponding exciter
+          voltage, <i>E</i><i><sub>FD2</sub></i> (<i>S</i><i><sub>E</sub></i><i>[E</i><i><sub>FD2</sub></i><i>]</i>)
+          (&gt;= 0).  Typical value = 0,068.
+      exclim:
+        slot_uri: cim:ExcIEEEDC3A.exclim
+        range: boolean
+        multivalued: false
+        required: true
+        description: '(<i>exclim</i>).  IEEE standard is ambiguous about lower limit
+          on exciter output.
+
+          true = a lower limit of zero is applied to integrator output
+
+          false = a lower limit of zero is not applied to integrator output.
+
+          Typical value = true.'
+    is_a: ExcitationSystemDynamics
+    description: 'IEEE 421.5-2005 type DC3A model. This model represents older systems,
+      in particular those DC commutator exciters with non-continuously acting regulators
+      that were commonly used before the development of the continuously acting varieties.  These
+      systems respond at basically two different rates, depending upon the magnitude
+      of voltage error. For small errors, adjustment is made periodically with a signal
+      to a motor-operated rheostat. Larger errors cause resistors to be quickly shorted
+      or inserted and a strong forcing signal applied to the exciter. Continuous motion
+      of the motor-operated rheostat occurs for these larger error signals, even though
+      it is bypassed by contactor action.
+
+      Reference: IEEE 421.5-2005, 5.3.'
+  ExcIEEEDC4B:
+    class_uri: cim:ExcIEEEDC4B
+    attributes:
+      ka:
+        slot_uri: cim:ExcIEEEDC4B.ka
+        range: PU
+        multivalued: false
+        required: true
+        description: Voltage regulator gain (<i>K</i><i><sub>A</sub></i>) (&gt; 0).  Typical
+          value = 1.
+      ta:
+        slot_uri: cim:ExcIEEEDC4B.ta
+        range: Seconds
+        multivalued: false
+        required: true
+        description: Voltage regulator time constant (<i>T</i><i><sub>A</sub></i>)
+          (&gt; 0).  Typical value = 0,2.
+      kp:
+        slot_uri: cim:ExcIEEEDC4B.kp
+        range: PU
+        multivalued: false
+        required: true
+        description: Regulator proportional gain (<i>K</i><i><sub>P</sub></i>) (&gt;=
+          0).  Typical value = 20.
+      ki:
+        slot_uri: cim:ExcIEEEDC4B.ki
+        range: PU
+        multivalued: false
+        required: true
+        description: Regulator integral gain (<i>K</i><i><sub>I</sub></i>) (&gt;=
+          0).  Typical value = 20.
+      kd:
+        slot_uri: cim:ExcIEEEDC4B.kd
+        range: PU
+        multivalued: false
+        required: true
+        description: Regulator derivative gain (<i>K</i><i><sub>D</sub></i>) (&gt;=
+          0).  Typical value = 20.
+      td:
+        slot_uri: cim:ExcIEEEDC4B.td
+        range: Seconds
+        multivalued: false
+        required: true
+        description: Regulator derivative filter time constant (<i>T</i><i><sub>D</sub></i>)
+          (&gt; 0 if ExcIEEEDC4B.kd &gt; 0).  Typical value = 0,01.
+      vrmax:
+        slot_uri: cim:ExcIEEEDC4B.vrmax
+        range: PU
+        multivalued: false
+        required: true
+        description: Maximum voltage regulator output (<i>V</i><i><sub>RMAX</sub></i>)
+          (&gt; ExcIEEEDC4B.vrmin).  Typical value = 2,7.
+      vrmin:
+        slot_uri: cim:ExcIEEEDC4B.vrmin
+        range: PU
+        multivalued: false
+        required: true
+        description: Minimum voltage regulator output (<i>V</i><i><sub>RMIN</sub></i>)
+          (&lt;= 0 and &lt; ExcIEEEDC4B.vrmax).  Typical value = -0,9.
+      ke:
+        slot_uri: cim:ExcIEEEDC4B.ke
+        range: PU
+        multivalued: false
+        required: true
+        description: Exciter constant related to self-excited field (<i>K</i><i><sub>E</sub></i>).  Typical
+          value = 1.
+      te:
+        slot_uri: cim:ExcIEEEDC4B.te
+        range: Seconds
+        multivalued: false
+        required: true
+        description: Exciter time constant, integration rate associated with exciter
+          control (<i>T</i><i><sub>E</sub></i>) (&gt; 0).  Typical value = 0,8.
+      kf:
+        slot_uri: cim:ExcIEEEDC4B.kf
+        range: PU
+        multivalued: false
+        required: true
+        description: Excitation control system stabilizer gain (<i>K</i><i><sub>F</sub></i>)
+          (&gt;= 0).  Typical value = 0.
+      tf:
+        slot_uri: cim:ExcIEEEDC4B.tf
+        range: Seconds
+        multivalued: false
+        required: true
+        description: Excitation control system stabilizer time constant (<i>T</i><i><sub>F</sub></i>)
+          (&gt;= 0).  Typical value = 1.
+      efd1:
+        slot_uri: cim:ExcIEEEDC4B.efd1
+        range: PU
+        multivalued: false
+        required: true
+        description: Exciter voltage at which exciter saturation is defined (<i>E</i><i><sub>FD1</sub></i>)
+          (&gt; 0).  Typical value = 1,75.
+      seefd1:
+        slot_uri: cim:ExcIEEEDC4B.seefd1
+        range: float
+        multivalued: false
+        required: true
+        description: Exciter saturation function value at the corresponding exciter
+          voltage, <i>E</i><i><sub>FD1</sub></i> (<i>S</i><i><sub>E</sub></i><i>[E</i><i><sub>FD1</sub></i><i>]</i>)
+          (&gt;= 0).  Typical value = 0,08.
+      efd2:
+        slot_uri: cim:ExcIEEEDC4B.efd2
+        range: PU
+        multivalued: false
+        required: true
+        description: Exciter voltage at which exciter saturation is defined (<i>E</i><i><sub>FD2</sub></i>)
+          (&gt; 0).  Typical value = 2,33.
+      seefd2:
+        slot_uri: cim:ExcIEEEDC4B.seefd2
+        range: float
+        multivalued: false
+        required: true
+        description: Exciter saturation function value at the corresponding exciter
+          voltage, <i>E</i><i><sub>FD2</sub></i> (<i>S</i><i><sub>E</sub></i><i>[E</i><i><sub>FD2</sub></i><i>]</i>)
+          (&gt;= 0).  Typical value = 0,27.
+      vemin:
+        slot_uri: cim:ExcIEEEDC4B.vemin
+        range: PU
+        multivalued: false
+        required: true
+        description: Minimum exciter voltage output (<i>V</i><i><sub>EMIN</sub></i>)
+          (&lt;= 0).  Typical value = 0.
+      oelin:
+        slot_uri: cim:ExcIEEEDC4B.oelin
+        range: boolean
+        multivalued: false
+        required: true
+        description: 'OEL input (<i>OELin</i>).
+
+          true = LV gate
+
+          false = subtract from error signal.
+
+          Typical value = true.'
+      uelin:
+        slot_uri: cim:ExcIEEEDC4B.uelin
+        range: boolean
+        multivalued: false
+        required: true
+        description: 'UEL input (<i>UELin</i>).
+
+          true = HV gate
+
+          false = add to error signal.
+
+          Typical value = true.'
+    is_a: ExcitationSystemDynamics
+    description: 'IEEE 421.5-2005 type DC4B model. These excitation systems utilize
+      a field-controlled DC commutator exciter with a continuously acting voltage
+      regulator having supplies obtained from the generator or auxiliary bus.
+
+      Reference: IEEE 421.5-2005, 5.4.'
+  ExcIEEEST1A:
+    class_uri: cim:ExcIEEEST1A
+    attributes:
+      ilr:
+        slot_uri: cim:ExcIEEEST1A.ilr
+        range: PU
+        multivalued: false
+        required: true
+        description: Exciter output current limit reference (<i>I</i><i><sub>LR</sub></i><i>)</i>.  Typical
+          value = 0.
+      ka:
+        slot_uri: cim:ExcIEEEST1A.ka
+        range: PU
+        multivalued: false
+        required: true
+        description: Voltage regulator gain (<i>K</i><i><sub>A</sub></i>) (&gt; 0).  Typical
+          value = 190.
+      kc:
+        slot_uri: cim:ExcIEEEST1A.kc
+        range: PU
+        multivalued: false
+        required: true
+        description: Rectifier loading factor proportional to commutating reactance
+          (<i>K</i><i><sub>C</sub></i>) (&gt;= 0). Typical value = 0,08.
+      kf:
+        slot_uri: cim:ExcIEEEST1A.kf
+        range: PU
+        multivalued: false
+        required: true
+        description: Excitation control system stabilizer gains (<i>K</i><i><sub>F</sub></i>)
+          (&gt;= 0).  Typical value = 0.
+      klr:
+        slot_uri: cim:ExcIEEEST1A.klr
+        range: PU
+        multivalued: false
+        required: true
+        description: Exciter output current limiter gain (<i>K</i><i><sub>LR</sub></i>).  Typical
+          value = 0.
+      pssin:
+        slot_uri: cim:ExcIEEEST1A.pssin
+        range: boolean
+        multivalued: false
+        required: true
+        description: 'Selector of the Power System Stabilizer (PSS) input (<i>PSSin</i>).
+
+          true = PSS input (<i>Vs</i>) added to error signal
+
+          false = PSS input (<i>Vs</i>) added to voltage regulator output.
+
+          Typical value = true.'
+      ta:
+        slot_uri: cim:ExcIEEEST1A.ta
+        range: Seconds
+        multivalued: false
+        required: true
+        description: Voltage regulator time constant (<i>T</i><i><sub>A</sub></i>)
+          (&gt;= 0).  Typical value = 0.
+      tb:
+        slot_uri: cim:ExcIEEEST1A.tb
+        range: Seconds
+        multivalued: false
+        required: true
+        description: Voltage regulator time constant (<i>T</i><i><sub>B</sub></i>)
+          (&gt;= 0).  Typical value = 10.
+      tb1:
+        slot_uri: cim:ExcIEEEST1A.tb1
+        range: Seconds
+        multivalued: false
+        required: true
+        description: Voltage regulator time constant (<i>T</i><i><sub>B1</sub></i>)
+          (&gt;= 0).  Typical value = 0.
+      tc:
+        slot_uri: cim:ExcIEEEST1A.tc
+        range: Seconds
+        multivalued: false
+        required: true
+        description: Voltage regulator time constant (<i>T</i><i><sub>C</sub></i>)
+          (&gt;= 0).  Typical value = 1.
+      tc1:
+        slot_uri: cim:ExcIEEEST1A.tc1
+        range: Seconds
+        multivalued: false
+        required: true
+        description: Voltage regulator time constant (<i>T</i><i><sub>C1</sub></i>)
+          (&gt;= 0).  Typical value = 0.
+      tf:
+        slot_uri: cim:ExcIEEEST1A.tf
+        range: Seconds
+        multivalued: false
+        required: true
+        description: Excitation control system stabilizer time constant (<i>T</i><i><sub>F</sub></i>)
+          (&gt;= 0).  Typical value = 1.
+      uelin:
+        slot_uri: cim:ExcIEEEST1A.uelin
+        range: ExcIEEEST1AUELselectorKind
+        multivalued: false
+        required: true
+        description: Selector of the connection of the UEL input (<i>UELin</i>).  Typical
+          value = ignoreUELsignal.
+      vamax:
+        slot_uri: cim:ExcIEEEST1A.vamax
+        range: PU
+        multivalued: false
+        required: true
+        description: Maximum voltage regulator output (<i>V</i><i><sub>AMAX</sub></i>)
+          (&gt; 0).  Typical value = 14,5.
+      vamin:
+        slot_uri: cim:ExcIEEEST1A.vamin
+        range: PU
+        multivalued: false
+        required: true
+        description: Minimum voltage regulator output (<i>V</i><i><sub>AMIN</sub></i>)
+          (&lt; 0).  Typical value = -14,5.
+      vimax:
+        slot_uri: cim:ExcIEEEST1A.vimax
+        range: PU
+        multivalued: false
+        required: true
+        description: Maximum voltage regulator input limit (<i>V</i><i><sub>IMAX</sub></i>)
+          (&gt; 0).  Typical value = 999.
+      vimin:
+        slot_uri: cim:ExcIEEEST1A.vimin
+        range: PU
+        multivalued: false
+        required: true
+        description: Minimum voltage regulator input limit (<i>V</i><i><sub>IMIN</sub></i>)
+          (&lt; 0).  Typical value = -999.
+      vrmax:
+        slot_uri: cim:ExcIEEEST1A.vrmax
+        range: PU
+        multivalued: false
+        required: true
+        description: Maximum voltage regulator outputs (<i>V</i><i><sub>RMAX</sub></i>)
+          (&gt; 0).  Typical value = 7,8.
+      vrmin:
+        slot_uri: cim:ExcIEEEST1A.vrmin
+        range: PU
+        multivalued: false
+        required: true
+        description: Minimum voltage regulator outputs (<i>V</i><i><sub>RMIN</sub></i>)
+          (&lt; 0).  Typical value = -6,7.
+    is_a: ExcitationSystemDynamics
+    description: "IEEE 421.5-2005 type ST1A model. This model represents systems in\
+      \ which excitation power is supplied through a transformer from the generator\
+      \ terminals (or the unit\u2019s auxiliary bus) and is regulated by a controlled\
+      \ rectifier.  The maximum exciter voltage available from such systems is directly\
+      \ related to the generator terminal voltage.\nReference: IEEE 421.5-2005, 7.1."
+  ExcIEEEST2A:
+    class_uri: cim:ExcIEEEST2A
+    attributes:
+      ka:
+        slot_uri: cim:ExcIEEEST2A.ka
+        range: PU
+        multivalued: false
+        required: true
+        description: Voltage regulator gain (<i>K</i><i><sub>A</sub></i>) (&gt; 0).  Typical
+          value = 120.
+      ta:
+        slot_uri: cim:ExcIEEEST2A.ta
+        range: Seconds
+        multivalued: false
+        required: true
+        description: Voltage regulator time constant (<i>T</i><i><sub>A</sub></i>)
+          (&gt; 0).  Typical value = 0,15.
+      vrmax:
+        slot_uri: cim:ExcIEEEST2A.vrmax
+        range: PU
+        multivalued: false
+        required: true
+        description: Maximum voltage regulator outputs (<i>V</i><i><sub>RMAX</sub></i>)
+          (&gt; 0).  Typical value = 1.
+      vrmin:
+        slot_uri: cim:ExcIEEEST2A.vrmin
+        range: PU
+        multivalued: false
+        required: true
+        description: Minimum voltage regulator outputs (<i>V</i><i><sub>RMIN</sub></i>)
+          (&lt;= 0).  Typical value = 0.
+      ke:
+        slot_uri: cim:ExcIEEEST2A.ke
+        range: PU
+        multivalued: false
+        required: true
+        description: Exciter constant related to self-excited field (<i>K</i><i><sub>E</sub></i>).  Typical
+          value = 1.
+      te:
+        slot_uri: cim:ExcIEEEST2A.te
+        range: Seconds
+        multivalued: false
+        required: true
+        description: Exciter time constant, integration rate associated with exciter
+          control (<i>T</i><i><sub>E</sub></i>) (&gt; 0).  Typical value = 0,5.
+      kf:
+        slot_uri: cim:ExcIEEEST2A.kf
+        range: PU
+        multivalued: false
+        required: true
+        description: Excitation control system stabilizer gains (<i>K</i><i><sub>F</sub></i>)
+          (&gt;= 0).  Typical value = 0,05.
+      tf:
+        slot_uri: cim:ExcIEEEST2A.tf
+        range: Seconds
+        multivalued: false
+        required: true
+        description: Excitation control system stabilizer time constant (<i>T</i><i><sub>F</sub></i>)
+          (&gt;= 0).  Typical value = 1.
+      kp:
+        slot_uri: cim:ExcIEEEST2A.kp
+        range: PU
+        multivalued: false
+        required: true
+        description: Potential circuit gain coefficient (<i>K</i><i><sub>P</sub></i>)
+          (&gt;= 0).  Typical value = 4,88.
+      ki:
+        slot_uri: cim:ExcIEEEST2A.ki
+        range: PU
+        multivalued: false
+        required: true
+        description: Potential circuit gain coefficient (<i>K</i><i><sub>I</sub></i>)
+          (&gt;= 0).  Typical value = 8.
+      kc:
+        slot_uri: cim:ExcIEEEST2A.kc
+        range: PU
+        multivalued: false
+        required: true
+        description: Rectifier loading factor proportional to commutating reactance
+          (<i>K</i><i><sub>C</sub></i>) (&gt;= 0). Typical value = 1,82.
+      efdmax:
+        slot_uri: cim:ExcIEEEST2A.efdmax
+        range: PU
+        multivalued: false
+        required: true
+        description: Maximum field voltage (<i>E</i><i><sub>FDMax</sub></i>) (&gt;=
+          0).  Typical value = 99.
+      uelin:
+        slot_uri: cim:ExcIEEEST2A.uelin
+        range: boolean
+        multivalued: false
+        required: true
+        description: 'UEL input (<i>UELin</i>).
+
+          true = HV gate
+
+          false = add to error signal.
+
+          Typical value = true.'
+    is_a: ExcitationSystemDynamics
+    description: 'IEEE 421.5-2005 type ST2A model. Some static systems use both current
+      and voltage sources (generator terminal quantities) to comprise the power source.  The
+      regulator controls the exciter output through controlled saturation of the power
+      transformer components.  These compound-source rectifier excitation systems
+      are designated type ST2A and are represented by ExcIEEEST2A.
+
+      Reference: IEEE 421.5-2005, 7.2.'
+  ExcIEEEST3A:
+    class_uri: cim:ExcIEEEST3A
+    attributes:
+      vimax:
+        slot_uri: cim:ExcIEEEST3A.vimax
+        range: PU
+        multivalued: false
+        required: true
+        description: Maximum voltage regulator input limit (<i>V</i><i><sub>IMAX</sub></i>)
+          (&gt; 0).  Typical value = 0,2.
+      vimin:
+        slot_uri: cim:ExcIEEEST3A.vimin
+        range: PU
+        multivalued: false
+        required: true
+        description: Minimum voltage regulator input limit (<i>V</i><i><sub>IMIN</sub></i>)
+          (&lt; 0).  Typical value = -0,2.
+      ka:
+        slot_uri: cim:ExcIEEEST3A.ka
+        range: PU
+        multivalued: false
+        required: true
+        description: Voltage regulator gain (<i>K</i><i><sub>A</sub></i>) (&gt; 0).
+          This is parameter <i>K</i> in the IEEE standard. Typical value = 200.
+      ta:
+        slot_uri: cim:ExcIEEEST3A.ta
+        range: Seconds
+        multivalued: false
+        required: true
+        description: Voltage regulator time constant (<i>T</i><i><sub>A</sub></i>)
+          (&gt;= 0).  Typical value = 0.
+      tb:
+        slot_uri: cim:ExcIEEEST3A.tb
+        range: Seconds
+        multivalued: false
+        required: true
+        description: Voltage regulator time constant (<i>T</i><i><sub>B</sub></i>)
+          (&gt;= 0).  Typical value = 10.
+      tc:
+        slot_uri: cim:ExcIEEEST3A.tc
+        range: Seconds
+        multivalued: false
+        required: true
+        description: Voltage regulator time constant (<i>T</i><i><sub>C</sub></i>)
+          (&gt;= 0).  Typical value = 1.
+      vrmax:
+        slot_uri: cim:ExcIEEEST3A.vrmax
+        range: PU
+        multivalued: false
+        required: true
+        description: Maximum voltage regulator output (<i>V</i><i><sub>RMAX</sub></i>)
+          (&gt; 0).  Typical value = 10.
+      vrmin:
+        slot_uri: cim:ExcIEEEST3A.vrmin
+        range: PU
+        multivalued: false
+        required: true
+        description: Minimum voltage regulator output (<i>V</i><i><sub>RMIN</sub></i>)
+          (&lt; 0).  Typical value = -10.
+      km:
+        slot_uri: cim:ExcIEEEST3A.km
+        range: PU
+        multivalued: false
+        required: true
+        description: Forward gain constant of the inner loop field regulator (<i>K</i><i><sub>M</sub></i>)
+          (&gt; 0).  Typical value = 7,93.
+      tm:
+        slot_uri: cim:ExcIEEEST3A.tm
+        range: Seconds
+        multivalued: false
+        required: true
+        description: Forward time constant of inner loop field regulator (<i>T</i><i><sub>M</sub></i>)
+          (&gt; 0).  Typical value = 0,4.
+      vmmax:
+        slot_uri: cim:ExcIEEEST3A.vmmax
+        range: PU
+        multivalued: false
+        required: true
+        description: Maximum inner loop output (<i>V</i><i><sub>MMax</sub></i>) (&gt;
+          0).  Typical value = 1.
+      vmmin:
+        slot_uri: cim:ExcIEEEST3A.vmmin
+        range: PU
+        multivalued: false
+        required: true
+        description: Minimum inner loop output (<i>V</i><i><sub>MMin</sub></i>) (&lt;=
+          0).  Typical value = 0.
+      kg:
+        slot_uri: cim:ExcIEEEST3A.kg
+        range: PU
+        multivalued: false
+        required: true
+        description: Feedback gain constant of the inner loop field regulator (<i>K</i><i><sub>G</sub></i>)
+          (&gt;= 0).  Typical value = 1.
+      kp:
+        slot_uri: cim:ExcIEEEST3A.kp
+        range: PU
+        multivalued: false
+        required: true
+        description: Potential circuit gain coefficient (<i>K</i><i><sub>P</sub></i>)
+          (&gt; 0).  Typical value = 6,15.
+      thetap:
+        slot_uri: cim:ExcIEEEST3A.thetap
+        range: AngleDegrees
+        multivalued: false
+        required: true
+        description: Potential circuit phase angle (<i>thetap</i>).  Typical value
+          = 0.
+      ki:
+        slot_uri: cim:ExcIEEEST3A.ki
+        range: PU
+        multivalued: false
+        required: true
+        description: Potential circuit gain coefficient (<i>K</i><i><sub>I</sub></i>)
+          (&gt;= 0).  Typical value = 0.
+      kc:
+        slot_uri: cim:ExcIEEEST3A.kc
+        range: PU
+        multivalued: false
+        required: true
+        description: Rectifier loading factor proportional to commutating reactance
+          (<i>K</i><i><sub>C</sub></i>) (&gt;= 0). Typical value = 0,2.
+      xl:
+        slot_uri: cim:ExcIEEEST3A.xl
+        range: PU
+        multivalued: false
+        required: true
+        description: Reactance associated with potential source (<i>X</i><i><sub>L</sub></i>)
+          (&gt;= 0).  Typical value = 0,081.
+      vbmax:
+        slot_uri: cim:ExcIEEEST3A.vbmax
+        range: PU
+        multivalued: false
+        required: true
+        description: Maximum excitation voltage (<i>V</i><i><sub>BMax</sub></i>) (&gt;
+          0).  Typical value = 6,9.
+      vgmax:
+        slot_uri: cim:ExcIEEEST3A.vgmax
+        range: PU
+        multivalued: false
+        required: true
+        description: Maximum inner loop feedback voltage (<i>V</i><i><sub>GMax</sub></i>)
+          (&gt;= 0).  Typical value = 5,8.
+    is_a: ExcitationSystemDynamics
+    description: 'IEEE 421.5-2005 type ST3A model.  Some static systems utilize a
+      field voltage control loop to linearize the exciter control characteristic.
+      This also makes the output independent of supply source variations until supply
+      limitations are reached.  These systems utilize a variety of controlled-rectifier
+      designs: full thyristor complements or hybrid bridges in either series or shunt
+      configurations. The power source can consist of only a potential source, either
+      fed from the machine terminals or from internal windings. Some designs can have
+      compound power sources utilizing both machine potential and current. These power
+      sources are represented as phasor combinations of machine terminal current and
+      voltage and are accommodated by suitable parameters in model type ST3A which
+      is represented by ExcIEEEST3A.
+
+      Reference: IEEE 421.5-2005, 7.3.'
+  ExcIEEEST4B:
+    class_uri: cim:ExcIEEEST4B
+    attributes:
+      kpr:
+        slot_uri: cim:ExcIEEEST4B.kpr
+        range: PU
+        multivalued: false
+        required: true
+        description: Voltage regulator proportional gain (<i>K</i><i><sub>PR</sub></i>).  Typical
+          value = 10,75.
+      kir:
+        slot_uri: cim:ExcIEEEST4B.kir
+        range: PU
+        multivalued: false
+        required: true
+        description: Voltage regulator integral gain (<i>K</i><i><sub>IR</sub></i>).  Typical
+          value = 10,75.
+      ta:
+        slot_uri: cim:ExcIEEEST4B.ta
+        range: Seconds
+        multivalued: false
+        required: true
+        description: Voltage regulator time constant (<i>T</i><i><sub>A</sub></i>)
+          (&gt;= 0).  Typical value = 0,02.
+      vrmax:
+        slot_uri: cim:ExcIEEEST4B.vrmax
+        range: PU
+        multivalued: false
+        required: true
+        description: Maximum voltage regulator output (<i>V</i><i><sub>RMAX</sub></i>)
+          (&gt; 0).  Typical value = 1.
+      vrmin:
+        slot_uri: cim:ExcIEEEST4B.vrmin
+        range: PU
+        multivalued: false
+        required: true
+        description: Minimum voltage regulator output (<i>V</i><i><sub>RMIN</sub></i>)
+          (&lt; 0).  Typical value = -0,87.
+      kpm:
+        slot_uri: cim:ExcIEEEST4B.kpm
+        range: PU
+        multivalued: false
+        required: true
+        description: Voltage regulator proportional gain output (<i>K</i><i><sub>PM</sub></i>).  Typical
+          value = 1.
+      kim:
+        slot_uri: cim:ExcIEEEST4B.kim
+        range: PU
+        multivalued: false
+        required: true
+        description: Voltage regulator integral gain output (<i>K</i><i><sub>IM</sub></i>).  Typical
+          value = 0.
+      vmmax:
+        slot_uri: cim:ExcIEEEST4B.vmmax
+        range: PU
+        multivalued: false
+        required: true
+        description: Maximum inner loop output (<i>V</i><i><sub>MMax</sub></i>) (&gt;
+          ExcIEEEST4B.vmmin).  Typical value = 99.
+      vmmin:
+        slot_uri: cim:ExcIEEEST4B.vmmin
+        range: PU
+        multivalued: false
+        required: true
+        description: Minimum inner loop output (<i>V</i><i><sub>MMin</sub></i>) (&lt;
+          ExcIEEEST4B.vmmax).  Typical value = -99.
+      kg:
+        slot_uri: cim:ExcIEEEST4B.kg
+        range: PU
+        multivalued: false
+        required: true
+        description: Feedback gain constant of the inner loop field regulator (<i>K</i><i><sub>G</sub></i>)
+          (&gt;= 0).  Typical value = 0.
+      kp:
+        slot_uri: cim:ExcIEEEST4B.kp
+        range: PU
+        multivalued: false
+        required: true
+        description: Potential circuit gain coefficient (<i>K</i><i><sub>P</sub></i>)
+          (&gt; 0).  Typical value = 9,3.
+      thetap:
+        slot_uri: cim:ExcIEEEST4B.thetap
+        range: AngleDegrees
+        multivalued: false
+        required: true
+        description: Potential circuit phase angle (<i>thetap</i>).  Typical value
+          = 0.
+      ki:
+        slot_uri: cim:ExcIEEEST4B.ki
+        range: PU
+        multivalued: false
+        required: true
+        description: Potential circuit gain coefficient (<i>K</i><i><sub>I</sub></i>)
+          (&gt;= 0).  Typical value = 0.
+      kc:
+        slot_uri: cim:ExcIEEEST4B.kc
+        range: PU
+        multivalued: false
+        required: true
+        description: Rectifier loading factor proportional to commutating reactance
+          (<i>K</i><i><sub>C</sub></i>) (&gt;= 0). Typical value = 0,113.
+      xl:
+        slot_uri: cim:ExcIEEEST4B.xl
+        range: PU
+        multivalued: false
+        required: true
+        description: Reactance associated with potential source (<i>X</i><i><sub>L</sub></i>)
+          (&gt;= 0).  Typical value = 0,124.
+      vbmax:
+        slot_uri: cim:ExcIEEEST4B.vbmax
+        range: PU
+        multivalued: false
+        required: true
+        description: Maximum excitation voltage (<i>V</i><i><sub>BMax</sub></i>) (&gt;
+          0).  Typical value = 11,63.
+    is_a: ExcitationSystemDynamics
+    description: 'IEEE 421.5-2005 type ST4B model. This model is a variation of the
+      type ST3A model, with a proportional plus integral (PI) regulator block replacing
+      the lag-lead regulator characteristic that is in the ST3A model. Both potential
+      and compound source rectifier excitation systems are modelled.  The PI regulator
+      blocks have non-windup limits that are represented. The voltage regulator of
+      this model is typically implemented digitally.
+
+      Reference: IEEE 421.5-2005, 7.4.'
+  ExcIEEEST5B:
+    class_uri: cim:ExcIEEEST5B
+    attributes:
+      kr:
+        slot_uri: cim:ExcIEEEST5B.kr
+        range: PU
+        multivalued: false
+        required: true
+        description: Regulator gain (<i>K</i><i><sub>R</sub></i>) (&gt; 0).  Typical
+          value = 200.
+      t1:
+        slot_uri: cim:ExcIEEEST5B.t1
+        range: Seconds
+        multivalued: false
+        required: true
+        description: Firing circuit time constant (<i>T1</i>) (&gt;= 0).  Typical
+          value = 0,004.
+      kc:
+        slot_uri: cim:ExcIEEEST5B.kc
+        range: PU
+        multivalued: false
+        required: true
+        description: Rectifier regulation factor (<i>K</i><i><sub>C</sub></i>) (&gt;=
+          0).  Typical value = 0,004.
+      vrmax:
+        slot_uri: cim:ExcIEEEST5B.vrmax
+        range: PU
+        multivalued: false
+        required: true
+        description: Maximum voltage regulator output (<i>V</i><i><sub>RMAX</sub></i>)
+          (&gt; 0).  Typical value = 5.
+      vrmin:
+        slot_uri: cim:ExcIEEEST5B.vrmin
+        range: PU
+        multivalued: false
+        required: true
+        description: Minimum voltage regulator output (<i>V</i><i><sub>RMIN</sub></i>)
+          (&lt; 0).  Typical value = -4.
+      tc1:
+        slot_uri: cim:ExcIEEEST5B.tc1
+        range: Seconds
+        multivalued: false
+        required: true
+        description: Regulator lead time constant (<i>T</i><i><sub>C1</sub></i>) (&gt;=
+          0).  Typical value = 0,8.
+      tb1:
+        slot_uri: cim:ExcIEEEST5B.tb1
+        range: Seconds
+        multivalued: false
+        required: true
+        description: Regulator lag time constant (<i>T</i><i><sub>B1</sub></i>) (&gt;=
+          0).  Typical value = 6.
+      tc2:
+        slot_uri: cim:ExcIEEEST5B.tc2
+        range: Seconds
+        multivalued: false
+        required: true
+        description: Regulator lead time constant (<i>T</i><i><sub>C2</sub></i>) (&gt;=
+          0).  Typical value = 0,08.
+      tb2:
+        slot_uri: cim:ExcIEEEST5B.tb2
+        range: Seconds
+        multivalued: false
+        required: true
+        description: Regulator lag time constant (<i>T</i><i><sub>B2</sub></i>) (&gt;=
+          0).  Typical value = 0,01.
+      toc1:
+        slot_uri: cim:ExcIEEEST5B.toc1
+        range: Seconds
+        multivalued: false
+        required: true
+        description: OEL lead time constant (<i>T</i><i><sub>OC1</sub></i>) (&gt;=
+          0).  Typical value = 0,1.
+      tob1:
+        slot_uri: cim:ExcIEEEST5B.tob1
+        range: Seconds
+        multivalued: false
+        required: true
+        description: OEL lag time constant (<i>T</i><i><sub>OB1</sub></i>) (&gt;=
+          0).  Typical value = 2.
+      toc2:
+        slot_uri: cim:ExcIEEEST5B.toc2
+        range: Seconds
+        multivalued: false
+        required: true
+        description: OEL lead time constant (<i>T</i><i><sub>OC2</sub></i>) (&gt;=
+          0).  Typical value = 0,08.
+      tob2:
+        slot_uri: cim:ExcIEEEST5B.tob2
+        range: Seconds
+        multivalued: false
+        required: true
+        description: OEL lag time constant (<i>T</i><i><sub>OB2</sub></i>) (&gt;=
+          0).  Typical value = 0,08.
+      tuc1:
+        slot_uri: cim:ExcIEEEST5B.tuc1
+        range: Seconds
+        multivalued: false
+        required: true
+        description: UEL lead time constant (<i>T</i><i><sub>UC1</sub></i>) (&gt;=
+          0).  Typical value = 2.
+      tub1:
+        slot_uri: cim:ExcIEEEST5B.tub1
+        range: Seconds
+        multivalued: false
+        required: true
+        description: UEL lag time constant (<i>T</i><i><sub>UB1</sub></i>) (&gt;=
+          0).  Typical value = 10.
+      tuc2:
+        slot_uri: cim:ExcIEEEST5B.tuc2
+        range: Seconds
+        multivalued: false
+        required: true
+        description: UEL lead time constant (<i>T</i><i><sub>UC2</sub></i>) (&gt;=
+          0).  Typical value = 0,1.
+      tub2:
+        slot_uri: cim:ExcIEEEST5B.tub2
+        range: Seconds
+        multivalued: false
+        required: true
+        description: UEL lag time constant (<i>T</i><i><sub>UB2</sub></i>) (&gt;=
+          0).  Typical value = 0,05.
+    is_a: ExcitationSystemDynamics
+    description: 'IEEE 421.5-2005 type ST5B model. The type ST5B excitation system
+      is a variation of the type ST1A model, with alternative overexcitation and underexcitation
+      inputs and additional limits.
+
+      The block diagram in the IEEE 421.5 standard has input signal <i>Vc </i>and
+      does not indicate the summation point with <i>Vref</i>. The implementation of
+      the ExcIEEEST5B shall consider summation point with <i>Vref</i>.
+
+      Reference: IEEE 421.5-2005, 7.5.'
+  ExcIEEEST6B:
+    class_uri: cim:ExcIEEEST6B
+    attributes:
+      ilr:
+        slot_uri: cim:ExcIEEEST6B.ilr
+        range: PU
+        multivalued: false
+        required: true
+        description: Exciter output current limit reference (<i>I</i><i><sub>LR</sub></i>)
+          (&gt; 0).  Typical value = 4,164.
+      kci:
+        slot_uri: cim:ExcIEEEST6B.kci
+        range: PU
+        multivalued: false
+        required: true
+        description: Exciter output current limit adjustment (<i>K</i><i><sub>CI</sub></i>)
+          (&gt; 0).  Typical value = 1,0577.
+      kff:
+        slot_uri: cim:ExcIEEEST6B.kff
+        range: PU
+        multivalued: false
+        required: true
+        description: Pre-control gain constant of the inner loop field regulator (<i>K</i><i><sub>FF</sub></i>).
+          Typical value = 1.
+      kg:
+        slot_uri: cim:ExcIEEEST6B.kg
+        range: PU
+        multivalued: false
+        required: true
+        description: Feedback gain constant of the inner loop field regulator (<i>K</i><i><sub>G</sub></i>)
+          (&gt;= 0).  Typical value = 1.
+      kia:
+        slot_uri: cim:ExcIEEEST6B.kia
+        range: PU
+        multivalued: false
+        required: true
+        description: Voltage regulator integral gain (<i>K</i><i><sub>IA</sub></i>)
+          (&gt; 0).  Typical value = 45,094.
+      klr:
+        slot_uri: cim:ExcIEEEST6B.klr
+        range: PU
+        multivalued: false
+        required: true
+        description: Exciter output current limiter gain (<i>K</i><i><sub>LR</sub></i>)
+          (&gt; 0).  Typical value = 17,33.
+      km:
+        slot_uri: cim:ExcIEEEST6B.km
+        range: PU
+        multivalued: false
+        required: true
+        description: Forward gain constant of the inner loop field regulator (<i>K</i><i><sub>M</sub></i>).  Typical
+          value = 1.
+      kpa:
+        slot_uri: cim:ExcIEEEST6B.kpa
+        range: PU
+        multivalued: false
+        required: true
+        description: Voltage regulator proportional gain (<u>K</u><u><sub>PA</sub></u>)
+          (&gt; 0).  Typical value = 18,038.
+      oelin:
+        slot_uri: cim:ExcIEEEST6B.oelin
+        range: ExcST6BOELselectorKind
+        multivalued: false
+        required: true
+        description: OEL input selector (<i>OELin</i>). Typical value = noOELinput.
+      tg:
+        slot_uri: cim:ExcIEEEST6B.tg
+        range: Seconds
+        multivalued: false
+        required: true
+        description: Feedback time constant of inner loop field voltage regulator
+          (<i>T</i><i><sub>G</sub></i>) (&gt;= 0). Typical value = 0,02.
+      vamax:
+        slot_uri: cim:ExcIEEEST6B.vamax
+        range: PU
+        multivalued: false
+        required: true
+        description: Maximum voltage regulator output (V<i><sub>AMAX</sub></i>) (&gt;
+          0).  Typical value = 4,81.
+      vamin:
+        slot_uri: cim:ExcIEEEST6B.vamin
+        range: PU
+        multivalued: false
+        required: true
+        description: Minimum voltage regulator output (<i>V</i><i><sub>AMIN</sub></i>)
+          (&lt; 0).  Typical value = -3,85.
+      vrmax:
+        slot_uri: cim:ExcIEEEST6B.vrmax
+        range: PU
+        multivalued: false
+        required: true
+        description: Maximum voltage regulator output (<i>V</i><i><sub>RMAX</sub></i>)
+          (&gt; 0).  Typical value = 4,81.
+      vrmin:
+        slot_uri: cim:ExcIEEEST6B.vrmin
+        range: PU
+        multivalued: false
+        required: true
+        description: Minimum voltage regulator output (<i>V</i><i><sub>RMIN</sub></i>)
+          (&lt; 0).  Typical value = -3,85.
+    is_a: ExcitationSystemDynamics
+    description: 'IEEE 421.5-2005 type ST6B model. This model consists of a PI voltage
+      regulator with an inner loop field voltage regulator and pre-control. The field
+      voltage regulator implements a proportional control. The pre-control and the
+      delay in the feedback circuit increase the dynamic response.
+
+      Reference: IEEE 421.5-2005, 7.6.'
+  ExcIEEEST7B:
+    class_uri: cim:ExcIEEEST7B
+    attributes:
+      kh:
+        slot_uri: cim:ExcIEEEST7B.kh
+        range: PU
+        multivalued: false
+        required: true
+        description: High-value gate feedback gain (<i>K</i><i><sub>H</sub></i>) (&gt;=
+          0).  Typical value = 1.
+      kia:
+        slot_uri: cim:ExcIEEEST7B.kia
+        range: PU
+        multivalued: false
+        required: true
+        description: Voltage regulator integral gain (<i>K</i><i><sub>IA</sub></i>)
+          (&gt;= 0).  Typical value = 1.
+      kl:
+        slot_uri: cim:ExcIEEEST7B.kl
+        range: PU
+        multivalued: false
+        required: true
+        description: Low-value gate feedback gain (<i>K</i><i><sub>L</sub></i>) (&gt;=
+          0).  Typical value = 1.
+      kpa:
+        slot_uri: cim:ExcIEEEST7B.kpa
+        range: PU
+        multivalued: false
+        required: true
+        description: Voltage regulator proportional gain (<i>K</i><i><sub>PA</sub></i>)
+          (&gt; 0).  Typical value = 40.
+      oelin:
+        slot_uri: cim:ExcIEEEST7B.oelin
+        range: ExcST7BOELselectorKind
+        multivalued: false
+        required: true
+        description: OEL input selector (<i>OELin</i>).  Typical value = noOELinput.
+      tb:
+        slot_uri: cim:ExcIEEEST7B.tb
+        range: Seconds
+        multivalued: false
+        required: true
+        description: Regulator lag time constant (<i>T</i><i><sub>B</sub></i>) (&gt;=
+          0).  Typical value = 1.
+      tc:
+        slot_uri: cim:ExcIEEEST7B.tc
+        range: Seconds
+        multivalued: false
+        required: true
+        description: Regulator lead time constant (<i>T</i><i><sub>C</sub></i>) (&gt;=
+          0).  Typical value = 1.
+      tf:
+        slot_uri: cim:ExcIEEEST7B.tf
+        range: Seconds
+        multivalued: false
+        required: true
+        description: Excitation control system stabilizer time constant (<i>T</i><i><sub>F</sub></i>)
+          (&gt;= 0).  Typical value = 1.
+      tg:
+        slot_uri: cim:ExcIEEEST7B.tg
+        range: Seconds
+        multivalued: false
+        required: true
+        description: Feedback time constant of inner loop field voltage regulator
+          (<i>T</i><i><sub>G</sub></i>) (&gt;= 0). Typical value = 1.
+      tia:
+        slot_uri: cim:ExcIEEEST7B.tia
+        range: Seconds
+        multivalued: false
+        required: true
+        description: Feedback time constant (<i>T</i><i><sub>IA</sub></i>) (&gt;=
+          0).  Typical value = 3.
+      uelin:
+        slot_uri: cim:ExcIEEEST7B.uelin
+        range: ExcST7BUELselectorKind
+        multivalued: false
+        required: true
+        description: UEL input selector (<i>UELin</i>). Typical value = noUELinput.
+      vmax:
+        slot_uri: cim:ExcIEEEST7B.vmax
+        range: PU
+        multivalued: false
+        required: true
+        description: Maximum voltage reference signal (<i>V</i><i><sub>MAX</sub></i>)
+          (&gt; 0 and &gt; ExcIEEEST7B.vmin).  Typical value = 1,1.
+      vmin:
+        slot_uri: cim:ExcIEEEST7B.vmin
+        range: PU
+        multivalued: false
+        required: true
+        description: Minimum voltage reference signal (<i>V</i><i><sub>MIN</sub></i>)
+          (&gt; 0 and &lt; ExcIEEEST7B.vmax).  Typical value = 0,9.
+      vrmax:
+        slot_uri: cim:ExcIEEEST7B.vrmax
+        range: PU
+        multivalued: false
+        required: true
+        description: Maximum voltage regulator output (<i>V</i><i><sub>RMAX</sub></i>)
+          (&gt; 0).  Typical value = 5.
+      vrmin:
+        slot_uri: cim:ExcIEEEST7B.vrmin
+        range: PU
+        multivalued: false
+        required: true
+        description: Minimum voltage regulator output (<i>V</i><i><sub>RMIN</sub></i>)
+          (&lt; 0).  Typical value = -4,5.
+    is_a: ExcitationSystemDynamics
+    description: 'IEEE 421.5-2005 type ST7B model. This model is representative of
+      static potential-source excitation systems. In this system, the AVR consists
+      of a PI voltage regulator. A phase lead-lag filter in series allows the introduction
+      of a derivative function, typically used with brushless excitation systems.
+      In that case, the regulator is of the PID type. In addition, the terminal voltage
+      channel includes a phase lead-lag filter.  The AVR includes the appropriate
+      inputs on its reference for overexcitation limiter (OEL1), underexcitation limiter
+      (UEL), stator current limiter (SCL), and current compensator (DROOP). All these
+      limitations, when they work at voltage reference level, keep the PSS (VS signal
+      from PSS) in operation. However, the UEL limitation can also be transferred
+      to the high value (HV) gate acting on the output signal. In addition, the output
+      signal passes through a low value (LV) gate for a ceiling overexcitation limiter
+      (OEL2).
+
+      Reference: IEEE 421.5-2005, 7.7.'
+  ExcAC1A:
+    class_uri: cim:ExcAC1A
+    attributes:
+      tb:
+        slot_uri: cim:ExcAC1A.tb
+        range: Seconds
+        multivalued: false
+        required: true
+        description: Voltage regulator time constant (<i>Tb</i>) (&gt;= 0).  Typical
+          value = 0.
+      tc:
+        slot_uri: cim:ExcAC1A.tc
+        range: Seconds
+        multivalued: false
+        required: true
+        description: Voltage regulator time constant (<i>T</i><i><sub>c</sub></i>)
+          (&gt;= 0).  Typical value = 0.
+      ka:
+        slot_uri: cim:ExcAC1A.ka
+        range: PU
+        multivalued: false
+        required: true
+        description: Voltage regulator gain (<i>Ka</i>) (&gt; 0).  Typical value =
+          400.
+      ta:
+        slot_uri: cim:ExcAC1A.ta
+        range: Seconds
+        multivalued: false
+        required: true
+        description: Voltage regulator time constant (<i>Ta</i>) (&gt; 0).  Typical
+          value = 0,02.
+      vamax:
+        slot_uri: cim:ExcAC1A.vamax
+        range: PU
+        multivalued: false
+        required: true
+        description: Maximum voltage regulator output (<i>V</i><i><sub>amax</sub></i>)
+          (&gt; 0).  Typical value = 14,5.
+      vamin:
+        slot_uri: cim:ExcAC1A.vamin
+        range: PU
+        multivalued: false
+        required: true
+        description: Minimum voltage regulator output (<i>V</i><i><sub>amin</sub></i>)
+          (&lt; 0).  Typical value = -14,5.
+      te:
+        slot_uri: cim:ExcAC1A.te
+        range: Seconds
+        multivalued: false
+        required: true
+        description: Exciter time constant, integration rate associated with exciter
+          control (<i>Te</i>) (&gt; 0).  Typical value = 0,8.
+      kf:
+        slot_uri: cim:ExcAC1A.kf
+        range: PU
+        multivalued: false
+        required: true
+        description: Excitation control system stabilizer gains (<i>Kf</i>) (&gt;=
+          0).  Typical value = 0,03.
+      kf1:
+        slot_uri: cim:ExcAC1A.kf1
+        range: PU
+        multivalued: false
+        required: true
+        description: Coefficient to allow different usage of the model (<i>Kf1</i>)
+          (&gt;= 0).  Typical value = 0.
+      kf2:
+        slot_uri: cim:ExcAC1A.kf2
+        range: PU
+        multivalued: false
+        required: true
+        description: Coefficient to allow different usage of the model (<i>Kf2</i>)
+          (&gt;= 0).  Typical value = 1.
+      ks:
+        slot_uri: cim:ExcAC1A.ks
+        range: PU
+        multivalued: false
+        required: true
+        description: Coefficient to allow different usage of the model-speed coefficient
+          (<i>Ks</i>) (&gt;= 0).  Typical value = 0.
+      tf:
+        slot_uri: cim:ExcAC1A.tf
+        range: Seconds
+        multivalued: false
+        required: true
+        description: Excitation control system stabilizer time constant (<i>Tf</i>)
+          (&gt; 0).  Typical value = 1.
+      kc:
+        slot_uri: cim:ExcAC1A.kc
+        range: PU
+        multivalued: false
+        required: true
+        description: Rectifier loading factor proportional to commutating reactance
+          (<i>Kc</i>) (&gt;= 0). Typical value = 0,2.
+      kd:
+        slot_uri: cim:ExcAC1A.kd
+        range: PU
+        multivalued: false
+        required: true
+        description: Demagnetizing factor, a function of exciter alternator reactances
+          (<i>Kd</i>) (&gt;= 0).  Typical value = 0,38.
+      ke:
+        slot_uri: cim:ExcAC1A.ke
+        range: PU
+        multivalued: false
+        required: true
+        description: Exciter constant related to self-excited field (<i>Ke</i>).  Typical
+          value = 1.
+      ve1:
+        slot_uri: cim:ExcAC1A.ve1
+        range: PU
+        multivalued: false
+        required: true
+        description: Exciter alternator output voltages back of commutating reactance
+          at which saturation is defined (<i>Ve1</i>) (&gt; 0).  Typical value = 4,18.
+      seve1:
+        slot_uri: cim:ExcAC1A.seve1
+        range: float
+        multivalued: false
+        required: true
+        description: Exciter saturation function value at the corresponding exciter
+          voltage, <i>Ve</i><i><sub>1</sub></i>, back of commutating reactance (<i>Se[Ve</i><i><sub>1</sub></i><i>]</i>)
+          (&gt;= 0).  Typical value = 0,1.
+      ve2:
+        slot_uri: cim:ExcAC1A.ve2
+        range: PU
+        multivalued: false
+        required: true
+        description: Exciter alternator output voltages back of commutating reactance
+          at which saturation is defined (<i>Ve2</i>) (&gt; 0).  Typical value = 3,14.
+      seve2:
+        slot_uri: cim:ExcAC1A.seve2
+        range: float
+        multivalued: false
+        required: true
+        description: Exciter saturation function value at the corresponding exciter
+          voltage, <i>Ve</i><i><sub>2</sub></i>, back of commutating reactance (<i>Se[Ve</i><i><sub>2</sub></i><i>]</i>)
+          (&gt;= 0).  Typical value = 0,03.
+      vrmax:
+        slot_uri: cim:ExcAC1A.vrmax
+        range: PU
+        multivalued: false
+        required: true
+        description: Maximum voltage regulator outputs (<i>Vrmax</i>) (&gt; 0).  Typical
+          value = 6,03.
+      vrmin:
+        slot_uri: cim:ExcAC1A.vrmin
+        range: PU
+        multivalued: false
+        required: true
+        description: Minimum voltage regulator outputs (<i>Vrmin</i>) (&lt; 0).  Typical
+          value = -5,43.
+      hvlvgates:
+        slot_uri: cim:ExcAC1A.hvlvgates
+        range: boolean
+        multivalued: false
+        required: true
+        description: 'Indicates if both HV gate and LV gate are active (<i>HVLVgates</i>).
+
+          true = gates are used
+
+          false = gates are not used.
+
+          Typical value = true.'
+    is_a: ExcitationSystemDynamics
+    description: Modified IEEE AC1A alternator-supplied rectifier excitation system
+      with different rate feedback source.
+  ExcAC2A:
+    class_uri: cim:ExcAC2A
+    attributes:
+      tb:
+        slot_uri: cim:ExcAC2A.tb
+        range: Seconds
+        multivalued: false
+        required: true
+        description: Voltage regulator time constant (<i>Tb</i>) (&gt;= 0).  Typical
+          value = 0.
+      tc:
+        slot_uri: cim:ExcAC2A.tc
+        range: Seconds
+        multivalued: false
+        required: true
+        description: Voltage regulator time constant (<i>Tc</i>) (&gt;= 0).  Typical
+          value = 0.
+      ka:
+        slot_uri: cim:ExcAC2A.ka
+        range: PU
+        multivalued: false
+        required: true
+        description: Voltage regulator gain (<i>Ka</i>) (&gt; 0).  Typical value =
+          400.
+      ta:
+        slot_uri: cim:ExcAC2A.ta
+        range: Seconds
+        multivalued: false
+        required: true
+        description: Voltage regulator time constant (<i>Ta</i>) (&gt; 0).  Typical
+          value = 0,02.
+      vamax:
+        slot_uri: cim:ExcAC2A.vamax
+        range: PU
+        multivalued: false
+        required: true
+        description: Maximum voltage regulator output (<i>Vamax</i>) (&gt; 0).  Typical
+          value = 8.
+      vamin:
+        slot_uri: cim:ExcAC2A.vamin
+        range: PU
+        multivalued: false
+        required: true
+        description: Minimum voltage regulator output (<i>Vamin</i>) (&lt; 0).  Typical
+          value = -8.
+      kb:
+        slot_uri: cim:ExcAC2A.kb
+        range: PU
+        multivalued: false
+        required: true
+        description: Second stage regulator gain (<i>Kb</i>) (&gt; 0).  Exciter field
+          current controller gain.  Typical value = 25.
+      kb1:
+        slot_uri: cim:ExcAC2A.kb1
+        range: PU
+        multivalued: false
+        required: true
+        description: Second stage regulator gain (<i>Kb1</i>). It is exciter field
+          current controller gain used as alternative to <i>Kb</i> to represent a
+          variant of the ExcAC2A model.  Typical value = 25.
+      vrmax:
+        slot_uri: cim:ExcAC2A.vrmax
+        range: PU
+        multivalued: false
+        required: true
+        description: Maximum voltage regulator outputs (<i>Vrmax</i>) (&gt; 0).  Typical
+          value = 105.
+      vrmin:
+        slot_uri: cim:ExcAC2A.vrmin
+        range: PU
+        multivalued: false
+        required: true
+        description: Minimum voltage regulator outputs (<i>Vrmin</i>) (&lt; 0).  Typical
+          value = -95.
+      te:
+        slot_uri: cim:ExcAC2A.te
+        range: Seconds
+        multivalued: false
+        required: true
+        description: Exciter time constant, integration rate associated with exciter
+          control (<i>Te</i>) (&gt; 0).  Typical value = 0,6.
+      vfemax:
+        slot_uri: cim:ExcAC2A.vfemax
+        range: PU
+        multivalued: false
+        required: true
+        description: Exciter field current limit reference (<i>Vfemax</i>) (&gt;=
+          0).  Typical value = 4,4.
+      kh:
+        slot_uri: cim:ExcAC2A.kh
+        range: PU
+        multivalued: false
+        required: true
+        description: Exciter field current feedback gain (<i>Kh</i>) (&gt;= 0).  Typical
+          value = 1.
+      kf:
+        slot_uri: cim:ExcAC2A.kf
+        range: PU
+        multivalued: false
+        required: true
+        description: Excitation control system stabilizer gains (<i>Kf</i>) (&gt;=
+          0).  Typical value = 0,03.
+      kl:
+        slot_uri: cim:ExcAC2A.kl
+        range: PU
+        multivalued: false
+        required: true
+        description: Exciter field current limiter gain (<i>Kl</i>).  Typical value
+          = 10.
+      vlr:
+        slot_uri: cim:ExcAC2A.vlr
+        range: PU
+        multivalued: false
+        required: true
+        description: Maximum exciter field current (<i>Vlr</i>) (&gt; 0).  Typical
+          value = 4,4.
+      kl1:
+        slot_uri: cim:ExcAC2A.kl1
+        range: PU
+        multivalued: false
+        required: true
+        description: Coefficient to allow different usage of the model (<i>Kl1</i>).  Typical
+          value = 1.
+      ks:
+        slot_uri: cim:ExcAC2A.ks
+        range: PU
+        multivalued: false
+        required: true
+        description: Coefficient to allow different usage of the model-speed coefficient
+          (<i>Ks</i>) (&gt;= 0).  Typical value = 0.
+      tf:
+        slot_uri: cim:ExcAC2A.tf
+        range: Seconds
+        multivalued: false
+        required: true
+        description: Excitation control system stabilizer time constant (<i>Tf</i>)
+          (&gt; 0).  Typical value = 1.
+      kc:
+        slot_uri: cim:ExcAC2A.kc
+        range: PU
+        multivalued: false
+        required: true
+        description: Rectifier loading factor proportional to commutating reactance
+          (<i>Kc</i>) (&gt;= 0).  Typical value = 0,28.
+      kd:
+        slot_uri: cim:ExcAC2A.kd
+        range: PU
+        multivalued: false
+        required: true
+        description: Demagnetizing factor, a function of exciter alternator reactances
+          (<i>Kd</i>) (&gt;= 0).  Typical value = 0,35.
+      ke:
+        slot_uri: cim:ExcAC2A.ke
+        range: PU
+        multivalued: false
+        required: true
+        description: Exciter constant related to self-excited field (<i>Ke</i>).  Typical
+          value = 1.
+      ve1:
+        slot_uri: cim:ExcAC2A.ve1
+        range: PU
+        multivalued: false
+        required: true
+        description: Exciter alternator output voltages back of commutating reactance
+          at which saturation is defined (<i>Ve</i><i><sub>1</sub></i>) (&gt; 0).  Typical
+          value = 4,4.
+      seve1:
+        slot_uri: cim:ExcAC2A.seve1
+        range: float
+        multivalued: false
+        required: true
+        description: Exciter saturation function value at the corresponding exciter
+          voltage, <i>Ve</i><i><sub>1</sub></i>, back of commutating reactance (<i>Se[Ve</i><i><sub>1</sub></i><i>]</i>)
+          (&gt;= 0).  Typical value = 0,037.
+      ve2:
+        slot_uri: cim:ExcAC2A.ve2
+        range: PU
+        multivalued: false
+        required: true
+        description: Exciter alternator output voltages back of commutating reactance
+          at which saturation is defined (<i>Ve</i><i><sub>2</sub></i>) (&gt; 0).  Typical
+          value = 3,3.
+      seve2:
+        slot_uri: cim:ExcAC2A.seve2
+        range: float
+        multivalued: false
+        required: true
+        description: Exciter saturation function value at the corresponding exciter
+          voltage, <i>Ve</i><i><sub>2</sub></i>, back of commutating reactance (<i>Se[Ve</i><i><sub>2</sub></i><i>]</i>)
+          (&gt;= 0).  Typical value = 0,012.
+      hvgate:
+        slot_uri: cim:ExcAC2A.hvgate
+        range: boolean
+        multivalued: false
+        required: true
+        description: 'Indicates if HV gate is active (<i>HVgate</i>).
+
+          true = gate is used
+
+          false = gate is not used.
+
+          Typical value = true.'
+      lvgate:
+        slot_uri: cim:ExcAC2A.lvgate
+        range: boolean
+        multivalued: false
+        required: true
+        description: 'Indicates if LV gate is active (<i>LVgate</i>).
+
+          true = gate is used
+
+          false = gate is not used.
+
+          Typical value = true.'
+    is_a: ExcitationSystemDynamics
+    description: Modified IEEE AC2A alternator-supplied rectifier excitation system
+      with different field current limit.
+  ExcAC3A:
+    class_uri: cim:ExcAC3A
+    attributes:
+      tb:
+        slot_uri: cim:ExcAC3A.tb
+        range: Seconds
+        multivalued: false
+        required: true
+        description: Voltage regulator time constant (<i>Tb</i>) (&gt;= 0).  Typical
+          value = 0.
+      tc:
+        slot_uri: cim:ExcAC3A.tc
+        range: Seconds
+        multivalued: false
+        required: true
+        description: Voltage regulator time constant (<i>Tc</i>) (&gt;= 0).  Typical
+          value = 0.
+      ka:
+        slot_uri: cim:ExcAC3A.ka
+        range: Seconds
+        multivalued: false
+        required: true
+        description: Voltage regulator gain (<i>Ka</i>) (&gt; 0).  Typical value =
+          45,62.
+      ta:
+        slot_uri: cim:ExcAC3A.ta
+        range: PU
+        multivalued: false
+        required: true
+        description: Voltage regulator time constant (<i>Ta</i>) (&gt; 0).  Typical
+          value = 0,013.
+      vamax:
+        slot_uri: cim:ExcAC3A.vamax
+        range: PU
+        multivalued: false
+        required: true
+        description: Maximum voltage regulator output (<i>Vamax</i>) (&gt; 0).  Typical
+          value = 1.
+      vamin:
+        slot_uri: cim:ExcAC3A.vamin
+        range: PU
+        multivalued: false
+        required: true
+        description: Minimum voltage regulator output (<i>Vamin</i>) (&lt; 0).  Typical
+          value = -0,95.
+      te:
+        slot_uri: cim:ExcAC3A.te
+        range: Seconds
+        multivalued: false
+        required: true
+        description: Exciter time constant, integration rate associated with exciter
+          control (<i>Te</i>) (&gt; 0).  Typical value = 1,17.
+      vemin:
+        slot_uri: cim:ExcAC3A.vemin
+        range: PU
+        multivalued: false
+        required: true
+        description: Minimum exciter voltage output (<i>Vemin</i>) (&lt;= 0).  Typical
+          value = 0.
+      kr:
+        slot_uri: cim:ExcAC3A.kr
+        range: PU
+        multivalued: false
+        required: true
+        description: Constant associated with regulator and alternator field power
+          supply (<i>Kr</i>) (&gt; 0).  Typical value =3,77.
+      kf:
+        slot_uri: cim:ExcAC3A.kf
+        range: PU
+        multivalued: false
+        required: true
+        description: Excitation control system stabilizer gains (<i>Kf</i>) (&gt;=
+          0).  Typical value = 0,143.
+      tf:
+        slot_uri: cim:ExcAC3A.tf
+        range: Seconds
+        multivalued: false
+        required: true
+        description: Excitation control system stabilizer time constant (<i>Tf</i>)
+          (&gt; 0).  Typical value = 1.
+      kn:
+        slot_uri: cim:ExcAC3A.kn
+        range: PU
+        multivalued: false
+        required: true
+        description: Excitation control system stabilizer gain (<i>Kn</i>) (&gt;=
+          0).  Typical value =0,05.
+      efdn:
+        slot_uri: cim:ExcAC3A.efdn
+        range: PU
+        multivalued: false
+        required: true
+        description: Value of <i>Efd </i>at which feedback gain changes (<i>Efdn</i>)
+          (&gt; 0).  Typical value = 2,36.
+      kc:
+        slot_uri: cim:ExcAC3A.kc
+        range: PU
+        multivalued: false
+        required: true
+        description: Rectifier loading factor proportional to commutating reactance
+          (<i>Kc</i>) (&gt;= 0).  Typical value = 0,104.
+      kd:
+        slot_uri: cim:ExcAC3A.kd
+        range: PU
+        multivalued: false
+        required: true
+        description: Demagnetizing factor, a function of exciter alternator reactances
+          (<i>Kd</i>) (&gt;= 0).  Typical value = 0,499.
+      ke:
+        slot_uri: cim:ExcAC3A.ke
+        range: PU
+        multivalued: false
+        required: true
+        description: Exciter constant related to self-excited field (<i>Ke</i>).  Typical
+          value = 1.
+      klv:
+        slot_uri: cim:ExcAC3A.klv
+        range: PU
+        multivalued: false
+        required: true
+        description: Gain used in the minimum field voltage limiter loop (<i>Klv</i>).  Typical
+          value = 0,194.
+      kf1:
+        slot_uri: cim:ExcAC3A.kf1
+        range: PU
+        multivalued: false
+        required: true
+        description: Coefficient to allow different usage of the model (<i>Kf1</i>).  Typical
+          value = 1.
+      kf2:
+        slot_uri: cim:ExcAC3A.kf2
+        range: PU
+        multivalued: false
+        required: true
+        description: Coefficient to allow different usage of the model (<i>Kf2</i>).  Typical
+          value = 0.
+      ks:
+        slot_uri: cim:ExcAC3A.ks
+        range: PU
+        multivalued: false
+        required: true
+        description: Coefficient to allow different usage of the model-speed coefficient
+          (<i>Ks</i>).  Typical value = 0.
+      vfemax:
+        slot_uri: cim:ExcAC3A.vfemax
+        range: PU
+        multivalued: false
+        required: true
+        description: Exciter field current limit reference (<i>Vfemax</i>) (&gt;=
+          0).  Typical value = 16.
+      ve1:
+        slot_uri: cim:ExcAC3A.ve1
+        range: PU
+        multivalued: false
+        required: true
+        description: Exciter alternator output voltages back of commutating reactance
+          at which saturation is defined (<i>Ve</i><i><sub>1</sub></i>) (&gt; 0).  Typical
+          value = 6.24.
+      seve1:
+        slot_uri: cim:ExcAC3A.seve1
+        range: float
+        multivalued: false
+        required: true
+        description: Exciter saturation function value at the corresponding exciter
+          voltage, <i>Ve</i><i><sub>1</sub></i>, back of commutating reactance (<i>Se[Ve</i><i><sub>1</sub></i><i>]</i>)
+          (&gt;= 0).  Typical value = 1,143.
+      ve2:
+        slot_uri: cim:ExcAC3A.ve2
+        range: PU
+        multivalued: false
+        required: true
+        description: Exciter alternator output voltages back of commutating reactance
+          at which saturation is defined (<i>Ve</i><i><sub>2</sub></i>) (&gt; 0).  Typical
+          value = 4,68.
+      seve2:
+        slot_uri: cim:ExcAC3A.seve2
+        range: float
+        multivalued: false
+        required: true
+        description: Exciter saturation function value at the corresponding exciter
+          voltage, <i>Ve</i><i><sub>2</sub></i>, back of commutating reactance (<i>Se[Ve</i><i><sub>2</sub></i><i>]</i>)
+          (&gt;= 0).  Typical value = 0,1.
+      vlv:
+        slot_uri: cim:ExcAC3A.vlv
+        range: PU
+        multivalued: false
+        required: true
+        description: Field voltage used in the minimum field voltage limiter loop
+          (<i>Vlv</i>).  Typical value = 0,79.
+    is_a: ExcitationSystemDynamics
+    description: Modified IEEE AC3A alternator-supplied rectifier excitation system
+      with different field current limit.
+  ExcAC4A:
+    class_uri: cim:ExcAC4A
+    attributes:
+      vimax:
+        slot_uri: cim:ExcAC4A.vimax
+        range: PU
+        multivalued: false
+        required: true
+        description: Maximum voltage regulator input limit (<i>Vimax</i>)  (&gt; 0).  Typical
+          value = 10.
+      vimin:
+        slot_uri: cim:ExcAC4A.vimin
+        range: PU
+        multivalued: false
+        required: true
+        description: Minimum voltage regulator input limit (<i>Vimin</i>) (&lt; 0).  Typical
+          value = -10.
+      tc:
+        slot_uri: cim:ExcAC4A.tc
+        range: Seconds
+        multivalued: false
+        required: true
+        description: Voltage regulator time constant (<i>Tc</i>) (&gt;= 0).  Typical
+          value = 1.
+      tb:
+        slot_uri: cim:ExcAC4A.tb
+        range: Seconds
+        multivalued: false
+        required: true
+        description: Voltage regulator time constant (<i>Tb</i>) (&gt;= 0).  Typical
+          value = 10.
+      ka:
+        slot_uri: cim:ExcAC4A.ka
+        range: PU
+        multivalued: false
+        required: true
+        description: Voltage regulator gain (<i>Ka</i>) (&gt; 0).  Typical value =
+          200.
+      ta:
+        slot_uri: cim:ExcAC4A.ta
+        range: Seconds
+        multivalued: false
+        required: true
+        description: Voltage regulator time constant (<i>Ta</i>) (&gt; 0).  Typical
+          value = 0,015.
+      vrmax:
+        slot_uri: cim:ExcAC4A.vrmax
+        range: PU
+        multivalued: false
+        required: true
+        description: Maximum voltage regulator output (<i>Vrmax</i>) (&gt; 0).  Typical
+          value = 5,64.
+      vrmin:
+        slot_uri: cim:ExcAC4A.vrmin
+        range: PU
+        multivalued: false
+        required: true
+        description: Minimum voltage regulator output (<i>Vrmin</i>) (&lt; 0).  Typical
+          value = -4,53.
+      kc:
+        slot_uri: cim:ExcAC4A.kc
+        range: PU
+        multivalued: false
+        required: true
+        description: Rectifier loading factor proportional to commutating reactance
+          (<i>Kc</i>) (&gt;= 0).  Typical value = 0.
+    is_a: ExcitationSystemDynamics
+    description: Modified IEEE AC4A alternator-supplied rectifier excitation system
+      with different minimum controller output.
+  ExcAC5A:
+    class_uri: cim:ExcAC5A
+    attributes:
+      ka:
+        slot_uri: cim:ExcAC5A.ka
+        range: PU
+        multivalued: false
+        required: true
+        description: Voltage regulator gain (<i>Ka</i>) (&gt; 0).  Typical value =
+          400.
+      ks:
+        slot_uri: cim:ExcAC5A.ks
+        range: PU
+        multivalued: false
+        required: true
+        description: Coefficient to allow different usage of the model-speed coefficient
+          (<i>Ks</i>).  Typical value = 0.
+      tb:
+        slot_uri: cim:ExcAC5A.tb
+        range: Seconds
+        multivalued: false
+        required: true
+        description: Voltage regulator time constant (<i>Tb</i>) (&gt;= 0).  Typical
+          value = 0.
+      tc:
+        slot_uri: cim:ExcAC5A.tc
+        range: Seconds
+        multivalued: false
+        required: true
+        description: Voltage regulator time constant (<i>Tc</i>) (&gt;= 0).  Typical
+          value = 0.
+      ta:
+        slot_uri: cim:ExcAC5A.ta
+        range: Seconds
+        multivalued: false
+        required: true
+        description: Voltage regulator time constant (<i>Ta</i>) (&gt; 0).  Typical
+          value = 0,02.
+      vrmax:
+        slot_uri: cim:ExcAC5A.vrmax
+        range: PU
+        multivalued: false
+        required: true
+        description: Maximum voltage regulator output (<i>Vrmax</i>) (&gt; 0).  Typical
+          value = 7,3.
+      vrmin:
+        slot_uri: cim:ExcAC5A.vrmin
+        range: PU
+        multivalued: false
+        required: true
+        description: Minimum voltage regulator output (<i>Vrmin</i>) (&lt; 0).  Typical
+          value =-7,3.
+      ke:
+        slot_uri: cim:ExcAC5A.ke
+        range: PU
+        multivalued: false
+        required: true
+        description: Exciter constant related to self-excited field (<i>Ke</i>).  Typical
+          value = 1.
+      te:
+        slot_uri: cim:ExcAC5A.te
+        range: Seconds
+        multivalued: false
+        required: true
+        description: Exciter time constant, integration rate associated with exciter
+          control (<i>Te</i>) (&gt; 0).  Typical value = 0,8.
+      kf:
+        slot_uri: cim:ExcAC5A.kf
+        range: PU
+        multivalued: false
+        required: true
+        description: Excitation control system stabilizer gains (<i>Kf</i>) (&gt;=
+          0).  Typical value = 0,03.
+      tf1:
+        slot_uri: cim:ExcAC5A.tf1
+        range: Seconds
+        multivalued: false
+        required: true
+        description: Excitation control system stabilizer time constant (<i>Tf1</i>)
+          (&gt; 0).  Typical value  = 1.
+      tf2:
+        slot_uri: cim:ExcAC5A.tf2
+        range: Seconds
+        multivalued: false
+        required: true
+        description: Excitation control system stabilizer time constant (<i>Tf2</i>)
+          (&gt;= 0).  Typical value = 0,8.
+      tf3:
+        slot_uri: cim:ExcAC5A.tf3
+        range: Seconds
+        multivalued: false
+        required: true
+        description: Excitation control system stabilizer time constant (<i>Tf3</i>)
+          (&gt;= 0).  Typical value = 0.
+      efd1:
+        slot_uri: cim:ExcAC5A.efd1
+        range: PU
+        multivalued: false
+        required: true
+        description: Exciter voltage at which exciter saturation is defined (<i>Efd1</i>)
+          (&gt; 0).  Typical value = 5,6.
+      seefd1:
+        slot_uri: cim:ExcAC5A.seefd1
+        range: float
+        multivalued: false
+        required: true
+        description: Exciter saturation function value at the corresponding exciter
+          voltage, <i>Efd</i><i><sub>1</sub></i> (<i>Se[Efd</i><i><sub>1</sub></i><i>]</i>)
+          (&gt;= 0).  Typical value = 0,86.
+      efd2:
+        slot_uri: cim:ExcAC5A.efd2
+        range: PU
+        multivalued: false
+        required: true
+        description: Exciter voltage at which exciter saturation is defined (<i>Efd2</i>)
+          (&gt; 0).  Typical value = 4,2.
+      seefd2:
+        slot_uri: cim:ExcAC5A.seefd2
+        range: float
+        multivalued: false
+        required: true
+        description: Exciter saturation function value at the corresponding exciter
+          voltage, <i>Efd</i><i><sub>2</sub></i> (<i>Se[Efd</i><i><sub>2</sub></i><i>]</i>)
+          (&gt;= 0).  Typical value = 0,5.
+      a:
+        slot_uri: cim:ExcAC5A.a
+        range: float
+        multivalued: false
+        required: true
+        description: Coefficient to allow different usage of the model (<i>a</i>).  Typical
+          value = 1.
+    is_a: ExcitationSystemDynamics
+    description: Modified IEEE AC5A alternator-supplied rectifier excitation system
+      with different minimum controller output.
+  ExcAC6A:
+    class_uri: cim:ExcAC6A
+    attributes:
+      ka:
+        slot_uri: cim:ExcAC6A.ka
+        range: PU
+        multivalued: false
+        required: true
+        description: Voltage regulator gain (<i>Ka</i>) (&gt; 0).  Typical value =
+          536.
+      ks:
+        slot_uri: cim:ExcAC6A.ks
+        range: PU
+        multivalued: false
+        required: true
+        description: Coefficient to allow different usage of the model-speed coefficient
+          (<i>Ks</i>).  Typical value = 0.
+      ta:
+        slot_uri: cim:ExcAC6A.ta
+        range: Seconds
+        multivalued: false
+        required: true
+        description: Voltage regulator time constant (<i>Ta</i>) (&gt;= 0).  Typical
+          value = 0,086.
+      tk:
+        slot_uri: cim:ExcAC6A.tk
+        range: Seconds
+        multivalued: false
+        required: true
+        description: Voltage regulator time constant (<i>Tk</i>) (&gt;= 0).  Typical
+          value = 0,18.
+      tb:
+        slot_uri: cim:ExcAC6A.tb
+        range: Seconds
+        multivalued: false
+        required: true
+        description: Voltage regulator time constant (<i>Tb</i>) (&gt;= 0).  Typical
+          value = 9.
+      tc:
+        slot_uri: cim:ExcAC6A.tc
+        range: Seconds
+        multivalued: false
+        required: true
+        description: Voltage regulator time constant (<i>Tc</i>) (&gt;= 0).  Typical
+          value = 3.
+      vamax:
+        slot_uri: cim:ExcAC6A.vamax
+        range: PU
+        multivalued: false
+        required: true
+        description: Maximum voltage regulator output (<i>Vamax</i>) (&gt; 0).  Typical
+          value = 75.
+      vamin:
+        slot_uri: cim:ExcAC6A.vamin
+        range: PU
+        multivalued: false
+        required: true
+        description: Minimum voltage regulator output (<i>Vamin</i>) (&lt; 0).  Typical
+          value = -75.
+      vrmax:
+        slot_uri: cim:ExcAC6A.vrmax
+        range: PU
+        multivalued: false
+        required: true
+        description: Maximum voltage regulator output (<i>Vrmax</i>) (&gt; 0).  Typical
+          value = 44.
+      vrmin:
+        slot_uri: cim:ExcAC6A.vrmin
+        range: PU
+        multivalued: false
+        required: true
+        description: Minimum voltage regulator output (<i>Vrmin</i>) (&lt; 0).  Typical
+          value = -36.
+      te:
+        slot_uri: cim:ExcAC6A.te
+        range: Seconds
+        multivalued: false
+        required: true
+        description: Exciter time constant, integration rate associated with exciter
+          control (<i>Te</i>) (&gt; 0).  Typical value = 1.
+      kh:
+        slot_uri: cim:ExcAC6A.kh
+        range: PU
+        multivalued: false
+        required: true
+        description: Exciter field current limiter gain (<i>Kh</i>) (&gt;= 0).  Typical
+          value = 92.
+      tj:
+        slot_uri: cim:ExcAC6A.tj
+        range: Seconds
+        multivalued: false
+        required: true
+        description: Exciter field current limiter time constant (<i>Tj</i>) (&gt;=
+          0).  Typical value = 0,02.
+      th:
+        slot_uri: cim:ExcAC6A.th
+        range: Seconds
+        multivalued: false
+        required: true
+        description: Exciter field current limiter time constant (<i>Th</i>) (&gt;
+          0).  Typical value = 0,08.
+      vfelim:
+        slot_uri: cim:ExcAC6A.vfelim
+        range: PU
+        multivalued: false
+        required: true
+        description: Exciter field current limit reference (<i>Vfelim</i>) (&gt; 0).  Typical
+          value = 19.
+      vhmax:
+        slot_uri: cim:ExcAC6A.vhmax
+        range: PU
+        multivalued: false
+        required: true
+        description: Maximum field current limiter signal reference (<i>Vhmax</i>)
+          (&gt; 0).  Typical value = 75.
+      kc:
+        slot_uri: cim:ExcAC6A.kc
+        range: PU
+        multivalued: false
+        required: true
+        description: Rectifier loading factor proportional to commutating reactance
+          (<i>Kc</i>) (&gt;= 0).  Typical value = 0,173.
+      kd:
+        slot_uri: cim:ExcAC6A.kd
+        range: PU
+        multivalued: false
+        required: true
+        description: Demagnetizing factor, a function of exciter alternator reactances
+          (<i>Kd</i>) (&gt;= 0).  Typical value = 1,91.
+      ke:
+        slot_uri: cim:ExcAC6A.ke
+        range: PU
+        multivalued: false
+        required: true
+        description: Exciter constant related to self-excited field (<i>Ke</i>).  Typical
+          value = 1,6.
+      ve1:
+        slot_uri: cim:ExcAC6A.ve1
+        range: PU
+        multivalued: false
+        required: true
+        description: Exciter alternator output voltages back of commutating reactance
+          at which saturation is defined (<i>Ve</i><i><sub>1</sub></i>) (&gt; 0).  Typical
+          value = 7,4.
+      seve1:
+        slot_uri: cim:ExcAC6A.seve1
+        range: float
+        multivalued: false
+        required: true
+        description: Exciter saturation function value at the corresponding exciter
+          voltage, <i>Ve</i><i><sub>1</sub></i>, back of commutating reactance (<i>Se[Ve</i><i><sub>1</sub></i><i>]</i>)
+          (&gt;= 0).  Typical value = 0,214.
+      ve2:
+        slot_uri: cim:ExcAC6A.ve2
+        range: PU
+        multivalued: false
+        required: true
+        description: Exciter alternator output voltages back of commutating reactance
+          at which saturation is defined (<i>Ve</i><i><sub>2</sub></i>) (&gt; 0).  Typical
+          value = 5,55.
+      seve2:
+        slot_uri: cim:ExcAC6A.seve2
+        range: float
+        multivalued: false
+        required: true
+        description: Exciter saturation function value at the corresponding exciter
+          voltage, <i>Ve</i><i><sub>2</sub></i>, back of commutating reactance (<i>Se[Ve</i><i><sub>2</sub></i><i>]</i>)
+          (&gt;= 0).  Typical value = 0,044.
+    is_a: ExcitationSystemDynamics
+    description: Modified IEEE AC6A alternator-supplied rectifier excitation system
+      with speed input.
+  ExcAC8B:
+    class_uri: cim:ExcAC8B
+    attributes:
+      inlim:
+        slot_uri: cim:ExcAC8B.inlim
+        range: boolean
+        multivalued: false
+        required: true
+        description: 'Input limiter indicator.
+
+          true = input limiter <i>Vimax</i> and <i>Vimin</i> is considered
+
+          false = input limiter <i>Vimax </i>and <i>Vimin</i> is not considered.
+
+          Typical value = true.'
+      ka:
+        slot_uri: cim:ExcAC8B.ka
+        range: PU
+        multivalued: false
+        required: true
+        description: Voltage regulator gain (<i>Ka</i>) (&gt; 0).  Typical value =
+          1.
+      kc:
+        slot_uri: cim:ExcAC8B.kc
+        range: PU
+        multivalued: false
+        required: true
+        description: Rectifier loading factor proportional to commutating reactance
+          (<i>Kc</i>) (&gt;= 0). Typical value = 0,55.
+      kd:
+        slot_uri: cim:ExcAC8B.kd
+        range: PU
+        multivalued: false
+        required: true
+        description: Demagnetizing factor, a function of exciter alternator reactances
+          (<i>Kd</i>) (&gt;= 0).  Typical value = 1,1.
+      kdr:
+        slot_uri: cim:ExcAC8B.kdr
+        range: PU
+        multivalued: false
+        required: true
+        description: Voltage regulator derivative gain (<i>Kdr</i>) (&gt;= 0).  Typical
+          value = 10.
+      ke:
+        slot_uri: cim:ExcAC8B.ke
+        range: PU
+        multivalued: false
+        required: true
+        description: Exciter constant related to self-excited field (<i>Ke</i>).  Typical
+          value = 1.
+      kir:
+        slot_uri: cim:ExcAC8B.kir
+        range: PU
+        multivalued: false
+        required: true
+        description: Voltage regulator integral gain (<i>Kir</i>) (&gt;= 0).  Typical
+          value = 5.
+      kpr:
+        slot_uri: cim:ExcAC8B.kpr
+        range: PU
+        multivalued: false
+        required: true
+        description: Voltage regulator proportional gain (<i>Kpr</i>) (&gt; 0 if ExcAC8B.kir
+          = 0).  Typical value = 80.
+      ks:
+        slot_uri: cim:ExcAC8B.ks
+        range: PU
+        multivalued: false
+        required: true
+        description: Coefficient to allow different usage of the model-speed coefficient
+          (<i>Ks</i>).  Typical value = 0.
+      pidlim:
+        slot_uri: cim:ExcAC8B.pidlim
+        range: boolean
+        multivalued: false
+        required: true
+        description: 'PID limiter indicator.
+
+          true = input limiter <i>Vpidmax</i> and <i>Vpidmin</i> is considered
+
+          false = input limiter <i>Vpidmax</i> and <i>Vpidmin</i> is not considered.
+
+          Typical value = true.'
+      seve1:
+        slot_uri: cim:ExcAC8B.seve1
+        range: float
+        multivalued: false
+        required: true
+        description: Exciter saturation function value at the corresponding exciter
+          voltage, <i>Ve</i><i><sub>1</sub></i>, back of commutating reactance (<i>Se[Ve</i><i><sub>1</sub></i><i>]</i>)
+          (&gt;= 0).  Typical value = 0,3.
+      seve2:
+        slot_uri: cim:ExcAC8B.seve2
+        range: float
+        multivalued: false
+        required: true
+        description: Exciter saturation function value at the corresponding exciter
+          voltage, <i>Ve</i><i><sub>2</sub></i>, back of commutating reactance (<i>Se[Ve</i><i><sub>2</sub></i><i>]</i>)
+          (&gt;= 0).  Typical value = 3.
+      ta:
+        slot_uri: cim:ExcAC8B.ta
+        range: Seconds
+        multivalued: false
+        required: true
+        description: Voltage regulator time constant (<i>Ta</i>) (&gt;= 0).  Typical
+          value = 0.
+      tdr:
+        slot_uri: cim:ExcAC8B.tdr
+        range: Seconds
+        multivalued: false
+        required: true
+        description: Lag time constant (<i>Tdr</i>) (&gt; 0 if ExcAC8B.kdr &gt; 0).  Typical
+          value = 0,1.
+      te:
+        slot_uri: cim:ExcAC8B.te
+        range: Seconds
+        multivalued: false
+        required: true
+        description: Exciter time constant, integration rate associated with exciter
+          control (<i>Te</i>) (&gt; 0).  Typical value = 1,2.
+      telim:
+        slot_uri: cim:ExcAC8B.telim
+        range: boolean
+        multivalued: false
+        required: true
+        description: "Selector for the limiter on the block (<i>1/sTe</i>). \nSee\
+          \ diagram for meaning of true and false.\nTypical value = false."
+      ve1:
+        slot_uri: cim:ExcAC8B.ve1
+        range: PU
+        multivalued: false
+        required: true
+        description: Exciter alternator output voltages back of commutating reactance
+          at which saturation is defined (<i>Ve</i><i><sub>1</sub></i>) (&gt; 0).  Typical
+          value = 6,5.
+      ve2:
+        slot_uri: cim:ExcAC8B.ve2
+        range: PU
+        multivalued: false
+        required: true
+        description: Exciter alternator output voltages back of commutating reactance
+          at which saturation is defined (<i>Ve</i><i><sub>2</sub></i>) (&gt; 0).  Typical
+          value = 9.
+      vemin:
+        slot_uri: cim:ExcAC8B.vemin
+        range: PU
+        multivalued: false
+        required: true
+        description: Minimum exciter voltage output (<i>Vemin</i>) (&lt;= 0).  Typical
+          value = 0.
+      vfemax:
+        slot_uri: cim:ExcAC8B.vfemax
+        range: PU
+        multivalued: false
+        required: true
+        description: Exciter field current limit reference (<i>Vfemax</i>).  Typical
+          value = 6.
+      vimax:
+        slot_uri: cim:ExcAC8B.vimax
+        range: PU
+        multivalued: false
+        required: true
+        description: Input signal maximum (<i>Vimax</i>) (&gt; ExcAC8B.vimin).  Typical
+          value = 35.
+      vimin:
+        slot_uri: cim:ExcAC8B.vimin
+        range: PU
+        multivalued: false
+        required: true
+        description: Input signal minimum (<i>Vimin</i>) (&lt; ExcAC8B.vimax).  Typical
+          value = -10.
+      vpidmax:
+        slot_uri: cim:ExcAC8B.vpidmax
+        range: PU
+        multivalued: false
+        required: true
+        description: PID maximum controller output (<i>Vpidmax</i>) (&gt; ExcAC8B.vpidmin).  Typical
+          value = 35.
+      vpidmin:
+        slot_uri: cim:ExcAC8B.vpidmin
+        range: PU
+        multivalued: false
+        required: true
+        description: PID minimum controller output (<i>Vpidmin</i>) (&lt; ExcAC8B.vpidmax).  Typical
+          value = -10.
+      vrmax:
+        slot_uri: cim:ExcAC8B.vrmax
+        range: PU
+        multivalued: false
+        required: true
+        description: Maximum voltage regulator output (<i>Vrmax</i>) (&gt; 0). Typical
+          value = 35.
+      vrmin:
+        slot_uri: cim:ExcAC8B.vrmin
+        range: PU
+        multivalued: false
+        required: true
+        description: Minimum voltage regulator output (<i>Vrmin</i>) (&lt; 0).  Typical
+          value = 0.
+      vtmult:
+        slot_uri: cim:ExcAC8B.vtmult
+        range: boolean
+        multivalued: false
+        required: true
+        description: "Multiply by generator's terminal voltage indicator.\ntrue =the\
+          \ limits <i>Vrmax</i> and <i>Vrmin</i> are multiplied by the generator\u2019\
+          s terminal voltage to represent a thyristor power stage fed from the generator\
+          \ terminals\nfalse = limits are not multiplied by generator's terminal voltage.\
+          \ \nTypical value = false."
+    is_a: ExcitationSystemDynamics
+    description: Modified IEEE AC8B alternator-supplied rectifier excitation system
+      with speed input and input limiter.
+  ExcANS:
+    class_uri: cim:ExcANS
+    attributes:
+      k3:
+        slot_uri: cim:ExcANS.k3
+        range: float
+        multivalued: false
+        required: true
+        description: AVR gain (<i>K</i><i><sub>3</sub></i>).  Typical value = 1000.
+      k2:
+        slot_uri: cim:ExcANS.k2
+        range: float
+        multivalued: false
+        required: true
+        description: Exciter gain (<i>K</i><i><sub>2</sub></i>).  Typical value =
+          20.
+      kce:
+        slot_uri: cim:ExcANS.kce
+        range: float
+        multivalued: false
+        required: true
+        description: Ceiling factor (<i>K</i><i><sub>CE</sub></i>).  Typical value
+          = 1.
+      t3:
+        slot_uri: cim:ExcANS.t3
+        range: Seconds
+        multivalued: false
+        required: true
+        description: Time constant (<i>T</i><i><sub>3</sub></i>) (&gt;= 0).  Typical
+          value = 1,6.
+      t2:
+        slot_uri: cim:ExcANS.t2
+        range: Seconds
+        multivalued: false
+        required: true
+        description: Time constant (<i>T</i><i><sub>2</sub></i>) (&gt;= 0).  Typical
+          value = 0,05.
+      t1:
+        slot_uri: cim:ExcANS.t1
+        range: Seconds
+        multivalued: false
+        required: true
+        description: Time constant (<i>T</i><i><sub>1</sub></i>) (&gt;= 0).  Typical
+          value = 20.
+      blint:
+        slot_uri: cim:ExcANS.blint
+        range: integer
+        multivalued: false
+        required: true
+        description: "Governor control flag (<i>BLINT</i>). \n0 = lead-lag regulator\n\
+          1 = proportional integral regulator.\nTypical value = 0."
+      kvfif:
+        slot_uri: cim:ExcANS.kvfif
+        range: integer
+        multivalued: false
+        required: true
+        description: "Rate feedback signal flag (<i>K</i><i><sub>VFIF</sub></i>).\
+          \ \n0 = output voltage of the exciter\n1 = exciter field current.\nTypical\
+          \ value = 0."
+      ifmn:
+        slot_uri: cim:ExcANS.ifmn
+        range: PU
+        multivalued: false
+        required: true
+        description: Minimum exciter current (<i>I</i><i><sub>FMN</sub></i>).  Typical
+          value = -5,2.
+      ifmx:
+        slot_uri: cim:ExcANS.ifmx
+        range: PU
+        multivalued: false
+        required: true
+        description: Maximum exciter current (<i>I</i><i><sub>FMX</sub></i>).  Typical
+          value = 6,5.
+      vrmn:
+        slot_uri: cim:ExcANS.vrmn
+        range: PU
+        multivalued: false
+        required: true
+        description: Minimum AVR output (<i>V</i><i><sub>RMN</sub></i>).  Typical
+          value = -5,2.
+      vrmx:
+        slot_uri: cim:ExcANS.vrmx
+        range: PU
+        multivalued: false
+        required: true
+        description: Maximum AVR output (<i>V</i><i><sub>RMX</sub></i>).  Typical
+          value = 6,5.
+      krvecc:
+        slot_uri: cim:ExcANS.krvecc
+        range: integer
+        multivalued: false
+        required: true
+        description: "Feedback enabling (<i>K</i><i><sub>RVECC</sub></i>). \n0 = open\
+          \ loop control\n1 = closed loop control.\nTypical value = 1."
+      tb:
+        slot_uri: cim:ExcANS.tb
+        range: Seconds
+        multivalued: false
+        required: true
+        description: Exciter time constant (<i>T</i><i><sub>B</sub></i>) (&gt;= 0).  Typical
+          value = 0,04.
+    is_a: ExcitationSystemDynamics
+    description: Italian excitation system. It represents static field voltage or
+      excitation current feedback excitation system.
+  ExcAVR1:
+    class_uri: cim:ExcAVR1
+    attributes:
+      ka:
+        slot_uri: cim:ExcAVR1.ka
+        range: float
+        multivalued: false
+        required: true
+        description: AVR gain (<i>K</i><i><sub>A</sub></i>).  Typical value = 500.
+      vrmn:
+        slot_uri: cim:ExcAVR1.vrmn
+        range: PU
+        multivalued: false
+        required: true
+        description: Minimum AVR output (<i>V</i><i><sub>RMN</sub></i>).  Typical
+          value = -6.
+      vrmx:
+        slot_uri: cim:ExcAVR1.vrmx
+        range: PU
+        multivalued: false
+        required: true
+        description: Maximum AVR output (<i>V</i><i><sub>RMX</sub></i>).  Typical
+          value = 7.
+      ta:
+        slot_uri: cim:ExcAVR1.ta
+        range: Seconds
+        multivalued: false
+        required: true
+        description: AVR time constant (<i>T</i><i><sub>A</sub></i>) (&gt;= 0).  Typical
+          value = 0,2.
+      tb:
+        slot_uri: cim:ExcAVR1.tb
+        range: Seconds
+        multivalued: false
+        required: true
+        description: AVR time constant (<i>T</i><i><sub>B</sub></i>) (&gt;= 0).  Typical
+          value = 0.
+      te:
+        slot_uri: cim:ExcAVR1.te
+        range: Seconds
+        multivalued: false
+        required: true
+        description: Exciter time constant (<i>T</i><i><sub>E</sub></i>) (&gt;= 0).  Typical
+          value = 1.
+      e1:
+        slot_uri: cim:ExcAVR1.e1
+        range: PU
+        multivalued: false
+        required: true
+        description: Field voltage value 1 (<i>E</i><i><sub>1</sub></i>).  Typical
+          value = 4.18.
+      se1:
+        slot_uri: cim:ExcAVR1.se1
+        range: float
+        multivalued: false
+        required: true
+        description: Saturation factor at <i>E</i><i><sub>1</sub></i> (<i>S[E</i><i><sub>1</sub></i><i>]</i>).  Typical
+          value = 0,1.
+      e2:
+        slot_uri: cim:ExcAVR1.e2
+        range: PU
+        multivalued: false
+        required: true
+        description: Field voltage value 2 (<i>E</i><i><sub>2</sub></i>).  Typical
+          value = 3,14.
+      se2:
+        slot_uri: cim:ExcAVR1.se2
+        range: float
+        multivalued: false
+        required: true
+        description: Saturation factor at <i>E</i><i><sub>2</sub></i> (<i>S[E</i><i><sub>2</sub></i><i>]</i>).  Typical
+          value = 0,03.
+      kf:
+        slot_uri: cim:ExcAVR1.kf
+        range: float
+        multivalued: false
+        required: true
+        description: Rate feedback gain (<i>K</i><i><sub>F</sub></i>).  Typical value
+          = 0,12.
+      tf:
+        slot_uri: cim:ExcAVR1.tf
+        range: Seconds
+        multivalued: false
+        required: true
+        description: Rate feedback time constant (<i>T</i><i><sub>F</sub></i>) (&gt;=
+          0).  Typical value = 1.
+    is_a: ExcitationSystemDynamics
+    description: Italian excitation system corresponding to IEEE (1968) type 1 model.
+      It represents an exciter dynamo and electromechanical regulator.
+  ExcAVR2:
+    class_uri: cim:ExcAVR2
+    attributes:
+      ka:
+        slot_uri: cim:ExcAVR2.ka
+        range: float
+        multivalued: false
+        required: true
+        description: AVR gain (<i>K</i><i><sub>A</sub></i>).  Typical value = 500.
+      vrmn:
+        slot_uri: cim:ExcAVR2.vrmn
+        range: PU
+        multivalued: false
+        required: true
+        description: Minimum AVR output (<i>V</i><i><sub>RMN</sub></i>).  Typical
+          value = -6.
+      vrmx:
+        slot_uri: cim:ExcAVR2.vrmx
+        range: PU
+        multivalued: false
+        required: true
+        description: Maximum AVR output (<i>V</i><i><sub>RMX</sub></i>).  Typical
+          value = 7.
+      ta:
+        slot_uri: cim:ExcAVR2.ta
+        range: Seconds
+        multivalued: false
+        required: true
+        description: AVR time constant (<i>T</i><i><sub>A</sub></i>) (&gt;= 0).  Typical
+          value = 0,02.
+      tb:
+        slot_uri: cim:ExcAVR2.tb
+        range: Seconds
+        multivalued: false
+        required: true
+        description: AVR time constant (<i>T</i><i><sub>B</sub></i>) (&gt;= 0).  Typical
+          value = 0.
+      te:
+        slot_uri: cim:ExcAVR2.te
+        range: Seconds
+        multivalued: false
+        required: true
+        description: Exciter time constant (<i>T</i><i><sub>E</sub></i>) (&gt;= 0).  Typical
+          value = 1.
+      e1:
+        slot_uri: cim:ExcAVR2.e1
+        range: PU
+        multivalued: false
+        required: true
+        description: Field voltage value 1 (<i>E</i><i><sub>1</sub></i>).  Typical
+          value = 4,18.
+      se1:
+        slot_uri: cim:ExcAVR2.se1
+        range: float
+        multivalued: false
+        required: true
+        description: Saturation factor at <i>E</i><i><sub>1</sub></i> (<i>S[E</i><i><sub>1</sub></i><i>]</i>).  Typical
+          value = 0.1.
+      e2:
+        slot_uri: cim:ExcAVR2.e2
+        range: PU
+        multivalued: false
+        required: true
+        description: Field voltage value 2 (<i>E</i><i><sub>2</sub></i>).  Typical
+          value = 3,14.
+      se2:
+        slot_uri: cim:ExcAVR2.se2
+        range: float
+        multivalued: false
+        required: true
+        description: Saturation factor at <i>E</i><i><sub>2</sub></i> (<i>S[E</i><i><sub>2</sub></i><i>]</i>).  Typical
+          value = 0,03.
+      kf:
+        slot_uri: cim:ExcAVR2.kf
+        range: float
+        multivalued: false
+        required: true
+        description: Rate feedback gain (<i>K</i><i><sub>F</sub></i>).  Typical value
+          = 0,12.
+      tf1:
+        slot_uri: cim:ExcAVR2.tf1
+        range: Seconds
+        multivalued: false
+        required: true
+        description: Rate feedback time constant (<i>T</i><i><sub>F1</sub></i>) (&gt;=
+          0).  Typical value = 1.
+      tf2:
+        slot_uri: cim:ExcAVR2.tf2
+        range: Seconds
+        multivalued: false
+        required: true
+        description: Rate feedback time constant (<i>T</i><i><sub>F2</sub></i>) (&gt;=
+          0).  Typical value = 1.
+    is_a: ExcitationSystemDynamics
+    description: Italian excitation system corresponding to IEEE (1968) type 2 model.
+      It represents an alternator and rotating diodes and electromechanic voltage
+      regulators.
+  ExcAVR3:
+    class_uri: cim:ExcAVR3
+    attributes:
+      ka:
+        slot_uri: cim:ExcAVR3.ka
+        range: float
+        multivalued: false
+        required: true
+        description: AVR gain (<i>K</i><i><sub>A</sub></i>).  Typical value = 100.
+      vrmn:
+        slot_uri: cim:ExcAVR3.vrmn
+        range: PU
+        multivalued: false
+        required: true
+        description: Minimum AVR output (<i>V</i><i><sub>RMN</sub></i>).  Typical
+          value = -7,5.
+      vrmx:
+        slot_uri: cim:ExcAVR3.vrmx
+        range: PU
+        multivalued: false
+        required: true
+        description: Maximum AVR output (<i>V</i><i><sub>RMX</sub></i>).  Typical
+          value = 7,5.
+      t1:
+        slot_uri: cim:ExcAVR3.t1
+        range: Seconds
+        multivalued: false
+        required: true
+        description: AVR time constant (<i>T</i><i><sub>1</sub></i>) (&gt;= 0).  Typical
+          value = 20.
+      t2:
+        slot_uri: cim:ExcAVR3.t2
+        range: Seconds
+        multivalued: false
+        required: true
+        description: AVR time constant (<i>T</i><i><sub>2</sub></i>) (&gt;= 0).  Typical
+          value = 1,6.
+      t3:
+        slot_uri: cim:ExcAVR3.t3
+        range: Seconds
+        multivalued: false
+        required: true
+        description: AVR time constant (<i>T</i><i><sub>3</sub></i>) (&gt;= 0).  Typical
+          value = 0,66.
+      t4:
+        slot_uri: cim:ExcAVR3.t4
+        range: Seconds
+        multivalued: false
+        required: true
+        description: AVR time constant (<i>T</i><i><sub>4</sub></i>) (&gt;= 0).  Typical
+          value = 0,07.
+      te:
+        slot_uri: cim:ExcAVR3.te
+        range: Seconds
+        multivalued: false
+        required: true
+        description: Exciter time constant (<i>T</i><i><sub>E</sub></i>) (&gt;= 0).  Typical
+          value = 1.
+      e1:
+        slot_uri: cim:ExcAVR3.e1
+        range: PU
+        multivalued: false
+        required: true
+        description: Field voltage value 1 (<i>E</i><i><sub>1</sub></i>).  Typical
+          value = 4,18.
+      se1:
+        slot_uri: cim:ExcAVR3.se1
+        range: float
+        multivalued: false
+        required: true
+        description: Saturation factor at <i>E</i><i><sub>1</sub></i><i> </i>(<i>S[E</i><i><sub>1</sub></i><i>]</i>).  Typical
+          value = 0,1.
+      e2:
+        slot_uri: cim:ExcAVR3.e2
+        range: PU
+        multivalued: false
+        required: true
+        description: Field voltage value 2 (<i>E</i><i><sub>2</sub></i>).  Typical
+          value = 3,14.
+      se2:
+        slot_uri: cim:ExcAVR3.se2
+        range: float
+        multivalued: false
+        required: true
+        description: Saturation factor at <i>E</i><i><sub>2</sub></i><i> </i>(<i>S[E</i><i><sub>2</sub></i><i>]</i>).  Typical
+          value = 0,03.
+    is_a: ExcitationSystemDynamics
+    description: Italian excitation system. It represents an exciter dynamo and electric
+      regulator.
+  ExcAVR4:
+    class_uri: cim:ExcAVR4
+    attributes:
+      ka:
+        slot_uri: cim:ExcAVR4.ka
+        range: float
+        multivalued: false
+        required: true
+        description: AVR gain (<i>K</i><i><sub>A</sub></i>).  Typical value = 300.
+      vrmn:
+        slot_uri: cim:ExcAVR4.vrmn
+        range: PU
+        multivalued: false
+        required: true
+        description: Minimum AVR output (<i>V</i><i><sub>RMN</sub></i>).  Typical
+          value = 0.
+      vrmx:
+        slot_uri: cim:ExcAVR4.vrmx
+        range: PU
+        multivalued: false
+        required: true
+        description: Maximum AVR output (<i>V</i><i><sub>RMX</sub></i>).  Typical
+          value = 5.
+      t1:
+        slot_uri: cim:ExcAVR4.t1
+        range: Seconds
+        multivalued: false
+        required: true
+        description: AVR time constant (<i>T</i><i><sub>1</sub></i>) (&gt;= 0).  Typical
+          value = 4,8.
+      t2:
+        slot_uri: cim:ExcAVR4.t2
+        range: Seconds
+        multivalued: false
+        required: true
+        description: AVR time constant (<i>T</i><i><sub>2</sub></i>) (&gt;= 0).  Typical
+          value = 1,5.
+      t3:
+        slot_uri: cim:ExcAVR4.t3
+        range: Seconds
+        multivalued: false
+        required: true
+        description: AVR time constant (<i>T</i><i><sub>3</sub></i>) (&gt;= 0).  Typical
+          value = 0.
+      t4:
+        slot_uri: cim:ExcAVR4.t4
+        range: Seconds
+        multivalued: false
+        required: true
+        description: AVR time constant (<i>T</i><i><sub>4</sub></i>) (&gt;= 0).  Typical
+          value = 0.
+      ke:
+        slot_uri: cim:ExcAVR4.ke
+        range: float
+        multivalued: false
+        required: true
+        description: Exciter gain (<i>K</i><i><sub>E</sub></i><i>)</i>.  Typical value
+          = 1.
+      vfmx:
+        slot_uri: cim:ExcAVR4.vfmx
+        range: PU
+        multivalued: false
+        required: true
+        description: Maximum exciter output (<i>V</i><i><sub>FMX</sub></i>).  Typical
+          value = 5.
+      vfmn:
+        slot_uri: cim:ExcAVR4.vfmn
+        range: PU
+        multivalued: false
+        required: true
+        description: Minimum exciter output (<i>V</i><i><sub>FMN</sub></i>).  Typical
+          value = 0.
+      kif:
+        slot_uri: cim:ExcAVR4.kif
+        range: float
+        multivalued: false
+        required: true
+        description: Exciter internal reactance (<i>K</i><i><sub>IF</sub></i>).  Typical
+          value = 0.
+      tif:
+        slot_uri: cim:ExcAVR4.tif
+        range: Seconds
+        multivalued: false
+        required: true
+        description: Exciter current feedback time constant (<i>T</i><i><sub>IF</sub></i>)
+          (&gt;= 0).  Typical value = 0.
+      t1if:
+        slot_uri: cim:ExcAVR4.t1if
+        range: Seconds
+        multivalued: false
+        required: true
+        description: Exciter current feedback time constant (<i>T</i><i><sub>1IF</sub></i>)
+          (&gt;= 0).  Typical value = 60.
+      imul:
+        slot_uri: cim:ExcAVR4.imul
+        range: boolean
+        multivalued: false
+        required: true
+        description: 'AVR output voltage dependency selector (<i>I</i><i><sub>MUL</sub></i>).
+
+          true = selector is connected
+
+          false = selector is not connected.
+
+          Typical value = true.'
+    is_a: ExcitationSystemDynamics
+    description: Italian excitation system. It represents a static exciter and electric
+      voltage regulator.
+  ExcAVR5:
+    class_uri: cim:ExcAVR5
+    attributes:
+      ka:
+        slot_uri: cim:ExcAVR5.ka
+        range: PU
+        multivalued: false
+        required: true
+        description: Gain (<i>Ka</i>).
+      ta:
+        slot_uri: cim:ExcAVR5.ta
+        range: Seconds
+        multivalued: false
+        required: true
+        description: Time constant (<i>Ta</i>) (&gt;= 0).
+      rex:
+        slot_uri: cim:ExcAVR5.rex
+        range: PU
+        multivalued: false
+        required: true
+        description: Effective output resistance (<i>Rex</i>). <i>Rex</i> represents
+          the effective output resistance seen by the excitation system.
+    is_a: ExcitationSystemDynamics
+    description: Manual excitation control with field circuit resistance. This model
+      can be used as a very simple representation of manual voltage control.
+  ExcAVR7:
+    class_uri: cim:ExcAVR7
+    attributes:
+      k1:
+        slot_uri: cim:ExcAVR7.k1
+        range: PU
+        multivalued: false
+        required: true
+        description: Gain (<i>K</i><i><sub>1</sub></i>).  Typical value = 1.
+      a1:
+        slot_uri: cim:ExcAVR7.a1
+        range: PU
+        multivalued: false
+        required: true
+        description: Lead coefficient (<i>A</i><i><sub>1</sub></i>).  Typical value
+          = 0,5.
+      a2:
+        slot_uri: cim:ExcAVR7.a2
+        range: PU
+        multivalued: false
+        required: true
+        description: Lag coefficient (<i>A</i><i><sub>2</sub></i>).  Typical value
+          = 0,5.
+      t1:
+        slot_uri: cim:ExcAVR7.t1
+        range: Seconds
+        multivalued: false
+        required: true
+        description: Lead time constant (<i>T</i><i><sub>1</sub></i>) (&gt;= 0).  Typical
+          value = 0,05.
+      t2:
+        slot_uri: cim:ExcAVR7.t2
+        range: Seconds
+        multivalued: false
+        required: true
+        description: Lag time constant (<i>T</i><i><sub>2</sub></i>) (&gt;= 0).  Typical
+          value = 0,1.
+      vmax1:
+        slot_uri: cim:ExcAVR7.vmax1
+        range: PU
+        multivalued: false
+        required: true
+        description: Lead-lag maximum limit (<i>Vmax1</i>) (&gt; ExcAVR7.vmin1).  Typical
+          value = 5.
+      vmin1:
+        slot_uri: cim:ExcAVR7.vmin1
+        range: PU
+        multivalued: false
+        required: true
+        description: Lead-lag minimum limit (<i>Vmin1</i>) (&lt; ExcAVR7.vmax1).  Typical
+          value = -5.
+      k3:
+        slot_uri: cim:ExcAVR7.k3
+        range: PU
+        multivalued: false
+        required: true
+        description: Gain (<i>K</i><i><sub>3</sub></i>).  Typical value = 3.
+      a3:
+        slot_uri: cim:ExcAVR7.a3
+        range: PU
+        multivalued: false
+        required: true
+        description: Lead coefficient (<i>A</i><i><sub>3</sub></i>).  Typical value
+          = 0,5.
+      a4:
+        slot_uri: cim:ExcAVR7.a4
+        range: PU
+        multivalued: false
+        required: true
+        description: Lag coefficient (<i>A</i><i><sub>4</sub></i>).  Typical value
+          = 0,5.
+      t3:
+        slot_uri: cim:ExcAVR7.t3
+        range: Seconds
+        multivalued: false
+        required: true
+        description: Lead time constant (<i>T</i><i><sub>3</sub></i>) (&gt;= 0).  Typical
+          value = 0,1.
+      t4:
+        slot_uri: cim:ExcAVR7.t4
+        range: Seconds
+        multivalued: false
+        required: true
+        description: Lag time constant (<i>T</i><i><sub>4</sub></i>) (&gt;= 0).  Typical
+          value = 0,1.
+      vmax3:
+        slot_uri: cim:ExcAVR7.vmax3
+        range: PU
+        multivalued: false
+        required: true
+        description: Lead-lag maximum limit (<i>Vmax3</i>) (&gt; ExcAVR7.vmin3).  Typical
+          value = 5.
+      vmin3:
+        slot_uri: cim:ExcAVR7.vmin3
+        range: PU
+        multivalued: false
+        required: true
+        description: Lead-lag minimum limit (<i>Vmin3</i>) (&lt; ExcAVR7.vmax3).  Typical
+          value = -5.
+      k5:
+        slot_uri: cim:ExcAVR7.k5
+        range: PU
+        multivalued: false
+        required: true
+        description: Gain (<i>K</i><i><sub>5</sub></i>).  Typical value = 1.
+      a5:
+        slot_uri: cim:ExcAVR7.a5
+        range: PU
+        multivalued: false
+        required: true
+        description: Lead coefficient (<i>A</i><i><sub>5</sub></i>).  Typical value
+          = 0,5.
+      a6:
+        slot_uri: cim:ExcAVR7.a6
+        range: PU
+        multivalued: false
+        required: true
+        description: Lag coefficient (<i>A</i><i><sub>6</sub></i>).  Typical value
+          = 0,5.
+      t5:
+        slot_uri: cim:ExcAVR7.t5
+        range: Seconds
+        multivalued: false
+        required: true
+        description: Lead time constant (<i>T</i><i><sub>5</sub></i>) (&gt;= 0).  Typical
+          value = 0,1.
+      t6:
+        slot_uri: cim:ExcAVR7.t6
+        range: Seconds
+        multivalued: false
+        required: true
+        description: Lag time constant (<i>T</i><i><sub>6</sub></i>) (&gt;= 0).  Typical
+          value = 0,1.
+      vmax5:
+        slot_uri: cim:ExcAVR7.vmax5
+        range: PU
+        multivalued: false
+        required: true
+        description: Lead-lag maximum limit (<i>Vmax5</i>) (&gt; ExcAVR7.vmin5).  Typical
+          value = 5.
+      vmin5:
+        slot_uri: cim:ExcAVR7.vmin5
+        range: PU
+        multivalued: false
+        required: true
+        description: Lead-lag minimum limit (<i>Vmin5</i>) (&lt; ExcAVR7.vmax5).  Typical
+          value = -2.
+    is_a: ExcitationSystemDynamics
+    description: IVO excitation system.
+  ExcBBC:
+    class_uri: cim:ExcBBC
+    attributes:
+      t1:
+        slot_uri: cim:ExcBBC.t1
+        range: Seconds
+        multivalued: false
+        required: true
+        description: Controller time constant (<i>T1</i>) (&gt;= 0).  Typical value
+          = 6.
+      t2:
+        slot_uri: cim:ExcBBC.t2
+        range: Seconds
+        multivalued: false
+        required: true
+        description: Controller time constant (<i>T2</i>) (&gt;= 0).  Typical value
+          = 1.
+      t3:
+        slot_uri: cim:ExcBBC.t3
+        range: Seconds
+        multivalued: false
+        required: true
+        description: Lead/lag time constant (<i>T3</i>) (&gt;= 0).  If = 0, block
+          is bypassed.  Typical value = 0,05.
+      t4:
+        slot_uri: cim:ExcBBC.t4
+        range: Seconds
+        multivalued: false
+        required: true
+        description: Lead/lag time constant (<i>T4</i>) (&gt;= 0).  If = 0, block
+          is bypassed.  Typical value = 0,01.
+      k:
+        slot_uri: cim:ExcBBC.k
+        range: PU
+        multivalued: false
+        required: true
+        description: Steady state gain (<i>K</i>) (not = 0).  Typical value = 300.
+      vrmin:
+        slot_uri: cim:ExcBBC.vrmin
+        range: PU
+        multivalued: false
+        required: true
+        description: Minimum control element output (<i>Vrmin</i>) (&lt; ExcBBC.vrmax).  Typical
+          value = -5.
+      vrmax:
+        slot_uri: cim:ExcBBC.vrmax
+        range: PU
+        multivalued: false
+        required: true
+        description: Maximum control element output (<i>Vrmax</i>) (&gt; ExcBBC.vrmin).  Typical
+          value = 5.
+      efdmin:
+        slot_uri: cim:ExcBBC.efdmin
+        range: PU
+        multivalued: false
+        required: true
+        description: Minimum open circuit exciter voltage (<i>Efdmin</i>) (&lt; ExcBBC.efdmax).  Typical
+          value = -5.
+      efdmax:
+        slot_uri: cim:ExcBBC.efdmax
+        range: PU
+        multivalued: false
+        required: true
+        description: Maximum open circuit exciter voltage (<i>Efdmax</i>) (&gt; ExcBBC.efdmin).  Typical
+          value = 5.
+      xe:
+        slot_uri: cim:ExcBBC.xe
+        range: PU
+        multivalued: false
+        required: true
+        description: Effective excitation transformer reactance (<i>Xe</i>) (&gt;=
+          0).  <i>Xe</i> models the regulation of the transformer/rectifier unit.  Typical
+          value = 0,05.
+      switch:
+        slot_uri: cim:ExcBBC.switch
+        range: boolean
+        multivalued: false
+        required: true
+        description: 'Supplementary signal routing selector (<i>switch</i>).
+
+          true = <i>Vs</i> connected to 3rd summing point
+
+          false =  <i>Vs</i> connected to 1st summing point (see diagram).
+
+          Typical value = false.'
+    is_a: ExcitationSystemDynamics
+    description: Transformer fed static excitation system (static with ABB regulator).
+      This model represents a static excitation system in which a gated thyristor
+      bridge fed by a transformer at the main generator terminals feeds the main generator
+      directly.
+  ExcCZ:
+    class_uri: cim:ExcCZ
+    attributes:
+      kp:
+        slot_uri: cim:ExcCZ.kp
+        range: PU
+        multivalued: false
+        required: true
+        description: Regulator proportional gain (<i>Kp</i>).
+      tc:
+        slot_uri: cim:ExcCZ.tc
+        range: Seconds
+        multivalued: false
+        required: true
+        description: Regulator integral time constant (<i>Tc</i>) (&gt;= 0).
+      vrmax:
+        slot_uri: cim:ExcCZ.vrmax
+        range: PU
+        multivalued: false
+        required: true
+        description: Voltage regulator maximum limit (<i>Vrmax</i>) (&gt; ExcCZ.vrmin).
+      vrmin:
+        slot_uri: cim:ExcCZ.vrmin
+        range: PU
+        multivalued: false
+        required: true
+        description: Voltage regulator minimum limit (<i>Vrmin</i>) (&lt; ExcCZ.vrmax).
+      ka:
+        slot_uri: cim:ExcCZ.ka
+        range: PU
+        multivalued: false
+        required: true
+        description: Regulator gain (<i>Ka</i>).
+      ta:
+        slot_uri: cim:ExcCZ.ta
+        range: Seconds
+        multivalued: false
+        required: true
+        description: Regulator time constant (<i>Ta</i>) (&gt;= 0).
+      ke:
+        slot_uri: cim:ExcCZ.ke
+        range: PU
+        multivalued: false
+        required: true
+        description: Exciter constant related to self-excited field (<i>Ke</i>).
+      te:
+        slot_uri: cim:ExcCZ.te
+        range: Seconds
+        multivalued: false
+        required: true
+        description: Exciter time constant, integration rate associated with exciter
+          control (<i>Te</i>) (&gt;= 0).
+      efdmax:
+        slot_uri: cim:ExcCZ.efdmax
+        range: PU
+        multivalued: false
+        required: true
+        description: Exciter output maximum limit (<i>Efdmax</i>) (&gt; ExcCZ.efdmin).
+      efdmin:
+        slot_uri: cim:ExcCZ.efdmin
+        range: PU
+        multivalued: false
+        required: true
+        description: Exciter output minimum limit (<i>Efdmin</i>) (&lt; ExcCZ.efdmax).
+    is_a: ExcitationSystemDynamics
+    description: Czech proportion/integral exciter.
+  ExcDC1A:
+    class_uri: cim:ExcDC1A
+    attributes:
+      ka:
+        slot_uri: cim:ExcDC1A.ka
+        range: PU
+        multivalued: false
+        required: true
+        description: Voltage regulator gain (<i>Ka</i>) (&gt; 0).  Typical value =
+          46.
+      ks:
+        slot_uri: cim:ExcDC1A.ks
+        range: PU
+        multivalued: false
+        required: true
+        description: Coefficient to allow different usage of the model-speed coefficient
+          (<i>Ks</i>).  Typical value = 0.
+      ta:
+        slot_uri: cim:ExcDC1A.ta
+        range: Seconds
+        multivalued: false
+        required: true
+        description: Voltage regulator time constant (<i>Ta</i>) (&gt; 0).  Typical
+          value = 0,06.
+      tb:
+        slot_uri: cim:ExcDC1A.tb
+        range: Seconds
+        multivalued: false
+        required: true
+        description: Voltage regulator time constant (<i>Tb</i>) (&gt;= 0).  Typical
+          value = 0.
+      tc:
+        slot_uri: cim:ExcDC1A.tc
+        range: Seconds
+        multivalued: false
+        required: true
+        description: Voltage regulator time constant (<i>Tc</i>) (&gt;= 0).  Typical
+          value = 0.
+      vrmax:
+        slot_uri: cim:ExcDC1A.vrmax
+        range: PU
+        multivalued: false
+        required: true
+        description: Maximum voltage regulator output (<i>Vrmax</i>) (&gt; ExcDC1A.vrmin).  Typical
+          value = 1.
+      vrmin:
+        slot_uri: cim:ExcDC1A.vrmin
+        range: PU
+        multivalued: false
+        required: true
+        description: Minimum voltage regulator output (<i>Vrmin</i>) (&lt; 0 and &lt;
+          ExcDC1A.vrmax).  Typical value = -0,9.
+      ke:
+        slot_uri: cim:ExcDC1A.ke
+        range: PU
+        multivalued: false
+        required: true
+        description: Exciter constant related to self-excited field (<i>Ke</i>).  Typical
+          value = 0.
+      te:
+        slot_uri: cim:ExcDC1A.te
+        range: Seconds
+        multivalued: false
+        required: true
+        description: Exciter time constant, integration rate associated with exciter
+          control (<i>Te</i>) (&gt; 0).  Typical value = 0,46.
+      kf:
+        slot_uri: cim:ExcDC1A.kf
+        range: PU
+        multivalued: false
+        required: true
+        description: Excitation control system stabilizer gain (<i>Kf</i>) (&gt;=
+          0).  Typical value = 0,1.
+      tf:
+        slot_uri: cim:ExcDC1A.tf
+        range: Seconds
+        multivalued: false
+        required: true
+        description: Excitation control system stabilizer time constant (<i>Tf</i>)
+          (&gt; 0).  Typical value = 1.
+      efd1:
+        slot_uri: cim:ExcDC1A.efd1
+        range: PU
+        multivalued: false
+        required: true
+        description: Exciter voltage at which exciter saturation is defined (<i>Efd</i><i><sub>1</sub></i>)
+          (&gt; 0).  Typical value = 3,1.
+      seefd1:
+        slot_uri: cim:ExcDC1A.seefd1
+        range: float
+        multivalued: false
+        required: true
+        description: Exciter saturation function value at the corresponding exciter
+          voltage, <i>Efd</i><i><sub>1</sub></i> (<i>Se[Eefd</i><i><sub>1</sub></i><i>]</i>)
+          (&gt;= 0).  Typical value = 0,33.
+      efd2:
+        slot_uri: cim:ExcDC1A.efd2
+        range: PU
+        multivalued: false
+        required: true
+        description: Exciter voltage at which exciter saturation is defined (<i>Efd</i><i><sub>2</sub></i>)
+          (&gt; 0).  Typical value = 2,3.
+      seefd2:
+        slot_uri: cim:ExcDC1A.seefd2
+        range: float
+        multivalued: false
+        required: true
+        description: Exciter saturation function value at the corresponding exciter
+          voltage, <i>Efd</i><i><sub>2</sub></i> (<i>Se[Eefd</i><i><sub>2</sub></i><i>]</i>)
+          (&gt;= 0).  Typical value = 0,1.
+      exclim:
+        slot_uri: cim:ExcDC1A.exclim
+        range: boolean
+        multivalued: false
+        required: true
+        description: "(<i>exclim</i>).  IEEE standard is ambiguous about lower limit\
+          \ on exciter output. \ntrue = a lower limit of zero is applied to integrator\
+          \ output\nfalse = a lower limit of zero is not applied to integrator output.\n\
+          Typical value = true."
+      efdmin:
+        slot_uri: cim:ExcDC1A.efdmin
+        range: PU
+        multivalued: false
+        required: true
+        description: Minimum voltage exciter output limiter (<i>Efdmin</i>) (&lt;
+          ExcDC1A.edfmax).  Typical value = -99.
+      efdmax:
+        slot_uri: cim:ExcDC1A.efdmax
+        range: PU
+        multivalued: false
+        required: true
+        description: Maximum voltage exciter output limiter (<i>Efdmax</i>) (&gt;
+          ExcDC1A.efdmin).  Typical value = 99.
+    is_a: ExcitationSystemDynamics
+    description: Modified IEEE DC1A direct current commutator exciter with speed input
+      and without underexcitation limiters (UEL) inputs.
+  ExcDC2A:
+    class_uri: cim:ExcDC2A
+    attributes:
+      ka:
+        slot_uri: cim:ExcDC2A.ka
+        range: PU
+        multivalued: false
+        required: true
+        description: Voltage regulator gain (<i>Ka</i>) (&gt; 0).  Typical value =
+          300.
+      ks:
+        slot_uri: cim:ExcDC2A.ks
+        range: PU
+        multivalued: false
+        required: true
+        description: Coefficient to allow different usage of the model-speed coefficient
+          (<i>Ks</i>).  Typical value = 0.
+      ta:
+        slot_uri: cim:ExcDC2A.ta
+        range: Seconds
+        multivalued: false
+        required: true
+        description: Voltage regulator time constant (<i>Ta</i>) (&gt; 0).  Typical
+          value = 0,01.
+      tb:
+        slot_uri: cim:ExcDC2A.tb
+        range: Seconds
+        multivalued: false
+        required: true
+        description: Voltage regulator time constant (<i>Tb</i>) (&gt;= 0).  Typical
+          value = 0.
+      tc:
+        slot_uri: cim:ExcDC2A.tc
+        range: Seconds
+        multivalued: false
+        required: true
+        description: Voltage regulator time constant (<i>Tc</i>) (&gt;= 0).  Typical
+          value = 0.
+      vrmax:
+        slot_uri: cim:ExcDC2A.vrmax
+        range: PU
+        multivalued: false
+        required: true
+        description: Maximum voltage regulator output (<i>Vrmax</i>) (&gt; ExcDC2A.vrmin).  Typical
+          value = 4,95.
+      vrmin:
+        slot_uri: cim:ExcDC2A.vrmin
+        range: PU
+        multivalued: false
+        required: true
+        description: Minimum voltage regulator output (<i>Vrmin</i>) (&lt; 0 and &lt;
+          ExcDC2A.vrmax).  Typical value = -4,9.
+      ke:
+        slot_uri: cim:ExcDC2A.ke
+        range: PU
+        multivalued: false
+        required: true
+        description: Exciter constant related to self-excited field (<i>Ke</i>).  If
+          <i>Ke</i> is entered as zero, the model calculates an effective value of
+          <i>Ke</i> such that the initial condition value of <i>Vr</i> is zero. The
+          zero value of <i>Ke</i> is not changed.  If <i>Ke</i> is entered as non-zero,
+          its value is used directly, without change.  Typical value = 1.
+      te:
+        slot_uri: cim:ExcDC2A.te
+        range: Seconds
+        multivalued: false
+        required: true
+        description: Exciter time constant, integration rate associated with exciter
+          control (<i>Te</i>) (&gt; 0).  Typical value = 1,33.
+      kf:
+        slot_uri: cim:ExcDC2A.kf
+        range: PU
+        multivalued: false
+        required: true
+        description: Excitation control system stabilizer gain (<i>Kf</i>) (&gt;=
+          0).  Typical value = 0,1.
+      tf:
+        slot_uri: cim:ExcDC2A.tf
+        range: Seconds
+        multivalued: false
+        required: true
+        description: Excitation control system stabilizer time constant (<i>Tf</i>)
+          (&gt; 0).  Typical value = 0,675.
+      tf1:
+        slot_uri: cim:ExcDC2A.tf1
+        range: Seconds
+        multivalued: false
+        required: true
+        description: Excitation control system stabilizer time constant (<i>Tf1</i>)
+          (&gt;= 0).  Typical value = 0.
+      efd1:
+        slot_uri: cim:ExcDC2A.efd1
+        range: PU
+        multivalued: false
+        required: true
+        description: Exciter voltage at which exciter saturation is defined (<i>Efd</i><i><sub>1</sub></i>)
+          (&gt; 0).  Typical value = 3,05.
+      seefd1:
+        slot_uri: cim:ExcDC2A.seefd1
+        range: float
+        multivalued: false
+        required: true
+        description: Exciter saturation function value at the corresponding exciter
+          voltage, <i>Efd</i><i><sub>1</sub></i> (<i>Se[Efd</i><i><sub>1</sub></i><i>]</i>)
+          (&gt;= 0).  Typical value = 0,279.
+      efd2:
+        slot_uri: cim:ExcDC2A.efd2
+        range: PU
+        multivalued: false
+        required: true
+        description: Exciter voltage at which exciter saturation is defined (<i>Efd</i><i><sub>2</sub></i>)
+          (&gt; 0).  Typical value = 2,29.
+      seefd2:
+        slot_uri: cim:ExcDC2A.seefd2
+        range: float
+        multivalued: false
+        required: true
+        description: Exciter saturation function value at the corresponding exciter
+          voltage, <i>Efd</i><i><sub>2</sub></i> (<i>Se[Efd</i><i><sub>2</sub></i><i>]</i>)
+          (&gt;= 0).  Typical value = 0,117.
+      exclim:
+        slot_uri: cim:ExcDC2A.exclim
+        range: boolean
+        multivalued: false
+        required: true
+        description: '(<i>exclim</i>).  IEEE standard is ambiguous about lower limit
+          on exciter output.
+
+          true = a lower limit of zero is applied to integrator output
+
+          false = a lower limit of zero is not applied to integrator output.
+
+          Typical value = true.'
+      vtlim:
+        slot_uri: cim:ExcDC2A.vtlim
+        range: boolean
+        multivalued: false
+        required: true
+        description: '(<i>Vtlim</i>).
+
+          true = limiter at the block (<i>Ka / [1 + sTa]</i>) is dependent on <i>Vt
+          </i>
+
+          false = limiter at the block is not dependent on <i>Vt</i>.
+
+          Typical value = true.'
+    is_a: ExcitationSystemDynamics
+    description: Modified IEEE DC2A direct current commutator exciter with speed input,
+      one more leg block in feedback loop and without underexcitation limiters (UEL)
+      inputs.  DC type 2 excitation system model with added speed multiplier, added
+      lead-lag, and voltage-dependent limits.
+  ExcDC3A:
+    class_uri: cim:ExcDC3A
+    attributes:
+      trh:
+        slot_uri: cim:ExcDC3A.trh
+        range: Seconds
+        multivalued: false
+        required: true
+        description: Rheostat travel time (<i>Trh</i>) (&gt; 0).  Typical value =
+          20.
+      ks:
+        slot_uri: cim:ExcDC3A.ks
+        range: PU
+        multivalued: false
+        required: true
+        description: Coefficient to allow different usage of the model-speed coefficient
+          (<i>Ks</i>).  Typical value = 0.
+      kr:
+        slot_uri: cim:ExcDC3A.kr
+        range: PU
+        multivalued: false
+        required: true
+        description: Deadband (<i>Kr</i>).  Typical value = 0.
+      kv:
+        slot_uri: cim:ExcDC3A.kv
+        range: PU
+        multivalued: false
+        required: true
+        description: Fast raise/lower contact setting (<i>Kv</i>) (&gt; 0).  Typical
+          value = 0,05.
+      vrmax:
+        slot_uri: cim:ExcDC3A.vrmax
+        range: PU
+        multivalued: false
+        required: true
+        description: Maximum voltage regulator output (<i>Vrmax</i>) (&gt; 0).  Typical
+          value = 5.
+      vrmin:
+        slot_uri: cim:ExcDC3A.vrmin
+        range: PU
+        multivalued: false
+        required: true
+        description: Minimum voltage regulator output (<i>Vrmin</i>) (&lt;= 0).  Typical
+          value = 0.
+      te:
+        slot_uri: cim:ExcDC3A.te
+        range: Seconds
+        multivalued: false
+        required: true
+        description: Exciter time constant, integration rate associated with exciter
+          control (<i>Te</i>) (&gt; 0).  Typical value = 1,83.
+      ke:
+        slot_uri: cim:ExcDC3A.ke
+        range: PU
+        multivalued: false
+        required: true
+        description: Exciter constant related to self-excited field (<i>Ke</i>).  Typical
+          value = 1.
+      efd1:
+        slot_uri: cim:ExcDC3A.efd1
+        range: PU
+        multivalued: false
+        required: true
+        description: Exciter voltage at which exciter saturation is defined (<i>Efd</i><i><sub>1</sub></i>)
+          (&gt; 0).  Typical value = 2,6.
+      seefd1:
+        slot_uri: cim:ExcDC3A.seefd1
+        range: float
+        multivalued: false
+        required: true
+        description: Exciter saturation function value at the corresponding exciter
+          voltage, <i>Efd</i><i><sub>1</sub></i> (<i>Se[Efd</i><i><sub>1</sub></i><i>]</i>)
+          (&gt;= 0).  Typical value = 0,1.
+      efd2:
+        slot_uri: cim:ExcDC3A.efd2
+        range: PU
+        multivalued: false
+        required: true
+        description: Exciter voltage at which exciter saturation is defined (<i>Efd</i><i><sub>2</sub></i>)
+          (&gt; 0).  Typical value = 3,45.
+      seefd2:
+        slot_uri: cim:ExcDC3A.seefd2
+        range: float
+        multivalued: false
+        required: true
+        description: Exciter saturation function value at the corresponding exciter
+          voltage, <i>Efd</i><i><sub>2</sub></i> (<i>Se[Efd</i><i><sub>2</sub></i><i>]</i>)
+          (&gt;= 0).  Typical value = 0,35.
+      exclim:
+        slot_uri: cim:ExcDC3A.exclim
+        range: boolean
+        multivalued: false
+        required: true
+        description: '(<i>exclim</i>).  IEEE standard is ambiguous about lower limit
+          on exciter output.
+
+          true = a lower limit of zero is applied to integrator output
+
+          false = a lower limit of zero not applied to integrator output.
+
+          Typical value = true.'
+      efdmax:
+        slot_uri: cim:ExcDC3A.efdmax
+        range: PU
+        multivalued: false
+        required: true
+        description: Maximum voltage exciter output limiter (<i>Efdmax</i>) (&gt;
+          ExcDC3A.efdmin).  Typical value = 99.
+      efdmin:
+        slot_uri: cim:ExcDC3A.efdmin
+        range: PU
+        multivalued: false
+        required: true
+        description: Minimum voltage exciter output limiter (<i>Efdmin</i>) (&lt;
+          ExcDC3A.efdmax).  Typical value = -99.
+      efdlim:
+        slot_uri: cim:ExcDC3A.efdlim
+        range: boolean
+        multivalued: false
+        required: true
+        description: '(<i>Efdlim</i>).
+
+          true = exciter output limiter is active
+
+          false = exciter output limiter not active.
+
+          Typical value = true.'
+    is_a: ExcitationSystemDynamics
+    description: Modified IEEE DC3A direct current commutator exciter with speed input,
+      and deadband.  DC old type 4.
+  ExcDC3A1:
+    class_uri: cim:ExcDC3A1
+    attributes:
+      ka:
+        slot_uri: cim:ExcDC3A1.ka
+        range: PU
+        multivalued: false
+        required: true
+        description: Voltage regulator gain (<i>Ka</i>) (&gt; 0).  Typical value =
+          300.
+      ta:
+        slot_uri: cim:ExcDC3A1.ta
+        range: Seconds
+        multivalued: false
+        required: true
+        description: Voltage regulator time constant (<i>Ta</i>) (&gt; 0).  Typical
+          value = 0,01.
+      vrmax:
+        slot_uri: cim:ExcDC3A1.vrmax
+        range: PU
+        multivalued: false
+        required: true
+        description: Maximum voltage regulator output (<i>Vrmax</i>) (&gt; ExcDC3A1.vrmin).  Typical
+          value = 5.
+      vrmin:
+        slot_uri: cim:ExcDC3A1.vrmin
+        range: PU
+        multivalued: false
+        required: true
+        description: Minimum voltage regulator output (<i>Vrmin</i>) (&lt; 0 and &lt;
+          ExcDC3A1.vrmax).  Typical value = 0.
+      te:
+        slot_uri: cim:ExcDC3A1.te
+        range: Seconds
+        multivalued: false
+        required: true
+        description: Exciter time constant, integration rate associated with exciter
+          control (<i>Te</i>) (&gt; 0).  Typical value = 1,83.
+      kf:
+        slot_uri: cim:ExcDC3A1.kf
+        range: PU
+        multivalued: false
+        required: true
+        description: Excitation control system stabilizer gain (<i>Kf</i>) (&gt;=
+          0).  Typical value = 0,1.
+      tf:
+        slot_uri: cim:ExcDC3A1.tf
+        range: Seconds
+        multivalued: false
+        required: true
+        description: Excitation control system stabilizer time constant (<i>Tf</i>)
+          (&gt;= 0).  Typical value = 0,675.
+      kp:
+        slot_uri: cim:ExcDC3A1.kp
+        range: PU
+        multivalued: false
+        required: true
+        description: Potential circuit gain coefficient (<i>Kp</i>) (&gt;= 0).  Typical
+          value = 4,37.
+      ki:
+        slot_uri: cim:ExcDC3A1.ki
+        range: PU
+        multivalued: false
+        required: true
+        description: Potential circuit gain coefficient (<i>Ki</i>) (&gt;= 0).  Typical
+          value = 4,83.
+      vbmax:
+        slot_uri: cim:ExcDC3A1.vbmax
+        range: PU
+        multivalued: false
+        required: true
+        description: Available exciter voltage limiter (<i>Vbmax</i>) (&gt; 0).  Typical
+          value = 11,63.
+      exclim:
+        slot_uri: cim:ExcDC3A1.exclim
+        range: boolean
+        multivalued: false
+        required: true
+        description: '(<i>exclim</i>).
+
+          true = lower limit of zero is applied to integrator output
+
+          false = lower limit of zero not applied to integrator output.
+
+          Typical value = true.'
+      ke:
+        slot_uri: cim:ExcDC3A1.ke
+        range: PU
+        multivalued: false
+        required: true
+        description: Exciter constant related to self-excited field (<i>Ke</i>).  Typical
+          value = 1.
+      vb1max:
+        slot_uri: cim:ExcDC3A1.vb1max
+        range: PU
+        multivalued: false
+        required: true
+        description: Available exciter voltage limiter (<i>Vb1max</i>) (&gt; 0).  Typical
+          value = 11,63.
+      vblim:
+        slot_uri: cim:ExcDC3A1.vblim
+        range: boolean
+        multivalued: false
+        required: true
+        description: "Vb limiter indicator.\ntrue = exciter <i>Vbmax</i> limiter is\
+          \ active\nfalse = <i>Vb1max</i> is active. \nTypical value = true."
+    is_a: ExcitationSystemDynamics
+    description: Modified old IEEE type 3 excitation system.
+  ExcELIN1:
+    class_uri: cim:ExcELIN1
+    attributes:
+      tfi:
+        slot_uri: cim:ExcELIN1.tfi
+        range: Seconds
+        multivalued: false
+        required: true
+        description: Current transducer time constant (<i>Tfi</i>) (&gt;= 0).  Typical
+          value = 0.
+      tnu:
+        slot_uri: cim:ExcELIN1.tnu
+        range: Seconds
+        multivalued: false
+        required: true
+        description: Controller reset time constant (<i>Tnu</i>) (&gt;= 0).  Typical
+          value = 2.
+      vpu:
+        slot_uri: cim:ExcELIN1.vpu
+        range: PU
+        multivalued: false
+        required: true
+        description: Voltage controller proportional gain (<i>Vpu</i>).  Typical value
+          = 34,5.
+      vpi:
+        slot_uri: cim:ExcELIN1.vpi
+        range: PU
+        multivalued: false
+        required: true
+        description: Current controller gain (<i>Vpi</i>).  Typical value = 12,45.
+      vpnf:
+        slot_uri: cim:ExcELIN1.vpnf
+        range: PU
+        multivalued: false
+        required: true
+        description: Controller follow up gain (<i>Vpnf</i>).  Typical value = 2.
+      dpnf:
+        slot_uri: cim:ExcELIN1.dpnf
+        range: PU
+        multivalued: false
+        required: true
+        description: Controller follow up deadband (<i>Dpnf</i>).  Typical value =
+          0.
+      tsw:
+        slot_uri: cim:ExcELIN1.tsw
+        range: Seconds
+        multivalued: false
+        required: true
+        description: Stabilizer parameters (<i>Tsw</i>) (&gt;= 0).  Typical value
+          = 3.
+      efmin:
+        slot_uri: cim:ExcELIN1.efmin
+        range: PU
+        multivalued: false
+        required: true
+        description: Minimum open circuit excitation voltage (<i>Efmin</i>) (&lt;
+          ExcELIN1.efmax).  Typical value = -5.
+      efmax:
+        slot_uri: cim:ExcELIN1.efmax
+        range: PU
+        multivalued: false
+        required: true
+        description: Maximum open circuit excitation voltage (<i>Efmax</i>) (&gt;
+          ExcELIN1.efmin).  Typical value = 5.
+      xe:
+        slot_uri: cim:ExcELIN1.xe
+        range: PU
+        multivalued: false
+        required: true
+        description: Excitation transformer effective reactance (<i>Xe</i>) (&gt;=
+          0).  <i>Xe</i> represents the regulation of the transformer/rectifier unit.  Typical
+          value = 0,06.
+      ks1:
+        slot_uri: cim:ExcELIN1.ks1
+        range: PU
+        multivalued: false
+        required: true
+        description: Stabilizer gain 1 (<i>Ks1</i>).  Typical value = 0.
+      ks2:
+        slot_uri: cim:ExcELIN1.ks2
+        range: PU
+        multivalued: false
+        required: true
+        description: Stabilizer gain 2 (<i>Ks2</i>).  Typical value = 0.
+      ts1:
+        slot_uri: cim:ExcELIN1.ts1
+        range: Seconds
+        multivalued: false
+        required: true
+        description: Stabilizer phase lag time constant (<i>Ts1</i>) (&gt;= 0).  Typical
+          value = 1.
+      ts2:
+        slot_uri: cim:ExcELIN1.ts2
+        range: Seconds
+        multivalued: false
+        required: true
+        description: Stabilizer filter time constant (<i>Ts2</i>) (&gt;= 0).  Typical
+          value = 1.
+      smax:
+        slot_uri: cim:ExcELIN1.smax
+        range: PU
+        multivalued: false
+        required: true
+        description: Stabilizer limit output (<i>smax</i>).  Typical value = 0,1.
+    is_a: ExcitationSystemDynamics
+    description: Static PI transformer fed excitation system ELIN (VATECH) - simplified
+      model.  This model represents an all-static excitation system. A PI voltage
+      controller establishes a desired field current set point for a proportional
+      current controller. The integrator of the PI controller has a follow-up input
+      to match its signal to the present field current.  A power system stabilizer
+      with power input is included in the model.
+  ExcELIN2:
+    class_uri: cim:ExcELIN2
+    attributes:
+      k1:
+        slot_uri: cim:ExcELIN2.k1
+        range: PU
+        multivalued: false
+        required: true
+        description: Voltage regulator input gain (<i>K1</i>).  Typical value = 0.
+      k1ec:
+        slot_uri: cim:ExcELIN2.k1ec
+        range: PU
+        multivalued: false
+        required: true
+        description: Voltage regulator input limit (<i>K1ec</i>).  Typical value =
+          2.
+      kd1:
+        slot_uri: cim:ExcELIN2.kd1
+        range: PU
+        multivalued: false
+        required: true
+        description: Voltage controller derivative gain (<i>Kd1</i>).  Typical value
+          = 34,5.
+      tb1:
+        slot_uri: cim:ExcELIN2.tb1
+        range: Seconds
+        multivalued: false
+        required: true
+        description: Voltage controller derivative washout time constant (<i>Tb1</i>)
+          (&gt;= 0).  Typical value = 12,45.
+      pid1max:
+        slot_uri: cim:ExcELIN2.pid1max
+        range: PU
+        multivalued: false
+        required: true
+        description: Controller follow up gain (<i>PID1max</i>).  Typical value =
+          2.
+      ti1:
+        slot_uri: cim:ExcELIN2.ti1
+        range: PU
+        multivalued: false
+        required: true
+        description: Controller follow up deadband (<i>Ti1</i>).  Typical value =
+          0.
+      iefmax2:
+        slot_uri: cim:ExcELIN2.iefmax2
+        range: PU
+        multivalued: false
+        required: true
+        description: Minimum open circuit excitation voltage (<i>I</i><i><sub>efmax2</sub></i>).  Typical
+          value = -5.
+      k2:
+        slot_uri: cim:ExcELIN2.k2
+        range: PU
+        multivalued: false
+        required: true
+        description: Gain (<i>K2</i>).  Typical value = 5.
+      ketb:
+        slot_uri: cim:ExcELIN2.ketb
+        range: PU
+        multivalued: false
+        required: true
+        description: Gain (<i>Ketb</i>).  Typical value = 0,06.
+      upmax:
+        slot_uri: cim:ExcELIN2.upmax
+        range: PU
+        multivalued: false
+        required: true
+        description: Limiter (<i>Upmax</i>) (&gt; ExcELIN2.upmin).  Typical value
+          = 3.
+      upmin:
+        slot_uri: cim:ExcELIN2.upmin
+        range: PU
+        multivalued: false
+        required: true
+        description: Limiter (<i>Upmin</i>) (&lt; ExcELIN2.upmax).  Typical value
+          = 0.
+      te:
+        slot_uri: cim:ExcELIN2.te
+        range: Seconds
+        multivalued: false
+        required: true
+        description: Time constant (<i>Te</i>) (&gt;= 0).  Typical value = 0.
+      xp:
+        slot_uri: cim:ExcELIN2.xp
+        range: PU
+        multivalued: false
+        required: true
+        description: Excitation transformer effective reactance (<i>Xp</i>).  Typical
+          value = 1.
+      te2:
+        slot_uri: cim:ExcELIN2.te2
+        range: Seconds
+        multivalued: false
+        required: true
+        description: Time Constant (<i>T</i><i><sub>e2</sub></i>) (&gt;= 0).  Typical
+          value = 1.
+      ke2:
+        slot_uri: cim:ExcELIN2.ke2
+        range: PU
+        multivalued: false
+        required: true
+        description: Gain (<i>Ke2</i>).  Typical value = 0,1.
+      ve1:
+        slot_uri: cim:ExcELIN2.ve1
+        range: PU
+        multivalued: false
+        required: true
+        description: Exciter alternator output voltages back of commutating reactance
+          at which saturation is defined (<i>Ve</i><i><sub>1</sub></i>) (&gt; 0).  Typical
+          value = 3.
+      seve1:
+        slot_uri: cim:ExcELIN2.seve1
+        range: PU
+        multivalued: false
+        required: true
+        description: Exciter saturation function value at the corresponding exciter
+          voltage, <i>Ve</i><i><sub>1</sub></i>, back of commutating reactance (<i>Se[Ve</i><i><sub>1</sub></i><i>]</i>)
+          (&gt;= 0).  Typical value = 0.
+      ve2:
+        slot_uri: cim:ExcELIN2.ve2
+        range: PU
+        multivalued: false
+        required: true
+        description: Exciter alternator output voltages back of commutating reactance
+          at which saturation is defined (<i>Ve</i><i><sub>2</sub></i>) (&gt; 0).  Typical
+          value = 0.
+      seve2:
+        slot_uri: cim:ExcELIN2.seve2
+        range: PU
+        multivalued: false
+        required: true
+        description: Exciter saturation function value at the corresponding exciter
+          voltage, <i>Ve</i><i><sub>2</sub></i>, back of commutating reactance (<i>Se[Ve</i><i><sub>2</sub></i><i>]</i>)
+          (&gt;= 0).  Typical value = 1.
+      tr4:
+        slot_uri: cim:ExcELIN2.tr4
+        range: Seconds
+        multivalued: false
+        required: true
+        description: Time constant (<i>T</i><i><sub>r4</sub></i>) (&gt;= 0).  Typical
+          value = 1.
+      k3:
+        slot_uri: cim:ExcELIN2.k3
+        range: PU
+        multivalued: false
+        required: true
+        description: Gain (<i>K3</i>).  Typical value = 0,1.
+      ti3:
+        slot_uri: cim:ExcELIN2.ti3
+        range: Seconds
+        multivalued: false
+        required: true
+        description: Time constant (<i>T</i><i><sub>i3</sub></i>) (&gt;= 0).  Typical
+          value = 3.
+      k4:
+        slot_uri: cim:ExcELIN2.k4
+        range: PU
+        multivalued: false
+        required: true
+        description: Gain (<i>K4</i>).  Typical value = 0.
+      ti4:
+        slot_uri: cim:ExcELIN2.ti4
+        range: Seconds
+        multivalued: false
+        required: true
+        description: Time constant (<i>T</i><i><sub>i4</sub></i>) (&gt;= 0).  Typical
+          value = 0.
+      iefmax:
+        slot_uri: cim:ExcELIN2.iefmax
+        range: PU
+        multivalued: false
+        required: true
+        description: Limiter (<i>I</i><i><sub>efmax</sub></i>) (&gt; ExcELIN2.iefmin).  Typical
+          value = 1.
+      iefmin:
+        slot_uri: cim:ExcELIN2.iefmin
+        range: PU
+        multivalued: false
+        required: true
+        description: Limiter (<i>I</i><i><sub>efmin</sub></i>) (&lt; ExcELIN2.iefmax).  Typical
+          value = 1.
+      efdbas:
+        slot_uri: cim:ExcELIN2.efdbas
+        range: PU
+        multivalued: false
+        required: true
+        description: Gain (<i>Efdbas</i>).  Typical value = 0,1.
+    is_a: ExcitationSystemDynamics
+    description: 'Detailed excitation system ELIN (VATECH).  This model represents
+      an all-static excitation system. A PI voltage controller establishes a desired
+      field current set point for a proportional current controller. The integrator
+      of the PI controller has a follow-up input to match its signal to the present
+      field current.  Power system stabilizer models used in conjunction with this
+      excitation system model: PssELIN2, PssIEEE2B, Pss2B.'
+  ExcHU:
+    class_uri: cim:ExcHU
+    attributes:
+      tr:
+        slot_uri: cim:ExcHU.tr
+        range: Seconds
+        multivalued: false
+        required: true
+        description: Filter time constant (<i>Tr</i>) (&gt;= 0). If a voltage compensator
+          is used in conjunction with this excitation system model, <i>Tr </i>should
+          be set to 0.  Typical value = 0,01.
+      te:
+        slot_uri: cim:ExcHU.te
+        range: Seconds
+        multivalued: false
+        required: true
+        description: Major loop PI tag integration time constant (<i>Te</i>) (&gt;=
+          0).  Typical value = 0,154.
+      imin:
+        slot_uri: cim:ExcHU.imin
+        range: PU
+        multivalued: false
+        required: true
+        description: Major loop PI tag output signal lower limit (<i>Imin</i>) (&lt;
+          ExcHU.imax).  Typical value = 0,1.
+      imax:
+        slot_uri: cim:ExcHU.imax
+        range: PU
+        multivalued: false
+        required: true
+        description: Major loop PI tag output signal upper limit (<i>Imax</i>) (&gt;
+          ExcHU.imin).  Typical value = 2,19.
+      ae:
+        slot_uri: cim:ExcHU.ae
+        range: PU
+        multivalued: false
+        required: true
+        description: Major loop PI tag gain factor (<i>Ae</i>).  Typical value = 3.
+      emin:
+        slot_uri: cim:ExcHU.emin
+        range: PU
+        multivalued: false
+        required: true
+        description: Field voltage control signal lower limit on AVR base (<i>Emin</i>)
+          (&lt; ExcHU.emax).  Typical value = -0,866.
+      emax:
+        slot_uri: cim:ExcHU.emax
+        range: PU
+        multivalued: false
+        required: true
+        description: Field voltage control signal upper limit on AVR base (<i>Emax</i>)
+          (&gt; ExcHU.emin).  Typical value = 0,996.
+      ki:
+        slot_uri: cim:ExcHU.ki
+        range: float
+        multivalued: false
+        required: true
+        description: Current base conversion constant (<i>Ki</i>).  Typical value
+          = 0,21428.
+      ai:
+        slot_uri: cim:ExcHU.ai
+        range: PU
+        multivalued: false
+        required: true
+        description: Minor loop PI tag gain factor (<i>Ai</i>).  Typical value = 22.
+      ti:
+        slot_uri: cim:ExcHU.ti
+        range: Seconds
+        multivalued: false
+        required: true
+        description: Minor loop PI control tag integration time constant (<i>Ti</i>)
+          (&gt;= 0).  Typical value = 0,01333.
+      atr:
+        slot_uri: cim:ExcHU.atr
+        range: PU
+        multivalued: false
+        required: true
+        description: AVR constant (<i>Atr</i>).  Typical value = 2,19.
+      ke:
+        slot_uri: cim:ExcHU.ke
+        range: float
+        multivalued: false
+        required: true
+        description: Voltage base conversion constant (<i>Ke</i>).  Typical value
+          = 4,666.
+    is_a: ExcitationSystemDynamics
+    description: Hungarian excitation system, with built-in voltage transducer.
+  ExcNI:
+    class_uri: cim:ExcNI
+    attributes:
+      busFedSelector:
+        slot_uri: cim:ExcNI.busFedSelector
+        range: boolean
+        multivalued: false
+        required: true
+        description: "Fed by selector (<i>BusFedSelector</i>). \ntrue = bus fed (switch\
+          \ is closed)\nfalse = solid fed (switch is open).\nTypical value = true."
+      tr:
+        slot_uri: cim:ExcNI.tr
+        range: Seconds
+        multivalued: false
+        required: true
+        description: Time constant (<i>Tr</i>) (&gt;= 0). Typical value = 0,02.
+      ka:
+        slot_uri: cim:ExcNI.ka
+        range: PU
+        multivalued: false
+        required: true
+        description: Voltage regulator gain (<i>Ka</i>) (&gt; 0).  Typical value =
+          210.
+      ta:
+        slot_uri: cim:ExcNI.ta
+        range: Seconds
+        multivalued: false
+        required: true
+        description: Voltage regulator time constant (<i>Ta</i>) (&gt; 0).  Typical
+          value = 0,02.
+      vrmax:
+        slot_uri: cim:ExcNI.vrmax
+        range: PU
+        multivalued: false
+        required: true
+        description: Maximum voltage regulator ouput (<i>Vrmax</i>) (&gt; ExcNI.vrmin).
+          Typical value = 5,0.
+      vrmin:
+        slot_uri: cim:ExcNI.vrmin
+        range: PU
+        multivalued: false
+        required: true
+        description: Minimum voltage regulator ouput (<i>Vrmin</i>) (&lt; ExcNI.vrmax).
+          Typical value = -2,0.
+      kf:
+        slot_uri: cim:ExcNI.kf
+        range: PU
+        multivalued: false
+        required: true
+        description: Excitation control system stabilizer gain (<i>Kf</i>) (&gt; 0).  Typical
+          value 0,01.
+      tf2:
+        slot_uri: cim:ExcNI.tf2
+        range: Seconds
+        multivalued: false
+        required: true
+        description: Excitation control system stabilizer time constant (<i>Tf2</i>)
+          (&gt; 0). Typical value = 0,1.
+      tf1:
+        slot_uri: cim:ExcNI.tf1
+        range: Seconds
+        multivalued: false
+        required: true
+        description: Excitation control system stabilizer time constant (<i>Tf1</i>)
+          (&gt; 0). Typical value = 1,0.
+      r:
+        slot_uri: cim:ExcNI.r
+        range: PU
+        multivalued: false
+        required: true
+        description: "<i>rc</i> / <i>rfd</i> (<i>R</i>) (&gt;= 0). \n0 means exciter\
+          \ has negative current capability\n&gt; 0 means exciter does not have negative\
+          \ current capability.  \nTypical value = 5."
+    is_a: ExcitationSystemDynamics
+    description: Bus or solid fed SCR (silicon-controlled rectifier) bridge excitation
+      system model type NI (NVE).
+  ExcOEX3T:
+    class_uri: cim:ExcOEX3T
+    attributes:
+      t1:
+        slot_uri: cim:ExcOEX3T.t1
+        range: Seconds
+        multivalued: false
+        required: true
+        description: Time constant (<i>T</i><i><sub>1</sub></i>) (&gt;= 0).
+      t2:
+        slot_uri: cim:ExcOEX3T.t2
+        range: Seconds
+        multivalued: false
+        required: true
+        description: Time constant (<i>T</i><i><sub>2</sub></i>) (&gt;= 0).
+      t3:
+        slot_uri: cim:ExcOEX3T.t3
+        range: Seconds
+        multivalued: false
+        required: true
+        description: Time constant (<i>T</i><i><sub>3</sub></i>) (&gt;= 0).
+      t4:
+        slot_uri: cim:ExcOEX3T.t4
+        range: Seconds
+        multivalued: false
+        required: true
+        description: Time constant (<i>T</i><i><sub>4</sub></i>) (&gt;= 0).
+      ka:
+        slot_uri: cim:ExcOEX3T.ka
+        range: PU
+        multivalued: false
+        required: true
+        description: Gain (<i>K</i><i><sub>A</sub></i>).
+      t5:
+        slot_uri: cim:ExcOEX3T.t5
+        range: Seconds
+        multivalued: false
+        required: true
+        description: Time constant (<i>T</i><i><sub>5</sub></i>) (&gt;= 0).
+      t6:
+        slot_uri: cim:ExcOEX3T.t6
+        range: Seconds
+        multivalued: false
+        required: true
+        description: Time constant (<i>T</i><i><sub>6</sub></i>) (&gt;= 0).
+      vrmax:
+        slot_uri: cim:ExcOEX3T.vrmax
+        range: PU
+        multivalued: false
+        required: true
+        description: Limiter (<i>V</i><i><sub>RMAX</sub></i>) (&gt; ExcOEX3T.vrmin).
+      vrmin:
+        slot_uri: cim:ExcOEX3T.vrmin
+        range: PU
+        multivalued: false
+        required: true
+        description: Limiter (<i>V</i><i><sub>RMIN</sub></i>) (&lt; ExcOEX3T.vrmax).
+      te:
+        slot_uri: cim:ExcOEX3T.te
+        range: Seconds
+        multivalued: false
+        required: true
+        description: Time constant (<i>T</i><i><sub>E</sub></i>) (&gt;= 0).
+      kf:
+        slot_uri: cim:ExcOEX3T.kf
+        range: PU
+        multivalued: false
+        required: true
+        description: Gain (<i>K</i><i><sub>F</sub></i>).
+      tf:
+        slot_uri: cim:ExcOEX3T.tf
+        range: Seconds
+        multivalued: false
+        required: true
+        description: Time constant (<i>T</i><i><sub>F</sub></i>) (&gt;= 0).
+      kc:
+        slot_uri: cim:ExcOEX3T.kc
+        range: PU
+        multivalued: false
+        required: true
+        description: Gain (<i>K</i><i><sub>C</sub></i>).
+      kd:
+        slot_uri: cim:ExcOEX3T.kd
+        range: PU
+        multivalued: false
+        required: true
+        description: Gain (<i>K</i><i><sub>D</sub></i>).
+      ke:
+        slot_uri: cim:ExcOEX3T.ke
+        range: PU
+        multivalued: false
+        required: true
+        description: Gain (<i>K</i><i><sub>E</sub></i>).
+      e1:
+        slot_uri: cim:ExcOEX3T.e1
+        range: PU
+        multivalued: false
+        required: true
+        description: Saturation parameter (<i>E</i><i><sub>1</sub></i>).
+      see1:
+        slot_uri: cim:ExcOEX3T.see1
+        range: PU
+        multivalued: false
+        required: true
+        description: Saturation parameter (<i>S</i><i><sub>E</sub></i><i>[E</i><i><sub>1</sub></i><i>]</i>).
+      e2:
+        slot_uri: cim:ExcOEX3T.e2
+        range: PU
+        multivalued: false
+        required: true
+        description: Saturation parameter (<i>E</i><i><sub>2</sub></i>).
+      see2:
+        slot_uri: cim:ExcOEX3T.see2
+        range: PU
+        multivalued: false
+        required: true
+        description: Saturation parameter (<i>S</i><i><sub>E</sub></i><i>[E</i><i><sub>2</sub></i><i>]</i>).
+    is_a: ExcitationSystemDynamics
+    description: Modified IEEE type ST1 excitation system with semi-continuous and
+      acting terminal voltage limiter.
+  ExcPIC:
+    class_uri: cim:ExcPIC
+    attributes:
+      ka:
+        slot_uri: cim:ExcPIC.ka
+        range: PU
+        multivalued: false
+        required: true
+        description: PI controller gain (<i>K</i><i><sub>a</sub></i>).  Typical value
+          = 3,15.
+      ta1:
+        slot_uri: cim:ExcPIC.ta1
+        range: Seconds
+        multivalued: false
+        required: true
+        description: PI controller time constant (<i>T</i><i><sub>a1</sub></i>) (&gt;=
+          0).  Typical value = 1.
+      vr1:
+        slot_uri: cim:ExcPIC.vr1
+        range: PU
+        multivalued: false
+        required: true
+        description: PI maximum limit (<i>V</i><i><sub>r1</sub></i>).  Typical value
+          = 1.
+      vr2:
+        slot_uri: cim:ExcPIC.vr2
+        range: PU
+        multivalued: false
+        required: true
+        description: PI minimum limit (<i>V</i><i><sub>r2</sub></i>).  Typical value
+          = -0,87.
+      ta2:
+        slot_uri: cim:ExcPIC.ta2
+        range: Seconds
+        multivalued: false
+        required: true
+        description: Voltage regulator time constant (<i>T</i><i><sub>a2</sub></i>)
+          (&gt;= 0).  Typical value = 0,01.
+      ta3:
+        slot_uri: cim:ExcPIC.ta3
+        range: Seconds
+        multivalued: false
+        required: true
+        description: Lead time constant (<i>T</i><i><sub>a3</sub></i>) (&gt;= 0).  Typical
+          value = 0.
+      ta4:
+        slot_uri: cim:ExcPIC.ta4
+        range: Seconds
+        multivalued: false
+        required: true
+        description: Lag time constant (<i>T</i><i><sub>a4</sub></i>) (&gt;= 0).  Typical
+          value = 0.
+      vrmax:
+        slot_uri: cim:ExcPIC.vrmax
+        range: PU
+        multivalued: false
+        required: true
+        description: Voltage regulator maximum limit (<i>V</i><i><sub>rmax</sub></i>)
+          (&gt; ExcPIC.vrmin).  Typical value = 1.
+      vrmin:
+        slot_uri: cim:ExcPIC.vrmin
+        range: PU
+        multivalued: false
+        required: true
+        description: Voltage regulator minimum limit (<i>V</i><i><sub>rmin</sub></i>)
+          (&lt; ExcPIC.vrmax).  Typical value = -0,87.
+      kf:
+        slot_uri: cim:ExcPIC.kf
+        range: PU
+        multivalued: false
+        required: true
+        description: Rate feedback gain (<i>K</i><i><sub>f</sub></i>).  Typical value
+          = 0.
+      tf1:
+        slot_uri: cim:ExcPIC.tf1
+        range: Seconds
+        multivalued: false
+        required: true
+        description: Rate feedback time constant (<i>T</i><i><sub>f1</sub></i>) (&gt;=
+          0).  Typical value = 0.
+      tf2:
+        slot_uri: cim:ExcPIC.tf2
+        range: Seconds
+        multivalued: false
+        required: true
+        description: Rate feedback lag time constant (<i>T</i><i><sub>f2</sub></i>)
+          (&gt;= 0).  Typical value = 0.
+      efdmax:
+        slot_uri: cim:ExcPIC.efdmax
+        range: PU
+        multivalued: false
+        required: true
+        description: Exciter maximum limit (<i>E</i><i><sub>fdmax</sub></i>) (&gt;
+          ExcPIC.efdmin).  Typical value = 8.
+      efdmin:
+        slot_uri: cim:ExcPIC.efdmin
+        range: PU
+        multivalued: false
+        required: true
+        description: Exciter minimum limit (<i>E</i><i><sub>fdmin</sub></i>) (&lt;
+          ExcPIC.efdmax).  Typical value = -0,87.
+      ke:
+        slot_uri: cim:ExcPIC.ke
+        range: PU
+        multivalued: false
+        required: true
+        description: Exciter constant (<i>K</i><i><sub>e</sub></i>).  Typical value
+          = 0.
+      te:
+        slot_uri: cim:ExcPIC.te
+        range: Seconds
+        multivalued: false
+        required: true
+        description: Exciter time constant (<i>T</i><i><sub>e</sub></i>) (&gt;= 0).  Typical
+          value = 0.
+      e1:
+        slot_uri: cim:ExcPIC.e1
+        range: PU
+        multivalued: false
+        required: true
+        description: Field voltage value 1 (<i>E</i><i><sub>1</sub></i>).  Typical
+          value = 0.
+      se1:
+        slot_uri: cim:ExcPIC.se1
+        range: PU
+        multivalued: false
+        required: true
+        description: Saturation factor at <i>E</i><i><sub>1</sub></i> (<i>Se</i><i><sub>1</sub></i>).  Typical
+          value = 0.
+      e2:
+        slot_uri: cim:ExcPIC.e2
+        range: PU
+        multivalued: false
+        required: true
+        description: Field voltage value 2 (<i>E</i><i><sub>2</sub></i>).  Typical
+          value = 0.
+      se2:
+        slot_uri: cim:ExcPIC.se2
+        range: PU
+        multivalued: false
+        required: true
+        description: Saturation factor at <i>E</i><i><sub>2</sub></i> (<i>Se</i><i><sub>2</sub></i>).  Typical
+          value = 0.
+      kp:
+        slot_uri: cim:ExcPIC.kp
+        range: PU
+        multivalued: false
+        required: true
+        description: Potential source gain (<i>K</i><i><sub>p</sub></i>).  Typical
+          value = 6,5.
+      ki:
+        slot_uri: cim:ExcPIC.ki
+        range: PU
+        multivalued: false
+        required: true
+        description: Current source gain (<i>K</i><i><sub>i</sub></i>).  Typical value
+          = 0.
+      kc:
+        slot_uri: cim:ExcPIC.kc
+        range: PU
+        multivalued: false
+        required: true
+        description: Exciter regulation factor (<i>K</i><i><sub>c</sub></i>).  Typical
+          value = 0,08.
+    is_a: ExcitationSystemDynamics
+    description: Proportional/integral regulator excitation system.  This model can
+      be used to represent excitation systems with a proportional-integral (PI) voltage
+      regulator controller.
+  ExcREXS:
+    class_uri: cim:ExcREXS
+    attributes:
+      e1:
+        slot_uri: cim:ExcREXS.e1
+        range: PU
+        multivalued: false
+        required: true
+        description: Field voltage value 1 (<i>E</i><i><sub>1</sub></i>).  Typical
+          value = 3.
+      e2:
+        slot_uri: cim:ExcREXS.e2
+        range: PU
+        multivalued: false
+        required: true
+        description: Field voltage value 2 (<i>E</i><i><sub>2</sub></i>).  Typical
+          value = 4.
+      fbf:
+        slot_uri: cim:ExcREXS.fbf
+        range: ExcREXSFeedbackSignalKind
+        multivalued: false
+        required: true
+        description: Rate feedback signal flag (<i>fbf</i>). Typical value = fieldCurrent.
+      flimf:
+        slot_uri: cim:ExcREXS.flimf
+        range: PU
+        multivalued: false
+        required: true
+        description: Limit type flag (<i>Flimf</i>).  Typical value = 0.
+      kc:
+        slot_uri: cim:ExcREXS.kc
+        range: PU
+        multivalued: false
+        required: true
+        description: Rectifier regulation factor (<i>Kc</i>).  Typical value = 0,05.
+      kd:
+        slot_uri: cim:ExcREXS.kd
+        range: PU
+        multivalued: false
+        required: true
+        description: Exciter regulation factor (<i>Kd</i>).  Typical value = 2.
+      ke:
+        slot_uri: cim:ExcREXS.ke
+        range: PU
+        multivalued: false
+        required: true
+        description: Exciter field proportional constant (<i>Ke</i>).  Typical value
+          = 1.
+      kefd:
+        slot_uri: cim:ExcREXS.kefd
+        range: PU
+        multivalued: false
+        required: true
+        description: Field voltage feedback gain (<i>Kefd</i>).  Typical value = 0.
+      kf:
+        slot_uri: cim:ExcREXS.kf
+        range: Seconds
+        multivalued: false
+        required: true
+        description: Rate feedback gain (<i>Kf</i>) (&gt;= 0).  Typical value = 0,05.
+      kh:
+        slot_uri: cim:ExcREXS.kh
+        range: PU
+        multivalued: false
+        required: true
+        description: Field voltage controller feedback gain (<i>Kh</i>).  Typical
+          value = 0.
+      kii:
+        slot_uri: cim:ExcREXS.kii
+        range: PU
+        multivalued: false
+        required: true
+        description: Field current regulator integral gain (<i>Kii</i>).  Typical
+          value = 0.
+      kip:
+        slot_uri: cim:ExcREXS.kip
+        range: PU
+        multivalued: false
+        required: true
+        description: Field current regulator proportional gain (<i>Kip</i>).  Typical
+          value = 1.
+      ks:
+        slot_uri: cim:ExcREXS.ks
+        range: PU
+        multivalued: false
+        required: true
+        description: Coefficient to allow different usage of the model-speed coefficient
+          (<i>Ks</i>).  Typical value = 0.
+      kvi:
+        slot_uri: cim:ExcREXS.kvi
+        range: PU
+        multivalued: false
+        required: true
+        description: Voltage regulator integral gain (<i>Kvi</i>).  Typical value
+          = 0.
+      kvp:
+        slot_uri: cim:ExcREXS.kvp
+        range: PU
+        multivalued: false
+        required: true
+        description: Voltage regulator proportional gain (<i>Kvp</i>).  Typical value
+          = 2800.
+      kvphz:
+        slot_uri: cim:ExcREXS.kvphz
+        range: PU
+        multivalued: false
+        required: true
+        description: V/Hz limiter gain (<i>Kvphz</i>).  Typical value = 0.
+      nvphz:
+        slot_uri: cim:ExcREXS.nvphz
+        range: PU
+        multivalued: false
+        required: true
+        description: Pickup speed of V/Hz limiter (<i>Nvphz</i>).  Typical value =
+          0.
+      se1:
+        slot_uri: cim:ExcREXS.se1
+        range: PU
+        multivalued: false
+        required: true
+        description: Saturation factor at <i>E</i><i><sub>1</sub></i><i> </i>(<i>Se</i><i><sub>1</sub></i>).  Typical
+          value = 0,0001.
+      se2:
+        slot_uri: cim:ExcREXS.se2
+        range: PU
+        multivalued: false
+        required: true
+        description: Saturation factor at <i>E</i><i><sub>2</sub></i> (<i>Se</i><i><sub>2</sub></i>).  Typical
+          value = 0,001.
+      ta:
+        slot_uri: cim:ExcREXS.ta
+        range: Seconds
+        multivalued: false
+        required: true
+        description: Voltage regulator time constant (<i>Ta</i>) (&gt;= 0).  If =
+          0, block is bypassed.  Typical value = 0,01.
+      tb1:
+        slot_uri: cim:ExcREXS.tb1
+        range: Seconds
+        multivalued: false
+        required: true
+        description: Lag time constant (<i>Tb1</i>) (&gt;= 0).  If = 0, block is bypassed.  Typical
+          value = 0.
+      tb2:
+        slot_uri: cim:ExcREXS.tb2
+        range: Seconds
+        multivalued: false
+        required: true
+        description: Lag time constant (<i>Tb2</i>) (&gt;= 0).  If = 0, block is bypassed.  Typical
+          value = 0.
+      tc1:
+        slot_uri: cim:ExcREXS.tc1
+        range: Seconds
+        multivalued: false
+        required: true
+        description: Lead time constant (<i>Tc1</i>) (&gt;= 0).  Typical value = 0.
+      tc2:
+        slot_uri: cim:ExcREXS.tc2
+        range: Seconds
+        multivalued: false
+        required: true
+        description: Lead time constant (<i>Tc2</i>) (&gt;= 0).  Typical value = 0.
+      te:
+        slot_uri: cim:ExcREXS.te
+        range: Seconds
+        multivalued: false
+        required: true
+        description: Exciter field time constant (<i>Te</i>) (&gt; 0).  Typical value
+          = 1,2.
+      tf:
+        slot_uri: cim:ExcREXS.tf
+        range: Seconds
+        multivalued: false
+        required: true
+        description: Rate feedback time constant (<i>Tf</i>) (&gt;= 0).  If = 0, the
+          feedback path is not used.  Typical value = 1.
+      tf1:
+        slot_uri: cim:ExcREXS.tf1
+        range: Seconds
+        multivalued: false
+        required: true
+        description: Feedback lead time constant (<i>Tf1</i>) (&gt;= 0).  Typical
+          value = 0.
+      tf2:
+        slot_uri: cim:ExcREXS.tf2
+        range: Seconds
+        multivalued: false
+        required: true
+        description: Feedback lag time constant (<i>Tf2</i>) (&gt;= 0).  If = 0, block
+          is bypassed.  Typical value = 0.
+      tp:
+        slot_uri: cim:ExcREXS.tp
+        range: Seconds
+        multivalued: false
+        required: true
+        description: Field current bridge time constant (<i>Tp</i>) (&gt;= 0).  Typical
+          value = 0.
+      vcmax:
+        slot_uri: cim:ExcREXS.vcmax
+        range: PU
+        multivalued: false
+        required: true
+        description: Maximum compounding voltage (<i>Vcmax</i>).  Typical value =
+          0.
+      vfmax:
+        slot_uri: cim:ExcREXS.vfmax
+        range: PU
+        multivalued: false
+        required: true
+        description: Maximum exciter field current (<i>Vfmax</i>) (&gt; ExcREXS.vfmin).  Typical
+          value = 47.
+      vfmin:
+        slot_uri: cim:ExcREXS.vfmin
+        range: PU
+        multivalued: false
+        required: true
+        description: Minimum exciter field current (<i>Vfmin</i>) (&lt; ExcREXS.vfmax).  Typical
+          value = -20.
+      vimax:
+        slot_uri: cim:ExcREXS.vimax
+        range: PU
+        multivalued: false
+        required: true
+        description: Voltage regulator input limit (<i>Vimax</i>).  Typical value
+          = 0,1.
+      vrmax:
+        slot_uri: cim:ExcREXS.vrmax
+        range: PU
+        multivalued: false
+        required: true
+        description: Maximum controller output (V<i>rmax</i>) (&gt; ExcREXS.vrmin).  Typical
+          value = 47.
+      vrmin:
+        slot_uri: cim:ExcREXS.vrmin
+        range: PU
+        multivalued: false
+        required: true
+        description: Minimum controller output (<i>Vrmin</i>) (&lt; ExcREXS.vrmax).  Typical
+          value = -20.
+      xc:
+        slot_uri: cim:ExcREXS.xc
+        range: PU
+        multivalued: false
+        required: true
+        description: Exciter compounding reactance (<i>Xc</i>).  Typical value = 0.
+    is_a: ExcitationSystemDynamics
+    description: General purpose rotating excitation system.  This model can be used
+      to represent a wide range of excitation systems whose DC power source is an
+      AC or DC generator. It encompasses IEEE type AC1, AC2, DC1, and DC2 excitation
+      system models.
+  ExcRQB:
+    class_uri: cim:ExcRQB
+    attributes:
+      ki0:
+        slot_uri: cim:ExcRQB.ki0
+        range: float
+        multivalued: false
+        required: true
+        description: Voltage reference input gain (<i>Ki0</i>).  Typical value = 12,7.
+      ki1:
+        slot_uri: cim:ExcRQB.ki1
+        range: float
+        multivalued: false
+        required: true
+        description: Voltage input gain (<i>Ki1</i>).  Typical value = -16,8.
+      te:
+        slot_uri: cim:ExcRQB.te
+        range: Seconds
+        multivalued: false
+        required: true
+        description: Lead lag time constant (<i>TE</i>) (&gt;= 0).  Typical value
+          = 0,22.
+      tc:
+        slot_uri: cim:ExcRQB.tc
+        range: Seconds
+        multivalued: false
+        required: true
+        description: Lead lag time constant (<i>TC</i>) (&gt;= 0).  Typical value
+          = 0,02.
+      klir:
+        slot_uri: cim:ExcRQB.klir
+        range: float
+        multivalued: false
+        required: true
+        description: OEL input gain (<i>KLIR</i>).  Typical value = 12,13.
+      ucmin:
+        slot_uri: cim:ExcRQB.ucmin
+        range: PU
+        multivalued: false
+        required: true
+        description: Minimum voltage reference limit (<i>UCMIN</i>) (&lt; ExcRQB.ucmax).  Typical
+          value = 0,9.
+      ucmax:
+        slot_uri: cim:ExcRQB.ucmax
+        range: PU
+        multivalued: false
+        required: true
+        description: Maximum voltage reference limit (<i>UCMAX</i>) (&gt; ExcRQB.ucmin).  Typical
+          value = 1,1.
+      lus:
+        slot_uri: cim:ExcRQB.lus
+        range: PU
+        multivalued: false
+        required: true
+        description: Setpoint (<i>LUS</i>).  Typical value = 0,12.
+      klus:
+        slot_uri: cim:ExcRQB.klus
+        range: float
+        multivalued: false
+        required: true
+        description: Limiter gain (<i>KLUS</i>).  Typical value = 50.
+      mesu:
+        slot_uri: cim:ExcRQB.mesu
+        range: Seconds
+        multivalued: false
+        required: true
+        description: Voltage input time constant (<i>MESU</i>) (&gt;= 0).  Typical
+          value = 0,02.
+      t4m:
+        slot_uri: cim:ExcRQB.t4m
+        range: Seconds
+        multivalued: false
+        required: true
+        description: Input time constant (<i>T4M</i>) (&gt;= 0).  Typical value =
+          5.
+      lsat:
+        slot_uri: cim:ExcRQB.lsat
+        range: PU
+        multivalued: false
+        required: true
+        description: Integrator limiter (<i>LSAT</i>).  Typical value = 5,73.
+      tf:
+        slot_uri: cim:ExcRQB.tf
+        range: Seconds
+        multivalued: false
+        required: true
+        description: Exciter time constant (<i>TF</i>) (&gt;= 0).  Typical value =
+          0,01.
+    is_a: ExcitationSystemDynamics
+    description: Excitation system type RQB (four-loop regulator, r?gulateur quatre
+      boucles, developed in France) primarily used in nuclear or thermal generating
+      units. This excitation system shall be always used together with power system
+      stabilizer type PssRQB.
+  ExcSCRX:
+    class_uri: cim:ExcSCRX
+    attributes:
+      tatb:
+        slot_uri: cim:ExcSCRX.tatb
+        range: float
+        multivalued: false
+        required: true
+        description: Gain reduction ratio of lag-lead element ([<i>Ta</i> / <i>Tb</i>]).
+          The parameter <i>Ta</i> is not defined explicitly.  Typical value = 0.1.
+      tb:
+        slot_uri: cim:ExcSCRX.tb
+        range: Seconds
+        multivalued: false
+        required: true
+        description: Denominator time constant of lag-lead block (<i>Tb</i>) (&gt;=
+          0).  Typical value = 10.
+      k:
+        slot_uri: cim:ExcSCRX.k
+        range: PU
+        multivalued: false
+        required: true
+        description: Gain (<i>K</i>) (&gt; 0).  Typical value = 200.
+      te:
+        slot_uri: cim:ExcSCRX.te
+        range: Seconds
+        multivalued: false
+        required: true
+        description: Time constant of gain block (<i>Te</i>) (&gt; 0).  Typical value
+          = 0,02.
+      emin:
+        slot_uri: cim:ExcSCRX.emin
+        range: PU
+        multivalued: false
+        required: true
+        description: Minimum field voltage output (<i>Emin</i>) (&lt; ExcSCRX.emax).  Typical
+          value = 0.
+      emax:
+        slot_uri: cim:ExcSCRX.emax
+        range: PU
+        multivalued: false
+        required: true
+        description: Maximum field voltage output (<i>Emax</i>) (&gt; ExcSCRX.emin).  Typical
+          value = 5.
+      cswitch:
+        slot_uri: cim:ExcSCRX.cswitch
+        range: boolean
+        multivalued: false
+        required: true
+        description: 'Power source switch (<i>Cswitch</i>).
+
+          true = fixed voltage of 1.0 PU
+
+          false = generator terminal voltage.'
+      rcrfd:
+        slot_uri: cim:ExcSCRX.rcrfd
+        range: float
+        multivalued: false
+        required: true
+        description: Ratio of field discharge resistance to field winding resistance
+          ([<i>rc / rfd]</i>).  Typical value = 0.
+    is_a: ExcitationSystemDynamics
+    description: Simple excitation system with generic characteristics typical of
+      many excitation systems; intended for use where negative field current could
+      be a problem.
+  ExcSEXS:
+    class_uri: cim:ExcSEXS
+    attributes:
+      tatb:
+        slot_uri: cim:ExcSEXS.tatb
+        range: float
+        multivalued: false
+        required: true
+        description: Gain reduction ratio of lag-lead element (<i>[Ta / Tb]</i>).  Typical
+          value = 0,1.
+      tb:
+        slot_uri: cim:ExcSEXS.tb
+        range: Seconds
+        multivalued: false
+        required: true
+        description: Denominator time constant of lag-lead block (<i>Tb</i>) (&gt;=
+          0).  Typical value = 10.
+      k:
+        slot_uri: cim:ExcSEXS.k
+        range: PU
+        multivalued: false
+        required: true
+        description: Gain (<i>K</i>) (&gt; 0).  Typical value = 100.
+      te:
+        slot_uri: cim:ExcSEXS.te
+        range: Seconds
+        multivalued: false
+        required: true
+        description: Time constant of gain block (<i>Te</i>) (&gt; 0).  Typical value
+          = 0,05.
+      emin:
+        slot_uri: cim:ExcSEXS.emin
+        range: PU
+        multivalued: false
+        required: true
+        description: Minimum field voltage output (<i>Emin</i>) (&lt; ExcSEXS.emax).  Typical
+          value = -5.
+      emax:
+        slot_uri: cim:ExcSEXS.emax
+        range: PU
+        multivalued: false
+        required: true
+        description: Maximum field voltage output (<i>Emax</i>) (&gt; ExcSEXS.emin).  Typical
+          value = 5.
+      kc:
+        slot_uri: cim:ExcSEXS.kc
+        range: PU
+        multivalued: false
+        required: true
+        description: PI controller gain (<i>Kc</i>) (&gt; 0 if ExcSEXS.tc &gt; 0).  Typical
+          value = 0,08.
+      tc:
+        slot_uri: cim:ExcSEXS.tc
+        range: Seconds
+        multivalued: false
+        required: true
+        description: PI controller phase lead time constant (<i>Tc</i>) (&gt;= 0).  Typical
+          value = 0.
+      efdmin:
+        slot_uri: cim:ExcSEXS.efdmin
+        range: PU
+        multivalued: false
+        required: true
+        description: Field voltage clipping minimum limit (<i>Efdmin</i>) (&lt; ExcSEXS.efdmax).  Typical
+          value = -5.
+      efdmax:
+        slot_uri: cim:ExcSEXS.efdmax
+        range: PU
+        multivalued: false
+        required: true
+        description: Field voltage clipping maximum limit (<i>Efdmax</i>) (&gt; ExcSEXS.efdmin).  Typical
+          value = 5.
+    is_a: ExcitationSystemDynamics
+    description: Simplified excitation system.
+  ExcSK:
+    class_uri: cim:ExcSK
+    attributes:
+      efdmax:
+        slot_uri: cim:ExcSK.efdmax
+        range: PU
+        multivalued: false
+        required: true
+        description: Field voltage clipping upper level limit (<i>Efdmax</i>) (&gt;
+          ExcSK.efdmin).
+      efdmin:
+        slot_uri: cim:ExcSK.efdmin
+        range: PU
+        multivalued: false
+        required: true
+        description: Field voltage clipping lower level limit (<i>Efdmin</i>) (&lt;
+          ExcSK.efdmax).
+      emax:
+        slot_uri: cim:ExcSK.emax
+        range: PU
+        multivalued: false
+        required: true
+        description: Maximum field voltage output (<i>Emax</i>) (&gt; ExcSK.emin).  Typical
+          value = 20.
+      emin:
+        slot_uri: cim:ExcSK.emin
+        range: PU
+        multivalued: false
+        required: true
+        description: Minimum field voltage output (<i>Emin</i>) (&lt; ExcSK.emax).  Typical
+          value = -20.
+      k:
+        slot_uri: cim:ExcSK.k
+        range: PU
+        multivalued: false
+        required: true
+        description: Gain (<i>K</i>).  Typical value = 1.
+      k1:
+        slot_uri: cim:ExcSK.k1
+        range: PU
+        multivalued: false
+        required: true
+        description: Parameter of underexcitation limit (<i>K1</i>).  Typical value
+          = 0,1364.
+      k2:
+        slot_uri: cim:ExcSK.k2
+        range: PU
+        multivalued: false
+        required: true
+        description: Parameter of underexcitation limit (<i>K2</i>).  Typical value
+          = -0,3861.
+      kc:
+        slot_uri: cim:ExcSK.kc
+        range: PU
+        multivalued: false
+        required: true
+        description: PI controller gain (<i>Kc</i>).  Typical value = 70.
+      kce:
+        slot_uri: cim:ExcSK.kce
+        range: PU
+        multivalued: false
+        required: true
+        description: Rectifier regulation factor (<i>Kce</i>).  Typical value = 0.
+      kd:
+        slot_uri: cim:ExcSK.kd
+        range: PU
+        multivalued: false
+        required: true
+        description: Exciter internal reactance (<i>Kd</i>).  Typical value = 0.
+      kgob:
+        slot_uri: cim:ExcSK.kgob
+        range: PU
+        multivalued: false
+        required: true
+        description: P controller gain (<i>Kgob</i>).  Typical value = 10.
+      kp:
+        slot_uri: cim:ExcSK.kp
+        range: PU
+        multivalued: false
+        required: true
+        description: PI controller gain (<i>Kp</i>).  Typical value = 1.
+      kqi:
+        slot_uri: cim:ExcSK.kqi
+        range: PU
+        multivalued: false
+        required: true
+        description: PI controller gain of integral component (<i>Kqi</i>).  Typical
+          value = 0.
+      kqob:
+        slot_uri: cim:ExcSK.kqob
+        range: PU
+        multivalued: false
+        required: true
+        description: Rate of rise of the reactive power (<i>Kqob</i>).
+      kqp:
+        slot_uri: cim:ExcSK.kqp
+        range: PU
+        multivalued: false
+        required: true
+        description: PI controller gain (<i>Kqp</i>).  Typical value = 0.
+      nq:
+        slot_uri: cim:ExcSK.nq
+        range: PU
+        multivalued: false
+        required: true
+        description: Deadband of reactive power (<i>nq</i>).  Determines the range
+          of sensitivity.  Typical value = 0,001.
+      qconoff:
+        slot_uri: cim:ExcSK.qconoff
+        range: boolean
+        multivalued: false
+        required: true
+        description: 'Secondary voltage control state (<i>Qc_on_off</i>).
+
+          true = secondary voltage control is on
+
+          false = secondary voltage control is off.
+
+          Typical value = false.'
+      qz:
+        slot_uri: cim:ExcSK.qz
+        range: PU
+        multivalued: false
+        required: true
+        description: Desired value (setpoint) of reactive power, manual setting (<i>Qz</i>).
+      remote:
+        slot_uri: cim:ExcSK.remote
+        range: boolean
+        multivalued: false
+        required: true
+        description: 'Selector to apply automatic calculation in secondary controller
+          model (<i>remote</i>).
+
+          true = automatic calculation is activated
+
+          false = manual set is active; the use of desired value of reactive power
+          (<i>Qz</i>) is required.
+
+          Typical value = true.'
+      sbase:
+        slot_uri: cim:ExcSK.sbase
+        range: ApparentPower
+        multivalued: false
+        required: true
+        description: Apparent power of the unit (<i>Sbase</i>) (&gt; 0).  Unit = MVA.  Typical
+          value = 259.
+      tc:
+        slot_uri: cim:ExcSK.tc
+        range: Seconds
+        multivalued: false
+        required: true
+        description: PI controller phase lead time constant (<i>Tc</i>) (&gt;= 0).  Typical
+          value = 8.
+      te:
+        slot_uri: cim:ExcSK.te
+        range: Seconds
+        multivalued: false
+        required: true
+        description: Time constant of gain block (<i>Te</i>) (&gt;= 0).  Typical value
+          = 0,1.
+      ti:
+        slot_uri: cim:ExcSK.ti
+        range: Seconds
+        multivalued: false
+        required: true
+        description: PI controller phase lead time constant (<i>Ti</i>) (&gt;= 0).  Typical
+          value = 2.
+      tp:
+        slot_uri: cim:ExcSK.tp
+        range: Seconds
+        multivalued: false
+        required: true
+        description: Time constant (<i>Tp</i>) (&gt;= 0).  Typical value = 0,1.
+      tr:
+        slot_uri: cim:ExcSK.tr
+        range: Seconds
+        multivalued: false
+        required: true
+        description: Voltage transducer time constant (<i>Tr</i>) (&gt;= 0).  Typical
+          value = 0,01.
+      uimax:
+        slot_uri: cim:ExcSK.uimax
+        range: PU
+        multivalued: false
+        required: true
+        description: Maximum error (<i>UImax</i>) (&gt; ExcSK.uimin).  Typical value
+          = 10.
+      uimin:
+        slot_uri: cim:ExcSK.uimin
+        range: PU
+        multivalued: false
+        required: true
+        description: Minimum error (<i>UImin</i>) (&lt; ExcSK.uimax).  Typical value
+          = -10.
+      urmax:
+        slot_uri: cim:ExcSK.urmax
+        range: PU
+        multivalued: false
+        required: true
+        description: Maximum controller output (<i>URmax</i>) (&gt; ExcSK.urmin).  Typical
+          value = 10.
+      urmin:
+        slot_uri: cim:ExcSK.urmin
+        range: PU
+        multivalued: false
+        required: true
+        description: Minimum controller output (<i>URmin</i>) (&lt; ExcSK.urmax).  Typical
+          value = -10.
+      vtmax:
+        slot_uri: cim:ExcSK.vtmax
+        range: PU
+        multivalued: false
+        required: true
+        description: Maximum terminal voltage input (<i>Vtmax</i>) (&gt; ExcSK.vtmin).  Determines
+          the range of voltage deadband.  Typical value = 1,05.
+      vtmin:
+        slot_uri: cim:ExcSK.vtmin
+        range: PU
+        multivalued: false
+        required: true
+        description: Minimum terminal voltage input (<i>Vtmin</i>) (&lt; ExcSK.vtmax).  Determines
+          the range of voltage deadband.  Typical value = 0,95.
+      yp:
+        slot_uri: cim:ExcSK.yp
+        range: PU
+        multivalued: false
+        required: true
+        description: Maximum output (<i>Yp</i>).  Typical value = 1.
+    is_a: ExcitationSystemDynamics
+    description: Slovakian excitation system.  UEL and secondary voltage control are
+      included in this model. When this model is used, there cannot be a separate
+      underexcitation limiter or VAr controller model.
+  ExcST1A:
+    class_uri: cim:ExcST1A
+    attributes:
+      vimax:
+        slot_uri: cim:ExcST1A.vimax
+        range: PU
+        multivalued: false
+        required: true
+        description: Maximum voltage regulator input limit (<i>Vimax</i>) (&gt; 0).  Typical
+          value = 999.
+      vimin:
+        slot_uri: cim:ExcST1A.vimin
+        range: PU
+        multivalued: false
+        required: true
+        description: Minimum voltage regulator input limit (<i>Vimin</i>) (&lt; 0).  Typical
+          value = -999.
+      tc:
+        slot_uri: cim:ExcST1A.tc
+        range: Seconds
+        multivalued: false
+        required: true
+        description: Voltage regulator time constant (<i>Tc</i>) (&gt;= 0).  Typical
+          value = 1.
+      tb:
+        slot_uri: cim:ExcST1A.tb
+        range: Seconds
+        multivalued: false
+        required: true
+        description: Voltage regulator time constant (<i>Tb</i>) (&gt;= 0).  Typical
+          value = 10.
+      ka:
+        slot_uri: cim:ExcST1A.ka
+        range: PU
+        multivalued: false
+        required: true
+        description: Voltage regulator gain (<i>Ka</i>) (&gt; 0).  Typical value =
+          190.
+      ta:
+        slot_uri: cim:ExcST1A.ta
+        range: Seconds
+        multivalued: false
+        required: true
+        description: Voltage regulator time constant (<i>Ta</i>) (&gt;= 0).  Typical
+          value = 0,02.
+      vrmax:
+        slot_uri: cim:ExcST1A.vrmax
+        range: PU
+        multivalued: false
+        required: true
+        description: Maximum voltage regulator outputs (<i>Vrmax</i>) (&gt; 0) .  Typical
+          value = 7,8.
+      vrmin:
+        slot_uri: cim:ExcST1A.vrmin
+        range: PU
+        multivalued: false
+        required: true
+        description: Minimum voltage regulator outputs (<i>Vrmin</i>) (&lt; 0).  Typical
+          value = -6,7.
+      kc:
+        slot_uri: cim:ExcST1A.kc
+        range: PU
+        multivalued: false
+        required: true
+        description: Rectifier loading factor proportional to commutating reactance
+          (<i>Kc</i>) (&gt;= 0). Typical value = 0,05.
+      kf:
+        slot_uri: cim:ExcST1A.kf
+        range: PU
+        multivalued: false
+        required: true
+        description: Excitation control system stabilizer gains (<i>Kf</i>) (&gt;=
+          0).  Typical value = 0.
+      tf:
+        slot_uri: cim:ExcST1A.tf
+        range: Seconds
+        multivalued: false
+        required: true
+        description: Excitation control system stabilizer time constant (<i>Tf</i>)
+          (&gt;= 0).  Typical value = 1.
+      tc1:
+        slot_uri: cim:ExcST1A.tc1
+        range: Seconds
+        multivalued: false
+        required: true
+        description: Voltage regulator time constant (<i>Tc1</i>) (&gt;= 0).  Typical
+          value = 0.
+      tb1:
+        slot_uri: cim:ExcST1A.tb1
+        range: Seconds
+        multivalued: false
+        required: true
+        description: Voltage regulator time constant (<i>Tb1</i>) (&gt;= 0).  Typical
+          value = 0.
+      vamax:
+        slot_uri: cim:ExcST1A.vamax
+        range: PU
+        multivalued: false
+        required: true
+        description: Maximum voltage regulator output (<i>Vamax</i>) (&gt; 0).  Typical
+          value = 999.
+      vamin:
+        slot_uri: cim:ExcST1A.vamin
+        range: PU
+        multivalued: false
+        required: true
+        description: Minimum voltage regulator output (<i>Vamin</i>) (&lt; 0).  Typical
+          value = -999.
+      ilr:
+        slot_uri: cim:ExcST1A.ilr
+        range: PU
+        multivalued: false
+        required: true
+        description: Exciter output current limit reference (<i>Ilr</i>).  Typical
+          value = 0.
+      klr:
+        slot_uri: cim:ExcST1A.klr
+        range: PU
+        multivalued: false
+        required: true
+        description: Exciter output current limiter gain (<i>Klr</i>).  Typical value
+          = 0.
+      xe:
+        slot_uri: cim:ExcST1A.xe
+        range: PU
+        multivalued: false
+        required: true
+        description: Excitation xfmr effective reactance (<i>Xe</i>).  Typical value
+          = 0,04.
+    is_a: ExcitationSystemDynamics
+    description: Modification of an old IEEE ST1A static excitation system without
+      overexcitation limiter (OEL) and underexcitation limiter (UEL).
+  ExcST2A:
+    class_uri: cim:ExcST2A
+    attributes:
+      ka:
+        slot_uri: cim:ExcST2A.ka
+        range: PU
+        multivalued: false
+        required: true
+        description: Voltage regulator gain (<i>Ka</i>) (&gt; 0).  Typical value =
+          120.
+      ta:
+        slot_uri: cim:ExcST2A.ta
+        range: Seconds
+        multivalued: false
+        required: true
+        description: Voltage regulator time constant (<i>Ta</i>) (&gt; 0).  Typical
+          value = 0,15.
+      vrmax:
+        slot_uri: cim:ExcST2A.vrmax
+        range: PU
+        multivalued: false
+        required: true
+        description: Maximum voltage regulator outputs (<i>Vrmax</i>) (&gt; 0).  Typical
+          value = 1.
+      vrmin:
+        slot_uri: cim:ExcST2A.vrmin
+        range: PU
+        multivalued: false
+        required: true
+        description: Minimum voltage regulator outputs (<i>Vrmin</i>) (&lt; 0).  Typical
+          value = -1.
+      ke:
+        slot_uri: cim:ExcST2A.ke
+        range: PU
+        multivalued: false
+        required: true
+        description: Exciter constant related to self-excited field (<i>Ke</i>).  Typical
+          value = 1.
+      te:
+        slot_uri: cim:ExcST2A.te
+        range: Seconds
+        multivalued: false
+        required: true
+        description: Exciter time constant, integration rate associated with exciter
+          control (<i>Te</i>) (&gt; 0).  Typical value = 0,5.
+      kf:
+        slot_uri: cim:ExcST2A.kf
+        range: PU
+        multivalued: false
+        required: true
+        description: Excitation control system stabilizer gains (<i>kf</i>) (&gt;=
+          0).  Typical value = 0,05.
+      tf:
+        slot_uri: cim:ExcST2A.tf
+        range: Seconds
+        multivalued: false
+        required: true
+        description: Excitation control system stabilizer time constant (<i>Tf</i>)
+          (&gt;= 0).  Typical value = 0,7.
+      kp:
+        slot_uri: cim:ExcST2A.kp
+        range: PU
+        multivalued: false
+        required: true
+        description: Potential circuit gain coefficient (<i>K</i><i><sub>p</sub></i>)
+          (&gt;= 0).  Typical value = 4,88.
+      ki:
+        slot_uri: cim:ExcST2A.ki
+        range: PU
+        multivalued: false
+        required: true
+        description: Potential circuit gain coefficient (<i>K</i><i><sub>i</sub></i>)
+          (&gt;= 0).  Typical value = 8.
+      kc:
+        slot_uri: cim:ExcST2A.kc
+        range: PU
+        multivalued: false
+        required: true
+        description: Rectifier loading factor proportional to commutating reactance
+          (<i>Kc</i>) (&gt;= 0).  Typical value = 1,82.
+      efdmax:
+        slot_uri: cim:ExcST2A.efdmax
+        range: PU
+        multivalued: false
+        required: true
+        description: Maximum field voltage (<i>Efdmax</i>) (&gt;= 0).  Typical value
+          = 99.
+      uelin:
+        slot_uri: cim:ExcST2A.uelin
+        range: boolean
+        multivalued: false
+        required: true
+        description: 'UEL input (<i>UELin</i>).
+
+          true = HV gate
+
+          false = add to error signal.
+
+          Typical value = false.'
+      tb:
+        slot_uri: cim:ExcST2A.tb
+        range: Seconds
+        multivalued: false
+        required: true
+        description: Voltage regulator time constant (<i>Tb</i>) (&gt;= 0).  Typical
+          value = 0.
+      tc:
+        slot_uri: cim:ExcST2A.tc
+        range: Seconds
+        multivalued: false
+        required: true
+        description: Voltage regulator time constant (<i>Tc</i>) (&gt;= 0).  Typical
+          value = 0.
+    is_a: ExcitationSystemDynamics
+    description: Modified IEEE ST2A static excitation system with another lead-lag
+      block added to match the model defined by WECC.
+  ExcST3A:
+    class_uri: cim:ExcST3A
+    attributes:
+      vimax:
+        slot_uri: cim:ExcST3A.vimax
+        range: PU
+        multivalued: false
+        required: true
+        description: Maximum voltage regulator input limit (<i>Vimax</i>) (&gt; 0).  Typical
+          value = 0,2.
+      vimin:
+        slot_uri: cim:ExcST3A.vimin
+        range: PU
+        multivalued: false
+        required: true
+        description: Minimum voltage regulator input limit (<i>Vimin</i>) (&lt; 0).  Typical
+          value = -0,2.
+      kj:
+        slot_uri: cim:ExcST3A.kj
+        range: PU
+        multivalued: false
+        required: true
+        description: AVR gain (<i>Kj</i>) (&gt; 0).  Typical value = 200.
+      tb:
+        slot_uri: cim:ExcST3A.tb
+        range: Seconds
+        multivalued: false
+        required: true
+        description: Voltage regulator time constant (<i>Tb</i>) (&gt;= 0).  Typical
+          value = 6,67.
+      tc:
+        slot_uri: cim:ExcST3A.tc
+        range: Seconds
+        multivalued: false
+        required: true
+        description: Voltage regulator time constant (<i>Tc</i>) (&gt;= 0).  Typical
+          value = 1.
+      efdmax:
+        slot_uri: cim:ExcST3A.efdmax
+        range: PU
+        multivalued: false
+        required: true
+        description: Maximum AVR output (<i>Efdmax</i>) (&gt;= 0).  Typical value
+          = 6,9.
+      km:
+        slot_uri: cim:ExcST3A.km
+        range: PU
+        multivalued: false
+        required: true
+        description: Forward gain constant of the inner loop field regulator (<i>Km</i>)
+          (&gt; 0).  Typical value = 7,04.
+      tm:
+        slot_uri: cim:ExcST3A.tm
+        range: Seconds
+        multivalued: false
+        required: true
+        description: Forward time constant of inner loop field regulator (<i>Tm</i>)
+          (&gt; 0).  Typical value = 1.
+      vrmax:
+        slot_uri: cim:ExcST3A.vrmax
+        range: PU
+        multivalued: false
+        required: true
+        description: Maximum voltage regulator output (<i>Vrmax</i>) (&gt; 0).  Typical
+          value = 1.
+      vrmin:
+        slot_uri: cim:ExcST3A.vrmin
+        range: PU
+        multivalued: false
+        required: true
+        description: Minimum voltage regulator output (<i>Vrmin</i>) (&lt; 0).  Typical
+          value = -1.
+      kg:
+        slot_uri: cim:ExcST3A.kg
+        range: PU
+        multivalued: false
+        required: true
+        description: Feedback gain constant of the inner loop field regulator (<i>Kg</i>)
+          (&gt;= 0).  Typical value = 1.
+      kp:
+        slot_uri: cim:ExcST3A.kp
+        range: PU
+        multivalued: false
+        required: true
+        description: Potential source gain (<i>K</i><i><sub>p</sub></i>) (&gt; 0).  Typical
+          value = 4,37.
+      thetap:
+        slot_uri: cim:ExcST3A.thetap
+        range: AngleDegrees
+        multivalued: false
+        required: true
+        description: Potential circuit phase angle (<i>theta</i><i><sub>p</sub></i>).  Typical
+          value = 20.
+      ki:
+        slot_uri: cim:ExcST3A.ki
+        range: PU
+        multivalued: false
+        required: true
+        description: Potential circuit gain coefficient (<i>K</i><i><sub>i</sub></i>)
+          (&gt;= 0).  Typical value = 4,83.
+      kc:
+        slot_uri: cim:ExcST3A.kc
+        range: PU
+        multivalued: false
+        required: true
+        description: Rectifier loading factor proportional to commutating reactance
+          (<i>Kc</i>) (&gt;= 0). Typical value = 1,1.
+      xl:
+        slot_uri: cim:ExcST3A.xl
+        range: PU
+        multivalued: false
+        required: true
+        description: Reactance associated with potential source (<i>Xl</i>) (&gt;=
+          0).  Typical value = 0,09.
+      vbmax:
+        slot_uri: cim:ExcST3A.vbmax
+        range: PU
+        multivalued: false
+        required: true
+        description: Maximum excitation voltage (<i>Vbmax</i>) (&gt; 0).  Typical
+          value = 8,63.
+      vgmax:
+        slot_uri: cim:ExcST3A.vgmax
+        range: PU
+        multivalued: false
+        required: true
+        description: Maximum inner loop feedback voltage (<i>Vgmax</i>) (&gt;= 0).  Typical
+          value = 6,53.
+      ks:
+        slot_uri: cim:ExcST3A.ks
+        range: PU
+        multivalued: false
+        required: true
+        description: Coefficient to allow different usage of the model-speed coefficient
+          (<i>Ks</i>).  Typical value = 0.
+      ks1:
+        slot_uri: cim:ExcST3A.ks1
+        range: PU
+        multivalued: false
+        required: true
+        description: Coefficient to allow different usage of the model-speed coefficient
+          (<i>Ks1</i>).  Typical value = 0.
+    is_a: ExcitationSystemDynamics
+    description: Modified IEEE ST3A static excitation system with added speed multiplier.
+  ExcST4B:
+    class_uri: cim:ExcST4B
+    attributes:
+      kpr:
+        slot_uri: cim:ExcST4B.kpr
+        range: PU
+        multivalued: false
+        required: true
+        description: Voltage regulator proportional gain (<i>Kpr</i>).  Typical value
+          = 10,75.
+      kir:
+        slot_uri: cim:ExcST4B.kir
+        range: PU
+        multivalued: false
+        required: true
+        description: Voltage regulator integral gain (<i>Kir</i>).  Typical value
+          = 10,75.
+      ta:
+        slot_uri: cim:ExcST4B.ta
+        range: Seconds
+        multivalued: false
+        required: true
+        description: Voltage regulator time constant (<i>Ta</i>) (&gt;= 0).  Typical
+          value = 0,02.
+      vrmax:
+        slot_uri: cim:ExcST4B.vrmax
+        range: PU
+        multivalued: false
+        required: true
+        description: Maximum voltage regulator output (<i>Vrmax</i>) (&gt; 0).  Typical
+          value = 1.
+      vrmin:
+        slot_uri: cim:ExcST4B.vrmin
+        range: PU
+        multivalued: false
+        required: true
+        description: Minimum voltage regulator output (<i>Vrmin</i>) (&lt; 0).  Typical
+          value = -0,87.
+      kpm:
+        slot_uri: cim:ExcST4B.kpm
+        range: PU
+        multivalued: false
+        required: true
+        description: Voltage regulator proportional gain output (<i>Kpm</i>).  Typical
+          value = 1.
+      kim:
+        slot_uri: cim:ExcST4B.kim
+        range: PU
+        multivalued: false
+        required: true
+        description: Voltage regulator integral gain output (<i>Kim</i>).  Typical
+          value = 0.
+      vmmax:
+        slot_uri: cim:ExcST4B.vmmax
+        range: PU
+        multivalued: false
+        required: true
+        description: Maximum inner loop output (<i>Vmmax</i>) (&gt; ExcST4B.vmmin).  Typical
+          value = 99.
+      vmmin:
+        slot_uri: cim:ExcST4B.vmmin
+        range: PU
+        multivalued: false
+        required: true
+        description: Minimum inner loop output (<i>Vmmin</i>) (&lt; ExcST4B.vmmax).  Typical
+          value = -99.
+      kg:
+        slot_uri: cim:ExcST4B.kg
+        range: PU
+        multivalued: false
+        required: true
+        description: Feedback gain constant of the inner loop field regulator (<i>Kg</i>)
+          (&gt;= 0). Typical value = 0.
+      kp:
+        slot_uri: cim:ExcST4B.kp
+        range: PU
+        multivalued: false
+        required: true
+        description: Potential circuit gain coefficient (<i>Kp</i>) (&gt; 0).  Typical
+          value = 9,3.
+      thetap:
+        slot_uri: cim:ExcST4B.thetap
+        range: AngleDegrees
+        multivalued: false
+        required: true
+        description: Potential circuit phase angle (<i>theta</i><i><sub>p</sub></i>).  Typical
+          value = 0.
+      ki:
+        slot_uri: cim:ExcST4B.ki
+        range: PU
+        multivalued: false
+        required: true
+        description: Potential circuit gain coefficient (<i>Ki</i>) (&gt;= 0).  Typical
+          value = 0.
+      kc:
+        slot_uri: cim:ExcST4B.kc
+        range: PU
+        multivalued: false
+        required: true
+        description: Rectifier loading factor proportional to commutating reactance
+          (<i>Kc</i>) (&gt;= 0). Typical value = 0,113.
+      xl:
+        slot_uri: cim:ExcST4B.xl
+        range: PU
+        multivalued: false
+        required: true
+        description: Reactance associated with potential source (<i>Xl</i>) (&gt;=
+          0).  Typical value = 0,124.
+      vbmax:
+        slot_uri: cim:ExcST4B.vbmax
+        range: PU
+        multivalued: false
+        required: true
+        description: Maximum excitation voltage (<i>Vbmax</i>) (&gt; 0).  Typical
+          value = 11,63.
+      vgmax:
+        slot_uri: cim:ExcST4B.vgmax
+        range: PU
+        multivalued: false
+        required: true
+        description: Maximum inner loop feedback voltage (<i>Vgmax</i>) (&gt;= 0).  Typical
+          value = 5,8.
+      uel:
+        slot_uri: cim:ExcST4B.uel
+        range: boolean
+        multivalued: false
+        required: true
+        description: "Selector (<i>UEL</i>).\ntrue = <i>UEL</i> is part of block diagram\n\
+          false = <i>UEL</i> is not part of block diagram. \nTypical value = false."
+      lvgate:
+        slot_uri: cim:ExcST4B.lvgate
+        range: boolean
+        multivalued: false
+        required: true
+        description: "Selector (<i>LVGate</i>).\ntrue = <i>LVGate</i> is part of the\
+          \ block diagram\nfalse = <i>LVGate</i> is not part of the block diagram.\
+          \ \nTypical value = false."
+    is_a: ExcitationSystemDynamics
+    description: Modified IEEE ST4B static excitation system with maximum inner loop
+      feedback gain <i>Vgmax</i>.
+  ExcST6B:
+    class_uri: cim:ExcST6B
+    attributes:
+      ilr:
+        slot_uri: cim:ExcST6B.ilr
+        range: PU
+        multivalued: false
+        required: true
+        description: Exciter output current limit reference (<i>Ilr</i>) (&gt; 0).  Typical
+          value = 4,164.
+      k1:
+        slot_uri: cim:ExcST6B.k1
+        range: boolean
+        multivalued: false
+        required: true
+        description: 'Selector (<i>K1</i>).
+
+          true = feedback is from <i>Ifd</i>
+
+          false = feedback is not from <i>Ifd</i>.
+
+          Typical value = true.'
+      kcl:
+        slot_uri: cim:ExcST6B.kcl
+        range: PU
+        multivalued: false
+        required: true
+        description: Exciter output current limit adjustment (<i>Kcl</i>) (&gt; 0).  Typical
+          value = 1,0577.
+      kff:
+        slot_uri: cim:ExcST6B.kff
+        range: PU
+        multivalued: false
+        required: true
+        description: Pre-control gain constant of the inner loop field regulator (<i>Kff</i>).  Typical
+          value = 1.
+      kg:
+        slot_uri: cim:ExcST6B.kg
+        range: PU
+        multivalued: false
+        required: true
+        description: Feedback gain constant of the inner loop field regulator (<i>Kg</i>)
+          (&gt;= 0).  Typical value = 1.
+      kia:
+        slot_uri: cim:ExcST6B.kia
+        range: PU
+        multivalued: false
+        required: true
+        description: Voltage regulator integral gain (<i>Kia</i>) (&gt; 0).  Typical
+          value = 45,094.
+      klr:
+        slot_uri: cim:ExcST6B.klr
+        range: PU
+        multivalued: false
+        required: true
+        description: Exciter output current limit adjustment (<i>Kcl</i>) (&gt; 0).  Typical
+          value = 17,33.
+      km:
+        slot_uri: cim:ExcST6B.km
+        range: PU
+        multivalued: false
+        required: true
+        description: Forward gain constant of the inner loop field regulator (<i>Km</i>).  Typical
+          value = 1.
+      kpa:
+        slot_uri: cim:ExcST6B.kpa
+        range: PU
+        multivalued: false
+        required: true
+        description: Voltage regulator proportional gain (<i>Kpa</i>) (&gt; 0).  Typical
+          value = 18,038.
+      kvd:
+        slot_uri: cim:ExcST6B.kvd
+        range: PU
+        multivalued: false
+        required: true
+        description: Voltage regulator derivative gain (<i>Kvd</i>).  Typical value
+          = 0.
+      oelin:
+        slot_uri: cim:ExcST6B.oelin
+        range: ExcST6BOELselectorKind
+        multivalued: false
+        required: true
+        description: OEL input selector (<i>OELin</i>).  Typical value = noOELinput
+          (corresponds to <i>OELin</i> = 0 on diagram).
+      tg:
+        slot_uri: cim:ExcST6B.tg
+        range: Seconds
+        multivalued: false
+        required: true
+        description: Feedback time constant of inner loop field voltage regulator
+          (<i>Tg</i>) (&gt;= 0).  Typical value = 0,02.
+      ts:
+        slot_uri: cim:ExcST6B.ts
+        range: Seconds
+        multivalued: false
+        required: true
+        description: Rectifier firing time constant (<i>Ts</i>) (&gt;= 0).  Typical
+          value = 0.
+      tvd:
+        slot_uri: cim:ExcST6B.tvd
+        range: Seconds
+        multivalued: false
+        required: true
+        description: Voltage regulator derivative gain (<i>Tvd</i>) (&gt;= 0).  Typical
+          value = 0.
+      vamax:
+        slot_uri: cim:ExcST6B.vamax
+        range: PU
+        multivalued: false
+        required: true
+        description: Maximum voltage regulator output (<i>Vamax</i>) (&gt; 0).  Typical
+          value = 4,81.
+      vamin:
+        slot_uri: cim:ExcST6B.vamin
+        range: PU
+        multivalued: false
+        required: true
+        description: Minimum voltage regulator output (<i>Vamin</i>) (&lt; 0).  Typical
+          value = -3,85.
+      vilim:
+        slot_uri: cim:ExcST6B.vilim
+        range: boolean
+        multivalued: false
+        required: true
+        description: 'Selector (<i>Vilim</i>).
+
+          true = <i>Vimin</i>-<i>Vimax</i> limiter is active
+
+          false = <i>Vimin</i>-<i>Vimax</i> limiter is not active.
+
+          Typical value = true.'
+      vimax:
+        slot_uri: cim:ExcST6B.vimax
+        range: PU
+        multivalued: false
+        required: true
+        description: Maximum voltage regulator input limit (<i>Vimax</i>) (&gt; ExcST6B.vimin).  Typical
+          value = 10.
+      vimin:
+        slot_uri: cim:ExcST6B.vimin
+        range: PU
+        multivalued: false
+        required: true
+        description: Minimum voltage regulator input limit (<i>Vimin</i>) (&lt; ExcST6B.vimax).  Typical
+          value = -10.
+      vmult:
+        slot_uri: cim:ExcST6B.vmult
+        range: boolean
+        multivalued: false
+        required: true
+        description: "Selector (<i>vmult</i>).\ntrue = multiply regulator output by\
+          \ terminal voltage\nfalse = do not multiply regulator output by terminal\
+          \ voltage. \nTypical value = true."
+      vrmax:
+        slot_uri: cim:ExcST6B.vrmax
+        range: PU
+        multivalued: false
+        required: true
+        description: Maximum voltage regulator output (<i>Vrmax</i>) (&gt; 0).  Typical
+          value = 4,81.
+      vrmin:
+        slot_uri: cim:ExcST6B.vrmin
+        range: PU
+        multivalued: false
+        required: true
+        description: Minimum voltage regulator output (<i>Vrmin</i>) (&lt; 0).  Typical
+          value = -3,85.
+      xc:
+        slot_uri: cim:ExcST6B.xc
+        range: PU
+        multivalued: false
+        required: true
+        description: Excitation source reactance (<i>Xc</i>).  Typical value = 0,05.
+    is_a: ExcitationSystemDynamics
+    description: Modified IEEE ST6B static excitation system with PID controller and
+      optional inner feedback loop.
+  ExcST7B:
+    class_uri: cim:ExcST7B
+    attributes:
+      kh:
+        slot_uri: cim:ExcST7B.kh
+        range: PU
+        multivalued: false
+        required: true
+        description: High-value gate feedback gain (<i>Kh</i>) (&gt;= 0).  Typical
+          value = 1.
+      kia:
+        slot_uri: cim:ExcST7B.kia
+        range: PU
+        multivalued: false
+        required: true
+        description: Voltage regulator integral gain (<i>Kia</i>) (&gt;= 0).  Typical
+          value = 1.
+      kl:
+        slot_uri: cim:ExcST7B.kl
+        range: PU
+        multivalued: false
+        required: true
+        description: Low-value gate feedback gain (<i>Kl</i>) (&gt;= 0).  Typical
+          value = 1.
+      kpa:
+        slot_uri: cim:ExcST7B.kpa
+        range: PU
+        multivalued: false
+        required: true
+        description: Voltage regulator proportional gain (<i>Kpa</i>) (&gt; 0).  Typical
+          value = 40.
+      oelin:
+        slot_uri: cim:ExcST7B.oelin
+        range: ExcST7BOELselectorKind
+        multivalued: false
+        required: true
+        description: OEL input selector (<i>OELin</i>). Typical value = noOELinput.
+      tb:
+        slot_uri: cim:ExcST7B.tb
+        range: Seconds
+        multivalued: false
+        required: true
+        description: Regulator lag time constant (<i>Tb</i>) (&gt;= 0).  Typical value
+          = 1.
+      tc:
+        slot_uri: cim:ExcST7B.tc
+        range: Seconds
+        multivalued: false
+        required: true
+        description: Regulator lead time constant (<i>Tc</i>) (&gt;= 0).  Typical
+          value = 1.
+      tf:
+        slot_uri: cim:ExcST7B.tf
+        range: Seconds
+        multivalued: false
+        required: true
+        description: Excitation control system stabilizer time constant (<i>Tf</i>)
+          (&gt;= 0).  Typical value = 1.
+      tg:
+        slot_uri: cim:ExcST7B.tg
+        range: Seconds
+        multivalued: false
+        required: true
+        description: Feedback time constant of inner loop field voltage regulator
+          (<i>Tg</i>) (&gt;= 0).  Typical value = 1.
+      tia:
+        slot_uri: cim:ExcST7B.tia
+        range: Seconds
+        multivalued: false
+        required: true
+        description: Feedback time constant (<i>Tia</i>) (&gt;= 0).  Typical value
+          = 3.
+      ts:
+        slot_uri: cim:ExcST7B.ts
+        range: Seconds
+        multivalued: false
+        required: true
+        description: Rectifier firing time constant (<i>Ts</i>) (&gt;= 0).  Typical
+          value = 0.
+      uelin:
+        slot_uri: cim:ExcST7B.uelin
+        range: ExcST7BUELselectorKind
+        multivalued: false
+        required: true
+        description: UEL input selector (<i>UELin</i>). Typical value = noUELinput.
+      vmax:
+        slot_uri: cim:ExcST7B.vmax
+        range: PU
+        multivalued: false
+        required: true
+        description: Maximum voltage reference signal (<i>Vmax</i>) (&gt; 0 and &gt;
+          ExcST7B.vmin)).  Typical value = 1,1.
+      vmin:
+        slot_uri: cim:ExcST7B.vmin
+        range: PU
+        multivalued: false
+        required: true
+        description: Minimum voltage reference signal (<i>Vmin</i>) (&gt; 0 and &lt;
+          ExcST7B.vmax).  Typical value = 0,9.
+      vrmax:
+        slot_uri: cim:ExcST7B.vrmax
+        range: PU
+        multivalued: false
+        required: true
+        description: Maximum voltage regulator output (<i>Vrmax</i>) (&gt; 0).  Typical
+          value = 5.
+      vrmin:
+        slot_uri: cim:ExcST7B.vrmin
+        range: PU
+        multivalued: false
+        required: true
+        description: Minimum voltage regulator output (<i>Vrmin</i>) (&lt; 0).  Typical
+          value = -4,5.
+    is_a: ExcitationSystemDynamics
+    description: Modified IEEE ST7B static excitation system without stator current
+      limiter (SCL) and current compensator (DROOP) inputs.
+  OverexcitationLimiterDynamics:
+    class_uri: cim:OverexcitationLimiterDynamics
+    attributes:
+      ExcitationSystemDynamics:
+        slot_uri: cim:OverexcitationLimiterDynamics.ExcitationSystemDynamics
+        range: ExcitationSystemDynamics
+        multivalued: false
+        required: true
+        description: Excitation system model with which this overexcitation limiter
+          model is associated.
+    is_a: DynamicsFunctionBlock
+    description: Overexcitation limiter function block whose behaviour is described
+      by reference to a standard model <font color="#0f0f0f">or by definition of a
+      user-defined model.</font>
+  OverexcLimIEEE:
+    class_uri: cim:OverexcLimIEEE
+    attributes:
+      itfpu:
+        slot_uri: cim:OverexcLimIEEE.itfpu
+        range: PU
+        multivalued: false
+        required: true
+        description: OEL timed field current limiter pickup level (<i>I</i><i><sub>TFPU</sub></i>).  Typical
+          value = 1,05.
+      ifdmax:
+        slot_uri: cim:OverexcLimIEEE.ifdmax
+        range: PU
+        multivalued: false
+        required: true
+        description: OEL instantaneous field current limit (<i>I</i><i><sub>FDMAX</sub></i>).  Typical
+          value = 1,5.
+      ifdlim:
+        slot_uri: cim:OverexcLimIEEE.ifdlim
+        range: PU
+        multivalued: false
+        required: true
+        description: OEL timed field current limit (<i>I</i><i><sub>FDLIM</sub></i>).  Typical
+          value = 1,05.
+      hyst:
+        slot_uri: cim:OverexcLimIEEE.hyst
+        range: PU
+        multivalued: false
+        required: true
+        description: OEL pickup/drop-out hysteresis (<i>HYST</i>).  Typical value
+          = 0,03.
+      kcd:
+        slot_uri: cim:OverexcLimIEEE.kcd
+        range: PU
+        multivalued: false
+        required: true
+        description: OEL cooldown gain (<i>K</i><i><sub>CD</sub></i>).  Typical value
+          = 1.
+      kramp:
+        slot_uri: cim:OverexcLimIEEE.kramp
+        range: float
+        multivalued: false
+        required: true
+        description: OEL ramped limit rate (<i>K</i><i><sub>RAMP</sub></i>).  Unit
+          = PU / s.  Typical value = 10.
+    is_a: OverexcitationLimiterDynamics
+    description: 'The over excitation limiter model is intended to represent the significant
+      features of OELs necessary for some large-scale system studies. It is the result
+      of a pragmatic approach to obtain a model that can be widely applied with attainable
+      data from generator owners. An attempt to include all variations in the functionality
+      of OELs and duplicate how they interact with the rest of the excitation systems
+      would likely result in a level of application insufficient for the studies for
+      which they are intended.
+
+      Reference: IEEE OEL 421.5-2005, 9.'
+  OverexcLim2:
+    class_uri: cim:OverexcLim2
+    attributes:
+      koi:
+        slot_uri: cim:OverexcLim2.koi
+        range: PU
+        multivalued: false
+        required: true
+        description: Gain Over excitation limiter (<i>K</i><i><sub>OI</sub></i>).  Typical
+          value = 0,1.
+      voimax:
+        slot_uri: cim:OverexcLim2.voimax
+        range: PU
+        multivalued: false
+        required: true
+        description: Maximum error signal (<i>V</i><i><sub>OIMAX</sub></i>) (&gt;
+          OverexcLim2.voimin).  Typical value = 0.
+      voimin:
+        slot_uri: cim:OverexcLim2.voimin
+        range: PU
+        multivalued: false
+        required: true
+        description: Minimum error signal (<i>V</i><i><sub>OIMIN</sub></i>) (&lt;
+          OverexcLim2.voimax).  Typical value = -9999.
+      ifdlim:
+        slot_uri: cim:OverexcLim2.ifdlim
+        range: PU
+        multivalued: false
+        required: true
+        description: Limit value of rated field current (<i>I</i><i><sub>FDLIM</sub></i>).  Typical
+          value = 1,05.
+    is_a: OverexcitationLimiterDynamics
+    description: 'Different from LimIEEEOEL, LimOEL2 has a fixed pickup threshold
+      and reduces the excitation set-point by means of a non-windup integral regulator.
+
+      <i>Irated</i> is the rated machine excitation current (calculated from nameplate
+      conditions: <i>V</i><i><sub>nom</sub></i>, <i>P</i><i><sub>nom</sub></i>, <i>CosPhi</i><i><sub>nom</sub></i>).'
+  OverexcLimX1:
+    class_uri: cim:OverexcLimX1
+    attributes:
+      efdrated:
+        slot_uri: cim:OverexcLimX1.efdrated
+        range: PU
+        multivalued: false
+        required: true
+        description: Rated field voltage (<i>EFD</i><i><sub>RATED</sub></i>).  Typical
+          value = 1,05.
+      efd1:
+        slot_uri: cim:OverexcLimX1.efd1
+        range: PU
+        multivalued: false
+        required: true
+        description: Low voltage point on the inverse time characteristic (<i>EFD</i><i><sub>1</sub></i>).  Typical
+          value = 1,1.
+      t1:
+        slot_uri: cim:OverexcLimX1.t1
+        range: Seconds
+        multivalued: false
+        required: true
+        description: Time to trip the exciter at the low voltage point on the inverse
+          time characteristic (<i>TIME</i><i><sub>1</sub></i>) (&gt;= 0).  Typical
+          value = 120.
+      efd2:
+        slot_uri: cim:OverexcLimX1.efd2
+        range: PU
+        multivalued: false
+        required: true
+        description: Mid voltage point on the inverse time characteristic (<i>EFD</i><i><sub>2</sub></i>).  Typical
+          value = 1,2.
+      t2:
+        slot_uri: cim:OverexcLimX1.t2
+        range: Seconds
+        multivalued: false
+        required: true
+        description: Time to trip the exciter at the mid voltage point on the inverse
+          time characteristic (<i>TIME</i><i><sub>2</sub></i>) (&gt;= 0).  Typical
+          value = 40.
+      efd3:
+        slot_uri: cim:OverexcLimX1.efd3
+        range: PU
+        multivalued: false
+        required: true
+        description: High voltage point on the inverse time characteristic (<i>EFD</i><i><sub>3</sub></i>).  Typical
+          value = 1,5.
+      t3:
+        slot_uri: cim:OverexcLimX1.t3
+        range: Seconds
+        multivalued: false
+        required: true
+        description: Time to trip the exciter at the high voltage point on the inverse
+          time characteristic (<i>TIME</i><i><sub>3</sub></i>) (&gt;= 0).  Typical
+          value = 15.
+      efddes:
+        slot_uri: cim:OverexcLimX1.efddes
+        range: PU
+        multivalued: false
+        required: true
+        description: Desired field voltage (<i>EFD</i><i><sub>DES</sub></i>).  Typical
+          value = 0,9.
+      kmx:
+        slot_uri: cim:OverexcLimX1.kmx
+        range: PU
+        multivalued: false
+        required: true
+        description: Gain (<i>K</i><i><sub>MX</sub></i>).  Typical value = 0,01.
+      vlow:
+        slot_uri: cim:OverexcLimX1.vlow
+        range: PU
+        multivalued: false
+        required: true
+        description: Low voltage limit (<i>V</i><i><sub>LOW</sub></i>) (&gt; 0).
+    is_a: OverexcitationLimiterDynamics
+    description: Field voltage over excitation limiter.
+  OverexcLimX2:
+    class_uri: cim:OverexcLimX2
+    attributes:
+      m:
+        slot_uri: cim:OverexcLimX2.m
+        range: boolean
+        multivalued: false
+        required: true
+        description: '(<i>m</i>).
+
+          true = IFD limiting
+
+          false = EFD limiting.'
+      efdrated:
+        slot_uri: cim:OverexcLimX2.efdrated
+        range: PU
+        multivalued: false
+        required: true
+        description: Rated field voltage if m = false or rated field current if m
+          = true (<i>EFD</i><i><sub>RATED</sub></i>).  Typical value = 1,05.
+      efd1:
+        slot_uri: cim:OverexcLimX2.efd1
+        range: PU
+        multivalued: false
+        required: true
+        description: Low voltage or current point on the inverse time characteristic
+          (<i>EFD</i><i><sub>1</sub></i>).  Typical value = 1,1.
+      t1:
+        slot_uri: cim:OverexcLimX2.t1
+        range: Seconds
+        multivalued: false
+        required: true
+        description: Time to trip the exciter at the low voltage or current point
+          on the inverse time characteristic (<i>TIME</i><i><sub>1</sub></i>) (&gt;=
+          0).  Typical value = 120.
+      efd2:
+        slot_uri: cim:OverexcLimX2.efd2
+        range: PU
+        multivalued: false
+        required: true
+        description: Mid voltage or current point on the inverse time characteristic
+          (<i>EFD</i><i><sub>2</sub></i>).  Typical value = 1,2.
+      t2:
+        slot_uri: cim:OverexcLimX2.t2
+        range: Seconds
+        multivalued: false
+        required: true
+        description: Time to trip the exciter at the mid voltage or current point
+          on the inverse time characteristic (<i>TIME</i><i><sub>2</sub></i>) (&gt;=
+          0).  Typical value = 40.
+      efd3:
+        slot_uri: cim:OverexcLimX2.efd3
+        range: PU
+        multivalued: false
+        required: true
+        description: High voltage or current point on the inverse time characteristic
+          (<i>EFD</i><i><sub>3</sub></i>).  Typical value = 1,5.
+      t3:
+        slot_uri: cim:OverexcLimX2.t3
+        range: Seconds
+        multivalued: false
+        required: true
+        description: Time to trip the exciter at the high voltage or current point
+          on the inverse time characteristic (<i>TIME</i><i><sub>3</sub></i>) (&gt;=
+          0).  Typical value = 15.
+      efddes:
+        slot_uri: cim:OverexcLimX2.efddes
+        range: PU
+        multivalued: false
+        required: true
+        description: Desired field voltage if <i>m</i> = false or desired field current
+          if <i>m </i>= true (<i>EFD</i><i><sub>DES</sub></i>).  Typical value = 1.
+      kmx:
+        slot_uri: cim:OverexcLimX2.kmx
+        range: PU
+        multivalued: false
+        required: true
+        description: Gain (<i>K</i><i><sub>MX</sub></i>).  Typical value = 0,002.
+      vlow:
+        slot_uri: cim:OverexcLimX2.vlow
+        range: PU
+        multivalued: false
+        required: true
+        description: Low voltage limit (<i>V</i><i><sub>LOW</sub></i>) (&gt; 0).
+    is_a: OverexcitationLimiterDynamics
+    description: Field voltage or current overexcitation limiter designed to protect
+      the generator field of an AC machine with automatic excitation control from
+      overheating due to prolonged overexcitation.
+  UnderexcitationLimiterDynamics:
+    class_uri: cim:UnderexcitationLimiterDynamics
+    attributes:
+      RemoteInputSignal:
+        slot_uri: cim:UnderexcitationLimiterDynamics.RemoteInputSignal
+        range: RemoteInputSignal
+        multivalued: false
+        required: false
+        description: Remote input signal used by this underexcitation limiter model.
+      ExcitationSystemDynamics:
+        slot_uri: cim:UnderexcitationLimiterDynamics.ExcitationSystemDynamics
+        range: ExcitationSystemDynamics
+        multivalued: false
+        required: true
+        description: Excitation system model with which this underexcitation limiter
+          model is associated.
+    is_a: DynamicsFunctionBlock
+    description: Underexcitation limiter function block whose behaviour is described
+      by reference to a standard model <font color="#0f0f0f">or by definition of a
+      user-defined model.</font>
+  UnderexcLimIEEE1:
+    class_uri: cim:UnderexcLimIEEE1
+    attributes:
+      kur:
+        slot_uri: cim:UnderexcLimIEEE1.kur
+        range: PU
+        multivalued: false
+        required: true
+        description: UEL radius setting (<i>K</i><i><sub>UR</sub></i>).  Typical value
+          = 1,95.
+      kuc:
+        slot_uri: cim:UnderexcLimIEEE1.kuc
+        range: PU
+        multivalued: false
+        required: true
+        description: UEL centre setting (<i>K</i><i><sub>UC</sub></i>).  Typical value
+          = 1,38.
+      kuf:
+        slot_uri: cim:UnderexcLimIEEE1.kuf
+        range: PU
+        multivalued: false
+        required: true
+        description: UEL excitation system stabilizer gain (<i>K</i><i><sub>UF</sub></i>).  Typical
+          value = 3,3.
+      vurmax:
+        slot_uri: cim:UnderexcLimIEEE1.vurmax
+        range: PU
+        multivalued: false
+        required: true
+        description: UEL maximum limit for radius phasor magnitude (<i>V</i><i><sub>URMAX</sub></i>).  Typical
+          value = 5,8.
+      vucmax:
+        slot_uri: cim:UnderexcLimIEEE1.vucmax
+        range: PU
+        multivalued: false
+        required: true
+        description: UEL maximum limit for operating point phasor magnitude (<i>V</i><i><sub>UCMAX</sub></i>).  Typical
+          value = 5,8.
+      kui:
+        slot_uri: cim:UnderexcLimIEEE1.kui
+        range: PU
+        multivalued: false
+        required: true
+        description: UEL integral gain (<i>K</i><i><sub>UI</sub></i>).  Typical value
+          = 0.
+      kul:
+        slot_uri: cim:UnderexcLimIEEE1.kul
+        range: PU
+        multivalued: false
+        required: true
+        description: UEL proportional gain (<i>K</i><i><sub>UL</sub></i>).  Typical
+          value = 100.
+      vuimax:
+        slot_uri: cim:UnderexcLimIEEE1.vuimax
+        range: PU
+        multivalued: false
+        required: true
+        description: UEL integrator output maximum limit (<i>V</i><i><sub>UIMAX</sub></i>)
+          (&gt; UnderexcLimIEEE1.vuimin).
+      vuimin:
+        slot_uri: cim:UnderexcLimIEEE1.vuimin
+        range: PU
+        multivalued: false
+        required: true
+        description: UEL integrator output minimum limit (<i>V</i><i><sub>UIMIN</sub></i>)
+          (&lt; UnderexcLimIEEE1.vuimax).
+      tu1:
+        slot_uri: cim:UnderexcLimIEEE1.tu1
+        range: Seconds
+        multivalued: false
+        required: true
+        description: UEL lead time constant (<i>T</i><i><sub>U1</sub></i>) (&gt;=
+          0).  Typical value = 0.
+      tu2:
+        slot_uri: cim:UnderexcLimIEEE1.tu2
+        range: Seconds
+        multivalued: false
+        required: true
+        description: UEL lag time constant (<i>T</i><i><sub>U2</sub></i>) (&gt;= 0).  Typical
+          value = 0,05.
+      tu3:
+        slot_uri: cim:UnderexcLimIEEE1.tu3
+        range: Seconds
+        multivalued: false
+        required: true
+        description: UEL lead time constant (<i>T</i><i><sub>U3</sub></i>) (&gt;=
+          0).  Typical value = 0.
+      tu4:
+        slot_uri: cim:UnderexcLimIEEE1.tu4
+        range: Seconds
+        multivalued: false
+        required: true
+        description: UEL lag time constant (<i>T</i><i><sub>U4</sub></i>) (&gt;= 0).  Typical
+          value = 0.
+      vulmax:
+        slot_uri: cim:UnderexcLimIEEE1.vulmax
+        range: PU
+        multivalued: false
+        required: true
+        description: UEL output maximum limit (<i>V</i><i><sub>ULMAX</sub></i>) (&gt;
+          UnderexcLimIEEE1.vulmin).  Typical value = 18.
+      vulmin:
+        slot_uri: cim:UnderexcLimIEEE1.vulmin
+        range: PU
+        multivalued: false
+        required: true
+        description: UEL output minimum limit (<i>V</i><i><sub>ULMIN</sub></i>) (&lt;
+          UnderexcLimIEEE1.vulmax).  Typical value = -18.
+    is_a: UnderexcitationLimiterDynamics
+    description: 'Type UEL1 model which has a circular limit boundary when plotted
+      in terms of machine reactive power vs. real power output.
+
+      Reference: IEEE UEL1 421.5-2005, 10.1.'
+  UnderexcLimIEEE2:
+    class_uri: cim:UnderexcLimIEEE2
+    attributes:
+      tuv:
+        slot_uri: cim:UnderexcLimIEEE2.tuv
+        range: Seconds
+        multivalued: false
+        required: true
+        description: Voltage filter time constant (<i>T</i><i><sub>UV</sub></i>) (&gt;=
+          0).  Typical value = 5.
+      tup:
+        slot_uri: cim:UnderexcLimIEEE2.tup
+        range: Seconds
+        multivalued: false
+        required: true
+        description: Real power filter time constant (<i>T</i><i><sub>UP</sub></i>)
+          (&gt;= 0).  Typical value = 5.
+      tuq:
+        slot_uri: cim:UnderexcLimIEEE2.tuq
+        range: Seconds
+        multivalued: false
+        required: true
+        description: Reactive power filter time constant (<i>T</i><i><sub>UQ</sub></i>)
+          (&gt;= 0).  Typical value = 0.
+      kui:
+        slot_uri: cim:UnderexcLimIEEE2.kui
+        range: PU
+        multivalued: false
+        required: true
+        description: UEL integral gain (<i>K</i><i><sub>UI</sub></i>).  Typical value
+          = 0,5.
+      kul:
+        slot_uri: cim:UnderexcLimIEEE2.kul
+        range: PU
+        multivalued: false
+        required: true
+        description: UEL proportional gain (<i>K</i><i><sub>UL</sub></i>).  Typical
+          value = 0,8.
+      vuimax:
+        slot_uri: cim:UnderexcLimIEEE2.vuimax
+        range: PU
+        multivalued: false
+        required: true
+        description: UEL integrator output maximum limit (<i>V</i><i><sub>UIMAX</sub></i>)
+          (&gt; UnderexcLimIEEE2.vuimin).  Typical value = 0,25.
+      vuimin:
+        slot_uri: cim:UnderexcLimIEEE2.vuimin
+        range: PU
+        multivalued: false
+        required: true
+        description: UEL integrator output minimum limit (<i>V</i><i><sub>UIMIN</sub></i>)
+          (&lt; UnderexcLimIEEE2.vuimax).  Typical value = 0.
+      kuf:
+        slot_uri: cim:UnderexcLimIEEE2.kuf
+        range: PU
+        multivalued: false
+        required: true
+        description: UEL excitation system stabilizer gain (<i>K</i><i><sub>UF</sub></i>).  Typical
+          value = 0.
+      kfb:
+        slot_uri: cim:UnderexcLimIEEE2.kfb
+        range: PU
+        multivalued: false
+        required: true
+        description: Gain associated with optional integrator feedback input signal
+          to UEL (<i>K</i><i><sub>FB</sub></i>).  Typical value = 0.
+      tul:
+        slot_uri: cim:UnderexcLimIEEE2.tul
+        range: Seconds
+        multivalued: false
+        required: true
+        description: Time constant associated with optional integrator feedback input
+          signal to UEL (<i>T</i><i><sub>UL</sub></i>) (&gt;= 0).  Typical value =
+          0.
+      tu1:
+        slot_uri: cim:UnderexcLimIEEE2.tu1
+        range: Seconds
+        multivalued: false
+        required: true
+        description: UEL lead time constant (<i>T</i><i><sub>U1</sub></i>) (&gt;=
+          0).  Typical value = 0.
+      tu2:
+        slot_uri: cim:UnderexcLimIEEE2.tu2
+        range: Seconds
+        multivalued: false
+        required: true
+        description: UEL lag time constant (<i>T</i><i><sub>U2</sub></i>) (&gt;= 0).  Typical
+          value = 0.
+      tu3:
+        slot_uri: cim:UnderexcLimIEEE2.tu3
+        range: Seconds
+        multivalued: false
+        required: true
+        description: UEL lead time constant (<i>T</i><i><sub>U3</sub></i>) (&gt;=
+          0).  Typical value = 0.
+      tu4:
+        slot_uri: cim:UnderexcLimIEEE2.tu4
+        range: Seconds
+        multivalued: false
+        required: true
+        description: UEL lag time constant (<i>T</i><i><sub>U4</sub></i>) (&gt;= 0).  Typical
+          value = 0.
+      vulmax:
+        slot_uri: cim:UnderexcLimIEEE2.vulmax
+        range: PU
+        multivalued: false
+        required: true
+        description: UEL output maximum limit (<i>V</i><i><sub>ULMAX</sub></i>) (&gt;
+          UnderexcLimIEEE2.vulmin).  Typical value = 0,25.
+      vulmin:
+        slot_uri: cim:UnderexcLimIEEE2.vulmin
+        range: PU
+        multivalued: false
+        required: true
+        description: UEL output minimum limit (<i>V</i><i><sub>ULMIN</sub></i>) (&lt;
+          UnderexcLimIEEE2.vulmax).  Typical value = 0.
+      p0:
+        slot_uri: cim:UnderexcLimIEEE2.p0
+        range: PU
+        multivalued: false
+        required: true
+        description: Real power values for endpoints (<i>P</i><i><sub>0</sub></i>).  Typical
+          value = 0.
+      q0:
+        slot_uri: cim:UnderexcLimIEEE2.q0
+        range: PU
+        multivalued: false
+        required: true
+        description: Reactive power values for endpoints (<i>Q</i><i><sub>0</sub></i>).  Typical
+          value = -0,31.
+      p1:
+        slot_uri: cim:UnderexcLimIEEE2.p1
+        range: PU
+        multivalued: false
+        required: true
+        description: Real power values for endpoints (<i>P</i><i><sub>1</sub></i>).  Typical
+          value = 0,3.
+      q1:
+        slot_uri: cim:UnderexcLimIEEE2.q1
+        range: PU
+        multivalued: false
+        required: true
+        description: Reactive power values for endpoints (<i>Q</i><i><sub>1</sub></i>).  Typical
+          value = -0,31.
+      p2:
+        slot_uri: cim:UnderexcLimIEEE2.p2
+        range: PU
+        multivalued: false
+        required: true
+        description: Real power values for endpoints (<i>P</i><i><sub>2</sub></i>).  Typical
+          value = 0,6.
+      q2:
+        slot_uri: cim:UnderexcLimIEEE2.q2
+        range: PU
+        multivalued: false
+        required: true
+        description: Reactive power values for endpoints (<i>Q</i><i><sub>2</sub></i>).  Typical
+          value = -0,28.
+      p3:
+        slot_uri: cim:UnderexcLimIEEE2.p3
+        range: PU
+        multivalued: false
+        required: true
+        description: Real power values for endpoints (<i>P</i><i><sub>3</sub></i>).  Typical
+          value = 0,9.
+      q3:
+        slot_uri: cim:UnderexcLimIEEE2.q3
+        range: PU
+        multivalued: false
+        required: true
+        description: Reactive power values for endpoints (<i>Q</i><i><sub>3</sub></i>).  Typical
+          value = -0,21.
+      p4:
+        slot_uri: cim:UnderexcLimIEEE2.p4
+        range: PU
+        multivalued: false
+        required: true
+        description: Real power values for endpoints (<i>P</i><i><sub>4</sub></i>).  Typical
+          value = 1,02.
+      q4:
+        slot_uri: cim:UnderexcLimIEEE2.q4
+        range: PU
+        multivalued: false
+        required: true
+        description: Reactive power values for endpoints (<i>Q</i><i><sub>4</sub></i>).  Typical
+          value = 0.
+      p5:
+        slot_uri: cim:UnderexcLimIEEE2.p5
+        range: PU
+        multivalued: false
+        required: true
+        description: Real power values for endpoints (<i>P</i><i><sub>5</sub></i>).
+      q5:
+        slot_uri: cim:UnderexcLimIEEE2.q5
+        range: PU
+        multivalued: false
+        required: true
+        description: Reactive power values for endpoints (<i>Q</i><i><sub>5</sub></i>).
+      p6:
+        slot_uri: cim:UnderexcLimIEEE2.p6
+        range: PU
+        multivalued: false
+        required: true
+        description: Real power values for endpoints (<i>P</i><i><sub>6</sub></i>).
+      q6:
+        slot_uri: cim:UnderexcLimIEEE2.q6
+        range: PU
+        multivalued: false
+        required: true
+        description: Reactive power values for endpoints (<i>Q</i><i><sub>6</sub></i>).
+      p7:
+        slot_uri: cim:UnderexcLimIEEE2.p7
+        range: PU
+        multivalued: false
+        required: true
+        description: Real power values for endpoints (<i>P</i><i><sub>7</sub></i>).
+      q7:
+        slot_uri: cim:UnderexcLimIEEE2.q7
+        range: PU
+        multivalued: false
+        required: true
+        description: Reactive power values for endpoints (<i>Q</i><i><sub>7</sub></i>).
+      p8:
+        slot_uri: cim:UnderexcLimIEEE2.p8
+        range: PU
+        multivalued: false
+        required: true
+        description: Real power values for endpoints (<i>P</i><i><sub>8</sub></i>).
+      q8:
+        slot_uri: cim:UnderexcLimIEEE2.q8
+        range: PU
+        multivalued: false
+        required: true
+        description: Reactive power values for endpoints (<i>Q</i><i><sub>8</sub></i>).
+      p9:
+        slot_uri: cim:UnderexcLimIEEE2.p9
+        range: PU
+        multivalued: false
+        required: true
+        description: Real power values for endpoints (<i>P</i><i><sub>9</sub></i>).
+      q9:
+        slot_uri: cim:UnderexcLimIEEE2.q9
+        range: PU
+        multivalued: false
+        required: true
+        description: Reactive power values for endpoints (<i>Q</i><i><sub>9</sub></i>).
+      p10:
+        slot_uri: cim:UnderexcLimIEEE2.p10
+        range: PU
+        multivalued: false
+        required: true
+        description: Real power values for endpoints (<i>P</i><i><sub>10</sub></i>).
+      q10:
+        slot_uri: cim:UnderexcLimIEEE2.q10
+        range: PU
+        multivalued: false
+        required: true
+        description: Reactive power values for endpoints (<i>Q</i><i><sub>10</sub></i>).
+      k1:
+        slot_uri: cim:UnderexcLimIEEE2.k1
+        range: float
+        multivalued: false
+        required: true
+        description: UEL terminal voltage exponent applied to real power input to
+          UEL limit look-up table (<i>k1</i>).  Typical value = 2.
+      k2:
+        slot_uri: cim:UnderexcLimIEEE2.k2
+        range: float
+        multivalued: false
+        required: true
+        description: UEL terminal voltage exponent applied to reactive power output
+          from UEL limit look-up table (<i>k2</i>).  Typical value = 2.
+    is_a: UnderexcitationLimiterDynamics
+    description: 'Type UEL2 underexcitation limiter which has either a straight-line
+      or multi-segment characteristic when plotted in terms of machine reactive power
+      output vs. real power output.
+
+      Reference: IEEE UEL2 421.5-2005, 10.2  (limit characteristic lookup table shown
+      in Figure 10.4 (p 32)).'
+  UnderexcLim2Simplified:
+    class_uri: cim:UnderexcLim2Simplified
+    attributes:
+      q0:
+        slot_uri: cim:UnderexcLim2Simplified.q0
+        range: PU
+        multivalued: false
+        required: true
+        description: Segment Q initial point (<i>Q</i><i><sub>0</sub></i>).  Typical
+          value = -0,31.
+      q1:
+        slot_uri: cim:UnderexcLim2Simplified.q1
+        range: PU
+        multivalued: false
+        required: true
+        description: Segment Q end point (<i>Q</i><i><sub>1</sub></i>).  Typical value
+          = -0,1.
+      p0:
+        slot_uri: cim:UnderexcLim2Simplified.p0
+        range: PU
+        multivalued: false
+        required: true
+        description: Segment P initial point (<i>P</i><i><sub>0</sub></i>).  Typical
+          value = 0.
+      p1:
+        slot_uri: cim:UnderexcLim2Simplified.p1
+        range: PU
+        multivalued: false
+        required: true
+        description: Segment P end point (<i>P</i><i><sub>1</sub></i>).  Typical value
+          = 1.
+      kui:
+        slot_uri: cim:UnderexcLim2Simplified.kui
+        range: PU
+        multivalued: false
+        required: true
+        description: Gain Under excitation limiter (<i>K</i><i><sub>UI</sub></i>).  Typical
+          value = 0,1.
+      vuimin:
+        slot_uri: cim:UnderexcLim2Simplified.vuimin
+        range: PU
+        multivalued: false
+        required: true
+        description: Minimum error signal (<i>V</i><i><sub>UIMIN</sub></i>) (&lt;
+          UnderexcLim2Simplified.vuimax).  Typical value = 0.
+      vuimax:
+        slot_uri: cim:UnderexcLim2Simplified.vuimax
+        range: PU
+        multivalued: false
+        required: true
+        description: Maximum error signal (<i>V</i><i><sub>UIMAX</sub></i>) (&gt;
+          UnderexcLim2Simplified.vuimin).  Typical value = 1.
+    is_a: UnderexcitationLimiterDynamics
+    description: "Simplified type UEL2 underexcitation limiter.  This model can be\
+      \ derived from UnderexcLimIEEE2.  The limit characteristic (look \u2013up table)\
+      \ is a single straight-line, the same as UnderexcLimIEEE2 (see Figure 10.4 (p\
+      \ 32), IEEE 421.5-2005 Section 10.2)."
+  UnderexcLimX1:
+    class_uri: cim:UnderexcLimX1
+    attributes:
+      kf2:
+        slot_uri: cim:UnderexcLimX1.kf2
+        range: PU
+        multivalued: false
+        required: true
+        description: Differential gain (<i>K</i><i><sub>F2</sub></i>).
+      tf2:
+        slot_uri: cim:UnderexcLimX1.tf2
+        range: Seconds
+        multivalued: false
+        required: true
+        description: Differential time constant (<i>T</i><i><sub>F2</sub></i>) (&gt;=
+          0).
+      km:
+        slot_uri: cim:UnderexcLimX1.km
+        range: PU
+        multivalued: false
+        required: true
+        description: Minimum excitation limit gain (<i>K</i><i><sub>M</sub></i>).
+      tm:
+        slot_uri: cim:UnderexcLimX1.tm
+        range: Seconds
+        multivalued: false
+        required: true
+        description: Minimum excitation limit time constant (<i>T</i><i><sub>M</sub></i>)
+          (&gt;= 0).
+      melmax:
+        slot_uri: cim:UnderexcLimX1.melmax
+        range: PU
+        multivalued: false
+        required: true
+        description: Minimum excitation limit value (<i>MELMAX</i>).
+      k:
+        slot_uri: cim:UnderexcLimX1.k
+        range: PU
+        multivalued: false
+        required: true
+        description: Minimum excitation limit slope (<i>K</i>) (&gt; 0).
+    is_a: UnderexcitationLimiterDynamics
+    description: <font color="#0f0f0f">Allis-Chalmers minimum excitation limiter.</font>
+  UnderexcLimX2:
+    class_uri: cim:UnderexcLimX2
+    attributes:
+      kf2:
+        slot_uri: cim:UnderexcLimX2.kf2
+        range: PU
+        multivalued: false
+        required: true
+        description: Differential gain (<i>K</i><i><sub>F2</sub></i>).
+      tf2:
+        slot_uri: cim:UnderexcLimX2.tf2
+        range: Seconds
+        multivalued: false
+        required: true
+        description: Differential time constant (<i>T</i><i><sub>F2</sub></i>) (&gt;=
+          0).
+      km:
+        slot_uri: cim:UnderexcLimX2.km
+        range: PU
+        multivalued: false
+        required: true
+        description: Minimum excitation limit gain (<i>K</i><i><sub>M</sub></i>).
+      tm:
+        slot_uri: cim:UnderexcLimX2.tm
+        range: Seconds
+        multivalued: false
+        required: true
+        description: Minimum excitation limit time constant (<i>T</i><i><sub>M</sub></i>)
+          (&gt;= 0).
+      melmax:
+        slot_uri: cim:UnderexcLimX2.melmax
+        range: PU
+        multivalued: false
+        required: true
+        description: Minimum excitation limit value (<i>MELMAX</i>).
+      qo:
+        slot_uri: cim:UnderexcLimX2.qo
+        range: PU
+        multivalued: false
+        required: true
+        description: Excitation centre setting (<i>Q</i><i><sub>O</sub></i>).
+      r:
+        slot_uri: cim:UnderexcLimX2.r
+        range: PU
+        multivalued: false
+        required: true
+        description: Excitation radius (<i>R</i>).
+    is_a: UnderexcitationLimiterDynamics
+    description: <font color="#0f0f0f">Westinghouse minimum excitation limiter.</font>
+  PowerSystemStabilizerDynamics:
+    class_uri: cim:PowerSystemStabilizerDynamics
+    attributes:
+      RemoteInputSignal:
+        slot_uri: cim:PowerSystemStabilizerDynamics.RemoteInputSignal
+        range: RemoteInputSignal
+        multivalued: true
+        required: false
+        description: Remote input signal used by this power system stabilizer model.
+      ExcitationSystemDynamics:
+        slot_uri: cim:PowerSystemStabilizerDynamics.ExcitationSystemDynamics
+        range: ExcitationSystemDynamics
+        multivalued: false
+        required: true
+        description: Excitation system model with which this power system stabilizer
+          model is associated.
+    is_a: DynamicsFunctionBlock
+    description: Power system stabilizer function block whose behaviour is described
+      by reference to a standard model <font color="#0f0f0f">or by definition of a
+      user-defined model.</font>
+  PssIEEE1A:
+    class_uri: cim:PssIEEE1A
+    attributes:
+      inputSignalType:
+        slot_uri: cim:PssIEEE1A.inputSignalType
+        range: InputSignalKind
+        multivalued: false
+        required: true
+        description: Type of input signal (rotorAngularFrequencyDeviation, generatorElectricalPower,
+          or busFrequencyDeviation).  Typical value = rotorAngularFrequencyDeviation.
+      a1:
+        slot_uri: cim:PssIEEE1A.a1
+        range: PU
+        multivalued: false
+        required: true
+        description: PSS signal conditioning frequency filter constant (<i>A1</i>).  Typical
+          value = 0,061.
+      a2:
+        slot_uri: cim:PssIEEE1A.a2
+        range: PU
+        multivalued: false
+        required: true
+        description: PSS signal conditioning frequency filter constant (<i>A2</i>).  Typical
+          value = 0,0017.
+      t1:
+        slot_uri: cim:PssIEEE1A.t1
+        range: Seconds
+        multivalued: false
+        required: true
+        description: Lead/lag time constant (<i>T1</i>) (&gt;= 0).  Typical value
+          = 0,3.
+      t2:
+        slot_uri: cim:PssIEEE1A.t2
+        range: Seconds
+        multivalued: false
+        required: true
+        description: Lead/lag time constant (<i>T2</i>) (&gt;= 0).  Typical value
+          = 0,03.
+      t3:
+        slot_uri: cim:PssIEEE1A.t3
+        range: Seconds
+        multivalued: false
+        required: true
+        description: Lead/lag time constant (<i>T3</i>) (&gt;= 0).  Typical value
+          = 0,3.
+      t4:
+        slot_uri: cim:PssIEEE1A.t4
+        range: Seconds
+        multivalued: false
+        required: true
+        description: Lead/lag time constant (<i>T4</i>) (&gt;= 0).  Typical value
+          = 0,03.
+      t5:
+        slot_uri: cim:PssIEEE1A.t5
+        range: Seconds
+        multivalued: false
+        required: true
+        description: Washout time constant (<i>T5</i>) (&gt;= 0).  Typical value =
+          10.
+      t6:
+        slot_uri: cim:PssIEEE1A.t6
+        range: Seconds
+        multivalued: false
+        required: true
+        description: Transducer time constant (<i>T6</i>) (&gt;= 0).  Typical value
+          = 0,01.
+      ks:
+        slot_uri: cim:PssIEEE1A.ks
+        range: PU
+        multivalued: false
+        required: true
+        description: Stabilizer gain (<i>Ks</i>).  Typical value = 5.
+      vrmax:
+        slot_uri: cim:PssIEEE1A.vrmax
+        range: PU
+        multivalued: false
+        required: true
+        description: Maximum stabilizer output (<i>Vrmax</i>) (&gt; PssIEEE1A.vrmin).  Typical
+          value = 0,05.
+      vrmin:
+        slot_uri: cim:PssIEEE1A.vrmin
+        range: PU
+        multivalued: false
+        required: true
+        description: Minimum stabilizer output (<i>Vrmin</i>) (&lt; PssIEEE1A.vrmax).  Typical
+          value = -0,05.
+    is_a: PowerSystemStabilizerDynamics
+    description: "IEEE 421.5-2005 type PSS1A power system stabilizer model. PSS1A\
+      \ is the generalized form of a PSS with a single input signal. \nReference:\
+      \ IEEE 1A 421.5-2005, 8.1."
+  PssIEEE2B:
+    class_uri: cim:PssIEEE2B
+    attributes:
+      inputSignal1Type:
+        slot_uri: cim:PssIEEE2B.inputSignal1Type
+        range: InputSignalKind
+        multivalued: false
+        required: true
+        description: 'Type of input signal #1 (rotorAngularFrequencyDeviation, busFrequencyDeviation).  Typical
+          value = rotorAngularFrequencyDeviation.'
+      inputSignal2Type:
+        slot_uri: cim:PssIEEE2B.inputSignal2Type
+        range: InputSignalKind
+        multivalued: false
+        required: true
+        description: 'Type of input signal #2 (generatorElectricalPower).  Typical
+          value = generatorElectricalPower.'
+      vsi1max:
+        slot_uri: cim:PssIEEE2B.vsi1max
+        range: PU
+        multivalued: false
+        required: true
+        description: 'Input signal #1 maximum limit (<i>Vsi1max</i>) (&gt; PssIEEE2B.vsi1min).  Typical
+          value = 2.'
+      vsi1min:
+        slot_uri: cim:PssIEEE2B.vsi1min
+        range: PU
+        multivalued: false
+        required: true
+        description: 'Input signal #1 minimum limit (<i>Vsi1min</i>) (&lt; PssIEEE2B.vsi1max).  Typical
+          value = -2.'
+      tw1:
+        slot_uri: cim:PssIEEE2B.tw1
+        range: Seconds
+        multivalued: false
+        required: true
+        description: 'First washout on signal #1 (<i>Tw1</i>) (&gt;= 0).  Typical
+          value = 2.'
+      tw2:
+        slot_uri: cim:PssIEEE2B.tw2
+        range: Seconds
+        multivalued: false
+        required: true
+        description: 'Second washout on signal #1 (<i>Tw2</i>) (&gt;= 0).  Typical
+          value = 2.'
+      vsi2max:
+        slot_uri: cim:PssIEEE2B.vsi2max
+        range: PU
+        multivalued: false
+        required: true
+        description: 'Input signal #2 maximum limit (<i>Vsi2max</i>) (&gt; PssIEEE2B.vsi2min).  Typical
+          value = 2.'
+      vsi2min:
+        slot_uri: cim:PssIEEE2B.vsi2min
+        range: PU
+        multivalued: false
+        required: true
+        description: 'Input signal #2 minimum limit (<i>Vsi2min</i>) (&lt; PssIEEE2B.vsi2max).  Typical
+          value = -2.'
+      tw3:
+        slot_uri: cim:PssIEEE2B.tw3
+        range: Seconds
+        multivalued: false
+        required: true
+        description: 'First washout on signal #2 (<i>Tw3</i>) (&gt;= 0).  Typical
+          value = 2.'
+      tw4:
+        slot_uri: cim:PssIEEE2B.tw4
+        range: Seconds
+        multivalued: false
+        required: true
+        description: 'Second washout on signal #2 (<i>Tw4</i>) (&gt;= 0).  Typical
+          value = 0.'
+      t1:
+        slot_uri: cim:PssIEEE2B.t1
+        range: Seconds
+        multivalued: false
+        required: true
+        description: Lead/lag time constant (<i>T1</i>) (&gt;= 0).  Typical value
+          = 0,12.
+      t2:
+        slot_uri: cim:PssIEEE2B.t2
+        range: Seconds
+        multivalued: false
+        required: true
+        description: Lead/lag time constant (<i>T2</i>) (&gt;= 0).  Typical value
+          = 0,02.
+      t3:
+        slot_uri: cim:PssIEEE2B.t3
+        range: Seconds
+        multivalued: false
+        required: true
+        description: Lead/lag time constant (<i>T3</i>) (&gt;= 0).  Typical value
+          = 0,3.
+      t4:
+        slot_uri: cim:PssIEEE2B.t4
+        range: Seconds
+        multivalued: false
+        required: true
+        description: Lead/lag time constant (<i>T4</i>) (&gt;= 0).  Typical value
+          = 0,02.
+      t6:
+        slot_uri: cim:PssIEEE2B.t6
+        range: Seconds
+        multivalued: false
+        required: true
+        description: 'Time constant on signal #1 (<i>T6</i>) (&gt;= 0).  Typical value
+          = 0.'
+      t7:
+        slot_uri: cim:PssIEEE2B.t7
+        range: Seconds
+        multivalued: false
+        required: true
+        description: 'Time constant on signal #2 (<i>T7</i>) (&gt;= 0).  Typical value
+          = 2.'
+      t8:
+        slot_uri: cim:PssIEEE2B.t8
+        range: Seconds
+        multivalued: false
+        required: true
+        description: Lead of ramp tracking filter (<i>T8</i>) (&gt;= 0).  Typical
+          value = 0,2.
+      t9:
+        slot_uri: cim:PssIEEE2B.t9
+        range: Seconds
+        multivalued: false
+        required: true
+        description: Lag of ramp tracking filter (<i>T9</i>) (&gt;= 0).  Typical value
+          = 0,1.
+      t10:
+        slot_uri: cim:PssIEEE2B.t10
+        range: Seconds
+        multivalued: false
+        required: true
+        description: Lead/lag time constant (<i>T10</i>) (&gt;= 0).  Typical value
+          = 0.
+      t11:
+        slot_uri: cim:PssIEEE2B.t11
+        range: Seconds
+        multivalued: false
+        required: true
+        description: Lead/lag time constant (<i>T11</i>) (&gt;= 0).  Typical value
+          = 0.
+      ks1:
+        slot_uri: cim:PssIEEE2B.ks1
+        range: PU
+        multivalued: false
+        required: true
+        description: Stabilizer gain (<i>Ks1</i>).  Typical value = 12.
+      ks2:
+        slot_uri: cim:PssIEEE2B.ks2
+        range: PU
+        multivalued: false
+        required: true
+        description: 'Gain on signal #2 (<i>Ks2</i>).  Typical value = 0,2.'
+      ks3:
+        slot_uri: cim:PssIEEE2B.ks3
+        range: PU
+        multivalued: false
+        required: true
+        description: 'Gain on signal #2 input before ramp-tracking filter (<i>Ks3</i>).  Typical
+          value = 1.'
+      n:
+        slot_uri: cim:PssIEEE2B.n
+        range: integer
+        multivalued: false
+        required: true
+        description: Order of ramp tracking filter (<i>N</i>).  Typical value = 1.
+      m:
+        slot_uri: cim:PssIEEE2B.m
+        range: integer
+        multivalued: false
+        required: true
+        description: Denominator order of ramp tracking filter (<i>M</i>).  Typical
+          value = 5.
+      vstmax:
+        slot_uri: cim:PssIEEE2B.vstmax
+        range: PU
+        multivalued: false
+        required: true
+        description: Stabilizer output maximum limit (<i>Vstmax</i>) (&gt; PssIEEE2B.vstmin).  Typical
+          value = 0,1.
+      vstmin:
+        slot_uri: cim:PssIEEE2B.vstmin
+        range: PU
+        multivalued: false
+        required: true
+        description: Stabilizer output minimum limit (<i>Vstmin</i>) (&lt; PssIEEE2B.vstmax).  Typical
+          value = -0,1.
+    is_a: PowerSystemStabilizerDynamics
+    description: 'IEEE 421.5-2005 type PSS2B power system stabilizer model. This stabilizer
+      model is designed to represent a variety of dual-input stabilizers, which normally
+      use combinations of power and speed or frequency to derive the stabilizing signal.
+
+      Reference: IEEE 2B 421.5-2005, 8.2.'
+  PssIEEE3B:
+    class_uri: cim:PssIEEE3B
+    attributes:
+      t1:
+        slot_uri: cim:PssIEEE3B.t1
+        range: Seconds
+        multivalued: false
+        required: true
+        description: Transducer time constant (<i>T1</i>) (&gt;= 0).  Typical value
+          = 0,012.
+      t2:
+        slot_uri: cim:PssIEEE3B.t2
+        range: Seconds
+        multivalued: false
+        required: true
+        description: Transducer time constant (<i>T2</i>) (&gt;= 0).  Typical value
+          = 0,012.
+      tw1:
+        slot_uri: cim:PssIEEE3B.tw1
+        range: Seconds
+        multivalued: false
+        required: true
+        description: Washout time constant (<i>Tw1</i>) (&gt;= 0).  Typical value
+          = 0,3.
+      tw2:
+        slot_uri: cim:PssIEEE3B.tw2
+        range: Seconds
+        multivalued: false
+        required: true
+        description: Washout time constant (<i>Tw2</i>) (&gt;= 0).  Typical value
+          = 0,3.
+      tw3:
+        slot_uri: cim:PssIEEE3B.tw3
+        range: Seconds
+        multivalued: false
+        required: true
+        description: Washout time constant (<i>Tw3</i>) (&gt;= 0).  Typical value
+          = 0,6.
+      ks1:
+        slot_uri: cim:PssIEEE3B.ks1
+        range: PU
+        multivalued: false
+        required: true
+        description: 'Gain on signal # 1 (<i>Ks1</i>).  Typical value = -0,602.'
+      ks2:
+        slot_uri: cim:PssIEEE3B.ks2
+        range: PU
+        multivalued: false
+        required: true
+        description: 'Gain on signal # 2 (<i>Ks2</i>).  Typical value = 30,12.'
+      a1:
+        slot_uri: cim:PssIEEE3B.a1
+        range: PU
+        multivalued: false
+        required: true
+        description: Notch filter parameter (<i>A1</i>).  Typical value = 0,359.
+      a2:
+        slot_uri: cim:PssIEEE3B.a2
+        range: PU
+        multivalued: false
+        required: true
+        description: Notch filter parameter (<i>A2</i>).  Typical value = 0,586.
+      a3:
+        slot_uri: cim:PssIEEE3B.a3
+        range: PU
+        multivalued: false
+        required: true
+        description: Notch filter parameter (<i>A3</i>).  Typical value = 0,429.
+      a4:
+        slot_uri: cim:PssIEEE3B.a4
+        range: PU
+        multivalued: false
+        required: true
+        description: Notch filter parameter (<i>A4</i>).  Typical value = 0,564.
+      a5:
+        slot_uri: cim:PssIEEE3B.a5
+        range: PU
+        multivalued: false
+        required: true
+        description: Notch filter parameter (<i>A5</i>).  Typical value = 0,001.
+      a6:
+        slot_uri: cim:PssIEEE3B.a6
+        range: PU
+        multivalued: false
+        required: true
+        description: Notch filter parameter (<i>A6</i>).  Typical value = 0.
+      a7:
+        slot_uri: cim:PssIEEE3B.a7
+        range: PU
+        multivalued: false
+        required: true
+        description: Notch filter parameter (<i>A7</i>).  Typical value = 0,031.
+      a8:
+        slot_uri: cim:PssIEEE3B.a8
+        range: PU
+        multivalued: false
+        required: true
+        description: Notch filter parameter (<i>A8</i>).  Typical value = 0.
+      vstmax:
+        slot_uri: cim:PssIEEE3B.vstmax
+        range: PU
+        multivalued: false
+        required: true
+        description: Stabilizer output maximum limit (<i>Vstmax</i>) (&gt; PssIEEE3B.vstmin).  Typical
+          value = 0,1.
+      vstmin:
+        slot_uri: cim:PssIEEE3B.vstmin
+        range: PU
+        multivalued: false
+        required: true
+        description: Stabilizer output minimum limit (<i>Vstmin</i>) (&lt; PssIEEE3B.vstmax).  Typical
+          value = -0,1.
+    is_a: PowerSystemStabilizerDynamics
+    description: 'IEEE 421.5-2005 type PSS3B power system stabilizer model. The PSS
+      model PSS3B has dual inputs of electrical power and rotor angular frequency
+      deviation. The signals are used to derive an equivalent mechanical power signal.
+
+      This model has 2 input signals. They have the following fixed types (expressed
+      in terms of InputSignalKind values): the first one is of rotorAngleFrequencyDeviation
+      type and the second one is of generatorElectricalPower type.
+
+      Reference: IEEE 3B 421.5-2005, 8.3.'
+  PssIEEE4B:
+    class_uri: cim:PssIEEE4B
+    attributes:
+      bwh1:
+        slot_uri: cim:PssIEEE4B.bwh1
+        range: float
+        multivalued: false
+        required: true
+        description: 'Notch filter 1 (high-frequency band): three dB bandwidth (<i>B</i><i><sub>wi</sub></i>).'
+      bwh2:
+        slot_uri: cim:PssIEEE4B.bwh2
+        range: float
+        multivalued: false
+        required: true
+        description: 'Notch filter 2 (high-frequency band): three dB bandwidth (<i>B</i><i><sub>wi</sub></i>).'
+      bwl1:
+        slot_uri: cim:PssIEEE4B.bwl1
+        range: float
+        multivalued: false
+        required: true
+        description: 'Notch filter 1 (low-frequency band): three dB bandwidth (<i>B</i><i><sub>wi</sub></i>).'
+      bwl2:
+        slot_uri: cim:PssIEEE4B.bwl2
+        range: float
+        multivalued: false
+        required: true
+        description: 'Notch filter 2 (low-frequency band): three dB bandwidth (<i>B</i><i><sub>wi</sub></i>).'
+      kh:
+        slot_uri: cim:PssIEEE4B.kh
+        range: PU
+        multivalued: false
+        required: true
+        description: High band gain (<i>K</i><i><sub>H</sub></i>).  Typical value
+          = 120.
+      kh1:
+        slot_uri: cim:PssIEEE4B.kh1
+        range: PU
+        multivalued: false
+        required: true
+        description: High band differential filter gain (<i>K</i><i><sub>H1</sub></i>).  Typical
+          value = 66.
+      kh11:
+        slot_uri: cim:PssIEEE4B.kh11
+        range: PU
+        multivalued: false
+        required: true
+        description: High band first lead-lag blocks coefficient (<i>K</i><i><sub>H11</sub></i>).  Typical
+          value = 1.
+      kh17:
+        slot_uri: cim:PssIEEE4B.kh17
+        range: PU
+        multivalued: false
+        required: true
+        description: High band first lead-lag blocks coefficient (<i>K</i><i><sub>H17</sub></i>).  Typical
+          value = 1.
+      kh2:
+        slot_uri: cim:PssIEEE4B.kh2
+        range: PU
+        multivalued: false
+        required: true
+        description: High band differential filter gain (<i>K</i><i><sub>H2</sub></i>).  Typical
+          value = 66.
+      ki:
+        slot_uri: cim:PssIEEE4B.ki
+        range: PU
+        multivalued: false
+        required: true
+        description: Intermediate band gain (<i>K</i><i><sub>I</sub></i>).  Typical
+          value = 30.
+      ki1:
+        slot_uri: cim:PssIEEE4B.ki1
+        range: PU
+        multivalued: false
+        required: true
+        description: Intermediate band differential filter gain (<i>K</i><i><sub>I1</sub></i>).  Typical
+          value = 66.
+      ki11:
+        slot_uri: cim:PssIEEE4B.ki11
+        range: PU
+        multivalued: false
+        required: true
+        description: Intermediate band first lead-lag blocks coefficient (<i>K</i><i><sub>I11</sub></i>).  Typical
+          value = 1.
+      ki17:
+        slot_uri: cim:PssIEEE4B.ki17
+        range: PU
+        multivalued: false
+        required: true
+        description: Intermediate band first lead-lag blocks coefficient (<i>K</i><i><sub>I17</sub></i>).  Typical
+          value = 1.
+      ki2:
+        slot_uri: cim:PssIEEE4B.ki2
+        range: PU
+        multivalued: false
+        required: true
+        description: Intermediate band differential filter gain (<i>K</i><i><sub>I2</sub></i>).  Typical
+          value = 66.
+      kl:
+        slot_uri: cim:PssIEEE4B.kl
+        range: PU
+        multivalued: false
+        required: true
+        description: Low band gain (<i>K</i><i><sub>L</sub></i>).  Typical value =
+          7.5.
+      kl1:
+        slot_uri: cim:PssIEEE4B.kl1
+        range: PU
+        multivalued: false
+        required: true
+        description: Low band differential filter gain (<i>K</i><i><sub>L1</sub></i>).  Typical
+          value = 66.
+      kl11:
+        slot_uri: cim:PssIEEE4B.kl11
+        range: PU
+        multivalued: false
+        required: true
+        description: Low band first lead-lag blocks coefficient (<i>K</i><i><sub>L11</sub></i>).  Typical
+          value = 1.
+      kl17:
+        slot_uri: cim:PssIEEE4B.kl17
+        range: PU
+        multivalued: false
+        required: true
+        description: Low band first lead-lag blocks coefficient (<i>K</i><i><sub>L17</sub></i>).  Typical
+          value = 1.
+      kl2:
+        slot_uri: cim:PssIEEE4B.kl2
+        range: PU
+        multivalued: false
+        required: true
+        description: Low band differential filter gain (<i>K</i><i><sub>L2</sub></i>).  Typical
+          value = 66.
+      omeganh1:
+        slot_uri: cim:PssIEEE4B.omeganh1
+        range: float
+        multivalued: false
+        required: true
+        description: 'Notch filter 1 (high-frequency band): filter frequency (<i>omega</i><i><sub>ni</sub></i>).'
+      omeganh2:
+        slot_uri: cim:PssIEEE4B.omeganh2
+        range: float
+        multivalued: false
+        required: true
+        description: 'Notch filter 2 (high-frequency band): filter frequency (<i>omega</i><i><sub>ni</sub></i>).'
+      omeganl1:
+        slot_uri: cim:PssIEEE4B.omeganl1
+        range: float
+        multivalued: false
+        required: true
+        description: 'Notch filter 1 (low-frequency band): filter frequency (<i>omega</i><i><sub>ni</sub></i>).'
+      omeganl2:
+        slot_uri: cim:PssIEEE4B.omeganl2
+        range: float
+        multivalued: false
+        required: true
+        description: 'Notch filter 2 (low-frequency band): filter frequency (<i>omega</i><i><sub>ni</sub></i>).'
+      th1:
+        slot_uri: cim:PssIEEE4B.th1
+        range: Seconds
+        multivalued: false
+        required: true
+        description: High band time constant (<i>T</i><i><sub>H1</sub></i>) (&gt;=
+          0).  Typical value = 0,01513.
+      th10:
+        slot_uri: cim:PssIEEE4B.th10
+        range: Seconds
+        multivalued: false
+        required: true
+        description: High band time constant (<i>T</i><i><sub>H10</sub></i>) (&gt;=
+          0).  Typical value = 0.
+      th11:
+        slot_uri: cim:PssIEEE4B.th11
+        range: Seconds
+        multivalued: false
+        required: true
+        description: High band time constant (<i>T</i><i><sub>H11</sub></i>) (&gt;=
+          0).  Typical value = 0.
+      th12:
+        slot_uri: cim:PssIEEE4B.th12
+        range: Seconds
+        multivalued: false
+        required: true
+        description: High band time constant (<i>T</i><i><sub>H12</sub></i>) (&gt;=
+          0).  Typical value = 0.
+      th2:
+        slot_uri: cim:PssIEEE4B.th2
+        range: Seconds
+        multivalued: false
+        required: true
+        description: High band time constant (<i>T</i><i><sub>H2</sub></i>) (&gt;=
+          0).  Typical value = 0,01816.
+      th3:
+        slot_uri: cim:PssIEEE4B.th3
+        range: Seconds
+        multivalued: false
+        required: true
+        description: High band time constant (<i>T</i><i><sub>H3</sub></i>) (&gt;=
+          0).  Typical value = 0.
+      th4:
+        slot_uri: cim:PssIEEE4B.th4
+        range: Seconds
+        multivalued: false
+        required: true
+        description: High band time constant (<i>T</i><i><sub>H4</sub></i>) (&gt;=
+          0).  Typical value = 0.
+      th5:
+        slot_uri: cim:PssIEEE4B.th5
+        range: Seconds
+        multivalued: false
+        required: true
+        description: High band time constant (<i>T</i><i><sub>H5</sub></i>) (&gt;=
+          0).  Typical value = 0.
+      th6:
+        slot_uri: cim:PssIEEE4B.th6
+        range: Seconds
+        multivalued: false
+        required: true
+        description: High band time constant (<i>T</i><i><sub>H6</sub></i>) (&gt;=
+          0).  Typical value = 0.
+      th7:
+        slot_uri: cim:PssIEEE4B.th7
+        range: Seconds
+        multivalued: false
+        required: true
+        description: High band time constant (<i>T</i><i><sub>H7</sub></i>) (&gt;=
+          0).  Typical value = 0,01816.
+      th8:
+        slot_uri: cim:PssIEEE4B.th8
+        range: Seconds
+        multivalued: false
+        required: true
+        description: High band time constant (<i>T</i><i><sub>H8</sub></i>) (&gt;=
+          0).  Typical value = 0,02179.
+      th9:
+        slot_uri: cim:PssIEEE4B.th9
+        range: Seconds
+        multivalued: false
+        required: true
+        description: High band time constant (<i>T</i><i><sub>H9</sub></i>) (&gt;=
+          0).  Typical value = 0.
+      ti1:
+        slot_uri: cim:PssIEEE4B.ti1
+        range: Seconds
+        multivalued: false
+        required: true
+        description: Intermediate band time constant (<i>T</i><i><sub>I1</sub></i>)
+          (&gt;= 0).  Typical value = 0,173.
+      ti10:
+        slot_uri: cim:PssIEEE4B.ti10
+        range: Seconds
+        multivalued: false
+        required: true
+        description: Intermediate band time constant (<i>T</i><i><sub>I10</sub></i>)
+          (&gt;= 0).  Typical value = 0.
+      ti11:
+        slot_uri: cim:PssIEEE4B.ti11
+        range: Seconds
+        multivalued: false
+        required: true
+        description: Intermediate band time constant (<i>T</i><i><sub>I11</sub></i>)
+          (&gt;= 0).  Typical value = 0.
+      ti12:
+        slot_uri: cim:PssIEEE4B.ti12
+        range: Seconds
+        multivalued: false
+        required: true
+        description: Intermediate band time constant (<i>T</i><i><sub>I12</sub></i>)
+          (&gt;= 0).  Typical value = 0.
+      ti2:
+        slot_uri: cim:PssIEEE4B.ti2
+        range: Seconds
+        multivalued: false
+        required: true
+        description: Intermediate band time constant (<i>T</i><i><sub>I2</sub></i>)
+          (&gt;= 0).  Typical value = 0,2075.
+      ti3:
+        slot_uri: cim:PssIEEE4B.ti3
+        range: Seconds
+        multivalued: false
+        required: true
+        description: Intermediate band time constant (<i>T</i><i><sub>I3</sub></i>)
+          (&gt;= 0).  Typical value = 0.
+      ti4:
+        slot_uri: cim:PssIEEE4B.ti4
+        range: Seconds
+        multivalued: false
+        required: true
+        description: Intermediate band time constant (<i>T</i><i><sub>I4</sub></i>)
+          (&gt;= 0).  Typical value = 0.
+      ti5:
+        slot_uri: cim:PssIEEE4B.ti5
+        range: Seconds
+        multivalued: false
+        required: true
+        description: Intermediate band time constant (<i>T</i><i><sub>I5</sub></i>)
+          (&gt;= 0).  Typical value = 0.
+      ti6:
+        slot_uri: cim:PssIEEE4B.ti6
+        range: Seconds
+        multivalued: false
+        required: true
+        description: Intermediate band time constant (<i>T</i><i><sub>I6</sub></i>)
+          (&gt;= 0).  Typical value = 0.
+      ti7:
+        slot_uri: cim:PssIEEE4B.ti7
+        range: Seconds
+        multivalued: false
+        required: true
+        description: Intermediate band time constant (<i>T</i><i><sub>I7</sub></i>)
+          (&gt;= 0).  Typical value = 0,2075.
+      ti8:
+        slot_uri: cim:PssIEEE4B.ti8
+        range: Seconds
+        multivalued: false
+        required: true
+        description: Intermediate band time constant (<i>T</i><i><sub>I8</sub></i>)
+          (&gt;= 0).  Typical value = 0,2491.
+      ti9:
+        slot_uri: cim:PssIEEE4B.ti9
+        range: Seconds
+        multivalued: false
+        required: true
+        description: Intermediate band time constant (<i>T</i><i><sub>I9</sub></i>)
+          (&gt;= 0).  Typical value = 0.
+      tl1:
+        slot_uri: cim:PssIEEE4B.tl1
+        range: Seconds
+        multivalued: false
+        required: true
+        description: Low band time constant (<i>T</i><i><sub>L1</sub></i>) (&gt;=
+          0).  Typical value = 1,73.
+      tl10:
+        slot_uri: cim:PssIEEE4B.tl10
+        range: Seconds
+        multivalued: false
+        required: true
+        description: Low band time constant (<i>T</i><i><sub>L10</sub></i>) (&gt;=
+          0).  Typical value = 0.
+      tl11:
+        slot_uri: cim:PssIEEE4B.tl11
+        range: Seconds
+        multivalued: false
+        required: true
+        description: Low band time constant (<i>T</i><i><sub>L11</sub></i>) (&gt;=
+          0).  Typical value = 0.
+      tl12:
+        slot_uri: cim:PssIEEE4B.tl12
+        range: Seconds
+        multivalued: false
+        required: true
+        description: Low band time constant (<i>T</i><i><sub>L12</sub></i>) (&gt;=
+          0).  Typical value = 0.
+      tl2:
+        slot_uri: cim:PssIEEE4B.tl2
+        range: Seconds
+        multivalued: false
+        required: true
+        description: Low band time constant (<i>T</i><i><sub>L2</sub></i>) (&gt;=
+          0).  Typical value = 2,075.
+      tl3:
+        slot_uri: cim:PssIEEE4B.tl3
+        range: Seconds
+        multivalued: false
+        required: true
+        description: Low band time constant (<i>T</i><i><sub>L3</sub></i>) (&gt;=
+          0).  Typical value = 0.
+      tl4:
+        slot_uri: cim:PssIEEE4B.tl4
+        range: Seconds
+        multivalued: false
+        required: true
+        description: Low band time constant (<i>T</i><i><sub>L4</sub></i>) (&gt;=
+          0).  Typical value = 0.
+      tl5:
+        slot_uri: cim:PssIEEE4B.tl5
+        range: Seconds
+        multivalued: false
+        required: true
+        description: Low band time constant (<i>T</i><i><sub>L5</sub></i>) (&gt;=
+          0).  Typical value = 0.
+      tl6:
+        slot_uri: cim:PssIEEE4B.tl6
+        range: Seconds
+        multivalued: false
+        required: true
+        description: Low band time constant (<i>T</i><i><sub>L6</sub></i>) (&gt;=
+          0).  Typical value = 0.
+      tl7:
+        slot_uri: cim:PssIEEE4B.tl7
+        range: Seconds
+        multivalued: false
+        required: true
+        description: Low band time constant (<i>T</i><i><sub>L7</sub></i>) (&gt;=
+          0).  Typical value = 2,075.
+      tl8:
+        slot_uri: cim:PssIEEE4B.tl8
+        range: Seconds
+        multivalued: false
+        required: true
+        description: Low band time constant (<i>T</i><i><sub>L8</sub></i>) (&gt;=
+          0).  Typical value = 2,491.
+      tl9:
+        slot_uri: cim:PssIEEE4B.tl9
+        range: Seconds
+        multivalued: false
+        required: true
+        description: Low band time constant (<i>T</i><i><sub>L9</sub></i>) (&gt;=
+          0).  Typical value = 0.
+      vhmax:
+        slot_uri: cim:PssIEEE4B.vhmax
+        range: PU
+        multivalued: false
+        required: true
+        description: High band output maximum limit (<i>V</i><i><sub>Hmax</sub></i>)
+          (&gt; PssIEEE4B.vhmin).  Typical value = 0,6.
+      vhmin:
+        slot_uri: cim:PssIEEE4B.vhmin
+        range: PU
+        multivalued: false
+        required: true
+        description: High band output minimum limit (<i>V</i><i><sub>Hmin</sub></i>)
+          (&lt; PssIEEE4V.vhmax).  Typical value = -0,6.
+      vimax:
+        slot_uri: cim:PssIEEE4B.vimax
+        range: PU
+        multivalued: false
+        required: true
+        description: Intermediate band output maximum limit (<i>V</i><i><sub>Imax</sub></i>)
+          (&gt; PssIEEE4B.vimin).  Typical value = 0,6.
+      vimin:
+        slot_uri: cim:PssIEEE4B.vimin
+        range: PU
+        multivalued: false
+        required: true
+        description: Intermediate band output minimum limit (<i>V</i><i><sub>Imin</sub></i>)
+          (&lt; PssIEEE4B.vimax).  Typical value = -0,6.
+      vlmax:
+        slot_uri: cim:PssIEEE4B.vlmax
+        range: PU
+        multivalued: false
+        required: true
+        description: Low band output maximum limit (<i>V</i><i><sub>Lmax</sub></i>)
+          (&gt; PssIEEE4B.vlmin).  Typical value = 0,075.
+      vlmin:
+        slot_uri: cim:PssIEEE4B.vlmin
+        range: PU
+        multivalued: false
+        required: true
+        description: Low band output minimum limit (<i>V</i><i><sub>Lmin</sub></i>)
+          (&lt; PssIEEE4B.vlmax).  Typical value = -0,075.
+      vstmax:
+        slot_uri: cim:PssIEEE4B.vstmax
+        range: PU
+        multivalued: false
+        required: true
+        description: PSS output maximum limit (<i>V</i><i><sub>STmax</sub></i>) (&gt;
+          PssIEEE4B.vstmin).  Typical value = 0,15.
+      vstmin:
+        slot_uri: cim:PssIEEE4B.vstmin
+        range: PU
+        multivalued: false
+        required: true
+        description: PSS output minimum limit (<i>V</i><i><sub>STmin</sub></i>) (&lt;
+          PssIEEE4B.vstmax).  Typical value = -0,15.
+    is_a: PowerSystemStabilizerDynamics
+    description: "IEEE 421.5-2005 type PSS4B power system stabilizer. The PSS4B model\
+      \ represents a structure based on multiple working frequency bands. Three separate\
+      \ bands, respectively dedicated to the low-, intermediate- and high-frequency\
+      \ modes of oscillations, are used in this delta omega (speed input) PSS.\nThere\
+      \ is an error in the in IEEE 421.5-2005 PSS4B model: the <i>Pe</i> input should\
+      \ read \u2013<i>Pe</i>. This implies that the input <i>Pe</i> needs to be multiplied\
+      \ by -1.\nReference: IEEE 4B 421.5-2005, 8.4. \nParameter details:\nThis model\
+      \ has 2 input signals. They have the following fixed types (expressed in terms\
+      \ of InputSignalKind values): the first one is of rotorAngleFrequencyDeviation\
+      \ type and the second one is of generatorElectricalPower type."
+  Pss1:
+    class_uri: cim:Pss1
+    attributes:
+      komega:
+        slot_uri: cim:Pss1.komega
+        range: float
+        multivalued: false
+        required: true
+        description: Shaft speed power input gain (<i>K</i><i><sub>omega</sub></i>).  Typical
+          value = 0.
+      kf:
+        slot_uri: cim:Pss1.kf
+        range: float
+        multivalued: false
+        required: true
+        description: Frequency power input gain (<i>K</i><i><sub>F</sub></i>).  Typical
+          value = 5.
+      kpe:
+        slot_uri: cim:Pss1.kpe
+        range: float
+        multivalued: false
+        required: true
+        description: Electric power input gain (<i>K</i><i><sub>PE</sub></i>).  Typical
+          value = 0,3.
+      pmin:
+        slot_uri: cim:Pss1.pmin
+        range: PU
+        multivalued: false
+        required: true
+        description: Minimum power PSS enabling (<i>Pmin</i>).  Typical value = 0,25.
+      ks:
+        slot_uri: cim:Pss1.ks
+        range: float
+        multivalued: false
+        required: true
+        description: PSS gain (<i>Ks</i>).  Typical value = 1.
+      vsmn:
+        slot_uri: cim:Pss1.vsmn
+        range: PU
+        multivalued: false
+        required: true
+        description: Stabilizer output maximum limit (<i>V</i><i><sub>SMN</sub></i>).  Typical
+          value = -0,06.
+      vsmx:
+        slot_uri: cim:Pss1.vsmx
+        range: PU
+        multivalued: false
+        required: true
+        description: Stabilizer output minimum limit (<i>V</i><i><sub>SMX</sub></i>).  Typical
+          value = 0,06.
+      tpe:
+        slot_uri: cim:Pss1.tpe
+        range: Seconds
+        multivalued: false
+        required: true
+        description: Electric power filter time constant (<i>T</i><i><sub>PE</sub></i>)
+          (&gt;= 0).  Typical value = 0,05.
+      t5:
+        slot_uri: cim:Pss1.t5
+        range: Seconds
+        multivalued: false
+        required: true
+        description: Washout (<i>T</i><i><sub>5</sub></i>) (&gt;= 0).  Typical value
+          = 3,5.
+      t6:
+        slot_uri: cim:Pss1.t6
+        range: Seconds
+        multivalued: false
+        required: true
+        description: Filter time constant (<i>T</i><i><sub>6</sub></i>) (&gt;= 0).  Typical
+          value = 0.
+      t7:
+        slot_uri: cim:Pss1.t7
+        range: Seconds
+        multivalued: false
+        required: true
+        description: Lead/lag time constant (<i>T</i><i><sub>7</sub></i>) (&gt;= 0).
+          If = 0, both blocks are bypassed.  Typical value = 0.
+      t8:
+        slot_uri: cim:Pss1.t8
+        range: Seconds
+        multivalued: false
+        required: true
+        description: Lead/lag time constant (<i>T</i><i><sub>8</sub></i>) (&gt;= 0).  Typical
+          value = 0.
+      t9:
+        slot_uri: cim:Pss1.t9
+        range: Seconds
+        multivalued: false
+        required: true
+        description: Lead/lag time constant (<i>T</i><i><sub>9</sub></i>) (&gt;= 0).  If
+          = 0, both blocks are bypassed.  Typical value = 0.
+      t10:
+        slot_uri: cim:Pss1.t10
+        range: Seconds
+        multivalued: false
+        required: true
+        description: Lead/lag time constant (<i>T</i><i><sub>10</sub></i>) (&gt;=
+          0).  Typical value = 0.
+      vadat:
+        slot_uri: cim:Pss1.vadat
+        range: boolean
+        multivalued: false
+        required: true
+        description: '<font color="#0f0f0f">Signal selector (<i>V</i><i><sub>ADAT</sub></i>).</font>
+
+          <font color="#0f0f0f">true = closed (generator power is greater than <i>Pmin</i>)</font>
+
+          <font color="#0f0f0f">false = open (<i>Pe</i> is smaller than <i>Pmin</i>).</font>
+
+          <font color="#0f0f0f">Typical value = true.</font>'
+    is_a: PowerSystemStabilizerDynamics
+    description: Italian PSS with three inputs (speed, frequency, power).
+  Pss1A:
+    class_uri: cim:Pss1A
+    attributes:
+      inputSignalType:
+        slot_uri: cim:Pss1A.inputSignalType
+        range: InputSignalKind
+        multivalued: false
+        required: true
+        description: Type of input signal (rotorAngularFrequencyDeviation, busFrequencyDeviation,
+          generatorElectricalPower, generatorAcceleratingPower, busVoltage, or busVoltageDerivative).
+      a1:
+        slot_uri: cim:Pss1A.a1
+        range: PU
+        multivalued: false
+        required: true
+        description: Notch filter parameter (<i>A</i><i><sub>1</sub></i>).
+      a2:
+        slot_uri: cim:Pss1A.a2
+        range: PU
+        multivalued: false
+        required: true
+        description: Notch filter parameter (<i>A</i><i><sub>2</sub></i>).
+      t1:
+        slot_uri: cim:Pss1A.t1
+        range: Seconds
+        multivalued: false
+        required: true
+        description: Lead/lag time constant (<i>T</i><i><sub>1</sub></i>) (&gt;= 0).
+      t2:
+        slot_uri: cim:Pss1A.t2
+        range: Seconds
+        multivalued: false
+        required: true
+        description: Lead/lag time constant (<i>T</i><i><sub>2</sub></i>) (&gt;= 0).
+      t3:
+        slot_uri: cim:Pss1A.t3
+        range: Seconds
+        multivalued: false
+        required: true
+        description: Lead/lag time constant (<i>T</i><i><sub>3</sub></i>) (&gt;= 0).
+      t4:
+        slot_uri: cim:Pss1A.t4
+        range: Seconds
+        multivalued: false
+        required: true
+        description: Lead/lag time constant (<i>T</i><i><sub>4</sub></i>) (&gt;= 0).
+      t5:
+        slot_uri: cim:Pss1A.t5
+        range: Seconds
+        multivalued: false
+        required: true
+        description: Washout time constant (<i>T</i><i><sub>5</sub></i>) (&gt;= 0).
+      t6:
+        slot_uri: cim:Pss1A.t6
+        range: Seconds
+        multivalued: false
+        required: true
+        description: Transducer time constant (<i>T</i><i><sub>6</sub></i>) (&gt;=
+          0).
+      ks:
+        slot_uri: cim:Pss1A.ks
+        range: PU
+        multivalued: false
+        required: true
+        description: Stabilizer gain (<i>K</i><i><sub>s</sub></i>).
+      vrmax:
+        slot_uri: cim:Pss1A.vrmax
+        range: PU
+        multivalued: false
+        required: true
+        description: Maximum stabilizer output (<i>Vrmax</i>) (&gt; Pss1A.vrmin).
+      vrmin:
+        slot_uri: cim:Pss1A.vrmin
+        range: PU
+        multivalued: false
+        required: true
+        description: Minimum stabilizer output (<i>Vrmin</i>) (&lt; Pss1A.vrmax).
+      vcu:
+        slot_uri: cim:Pss1A.vcu
+        range: PU
+        multivalued: false
+        required: true
+        description: Stabilizer input cutoff threshold (<i>Vcu</i>).
+      vcl:
+        slot_uri: cim:Pss1A.vcl
+        range: PU
+        multivalued: false
+        required: true
+        description: Stabilizer input cutoff threshold (<i>Vcl</i>).
+      a3:
+        slot_uri: cim:Pss1A.a3
+        range: PU
+        multivalued: false
+        required: true
+        description: Notch filter parameter (<i>A</i><i><sub>3</sub></i>).
+      a4:
+        slot_uri: cim:Pss1A.a4
+        range: PU
+        multivalued: false
+        required: true
+        description: Notch filter parameter (<i>A</i><i><sub>4</sub></i>).
+      a5:
+        slot_uri: cim:Pss1A.a5
+        range: PU
+        multivalued: false
+        required: true
+        description: Notch filter parameter (<i>A</i><i><sub>5</sub></i>).
+      a6:
+        slot_uri: cim:Pss1A.a6
+        range: PU
+        multivalued: false
+        required: true
+        description: Notch filter parameter (<i>A</i><i><sub>6</sub></i>).
+      a7:
+        slot_uri: cim:Pss1A.a7
+        range: PU
+        multivalued: false
+        required: true
+        description: Notch filter parameter (<i>A</i><i><sub>7</sub></i>).
+      a8:
+        slot_uri: cim:Pss1A.a8
+        range: PU
+        multivalued: false
+        required: true
+        description: Notch filter parameter (<i>A</i><i><sub>8</sub></i>).
+      kd:
+        slot_uri: cim:Pss1A.kd
+        range: boolean
+        multivalued: false
+        required: true
+        description: "Selector (<i>Kd</i>). \ntrue = e<sup>-sTdelay</sup> used\nfalse\
+          \ = e<sup>-sTdelay</sup> not used."
+      tdelay:
+        slot_uri: cim:Pss1A.tdelay
+        range: Seconds
+        multivalued: false
+        required: true
+        description: Time constant (<i>Tdelay</i>) (&gt;= 0).
+    is_a: PowerSystemStabilizerDynamics
+    description: Single input power system stabilizer. It is a modified version in
+      order to allow representation of various vendors' implementations on PSS type
+      1A.
+  Pss2B:
+    class_uri: cim:Pss2B
+    attributes:
+      vsi1max:
+        slot_uri: cim:Pss2B.vsi1max
+        range: PU
+        multivalued: false
+        required: true
+        description: 'Input signal #1 maximum limit (<i>Vsi1max</i>) (&gt; Pss2B.vsi1min).  Typical
+          value = 2.'
+      vsi1min:
+        slot_uri: cim:Pss2B.vsi1min
+        range: PU
+        multivalued: false
+        required: true
+        description: 'Input signal #1 minimum limit (<i>Vsi1min</i>) (&lt; Pss2B.vsi1max).  Typical
+          value = -2.'
+      tw1:
+        slot_uri: cim:Pss2B.tw1
+        range: Seconds
+        multivalued: false
+        required: true
+        description: 'First washout on signal #1 (<i>T</i><i><sub>w1</sub></i>) (&gt;=
+          0).  Typical value = 2.'
+      tw2:
+        slot_uri: cim:Pss2B.tw2
+        range: Seconds
+        multivalued: false
+        required: true
+        description: 'Second washout on signal #1 (<i>T</i><i><sub>w2</sub></i>) (&gt;=
+          0).  Typical value = 2.'
+      vsi2max:
+        slot_uri: cim:Pss2B.vsi2max
+        range: PU
+        multivalued: false
+        required: true
+        description: 'Input signal #2 maximum limit (<i>Vsi2max</i>) (&gt; Pss2B.vsi2min).  Typical
+          value = 2.'
+      vsi2min:
+        slot_uri: cim:Pss2B.vsi2min
+        range: PU
+        multivalued: false
+        required: true
+        description: 'Input signal #2 minimum limit (<i>Vsi2min</i>) (&lt; Pss2B.vsi2max).  Typical
+          value = -2.'
+      tw3:
+        slot_uri: cim:Pss2B.tw3
+        range: Seconds
+        multivalued: false
+        required: true
+        description: 'First washout on signal #2 (<i>T</i><i><sub>w3</sub></i>) (&gt;=
+          0).  Typical value = 2.'
+      tw4:
+        slot_uri: cim:Pss2B.tw4
+        range: Seconds
+        multivalued: false
+        required: true
+        description: 'Second washout on signal #2 (<i>T</i><i><sub>w4</sub></i>) (&gt;=
+          0).  Typical value = 0.'
+      t1:
+        slot_uri: cim:Pss2B.t1
+        range: Seconds
+        multivalued: false
+        required: true
+        description: Lead/lag time constant (<i>T</i><i><sub>1</sub></i>) (&gt;= 0).  Typical
+          value = 0,12.
+      t2:
+        slot_uri: cim:Pss2B.t2
+        range: Seconds
+        multivalued: false
+        required: true
+        description: Lead/lag time constant (<i>T</i><i><sub>2</sub></i>) (&gt;= 0).  Typical
+          value = 0,02.
+      t3:
+        slot_uri: cim:Pss2B.t3
+        range: Seconds
+        multivalued: false
+        required: true
+        description: Lead/lag time constant (<i>T</i><i><sub>3</sub></i>) (&gt;= 0).  Typical
+          value = 0,3.
+      t4:
+        slot_uri: cim:Pss2B.t4
+        range: Seconds
+        multivalued: false
+        required: true
+        description: Lead/lag time constant (<i>T</i><i><sub>4</sub></i>) (&gt;= 0).  Typical
+          value = 0,02.
+      t6:
+        slot_uri: cim:Pss2B.t6
+        range: Seconds
+        multivalued: false
+        required: true
+        description: 'Time constant on signal #1 (<i>T</i><i><sub>6</sub></i>) (&gt;=
+          0).  Typical value = 0.'
+      t7:
+        slot_uri: cim:Pss2B.t7
+        range: Seconds
+        multivalued: false
+        required: true
+        description: 'Time constant on signal #2 (<i>T</i><i><sub>7</sub></i>) (&gt;=
+          0).  Typical value = 2.'
+      t8:
+        slot_uri: cim:Pss2B.t8
+        range: Seconds
+        multivalued: false
+        required: true
+        description: Lead of ramp tracking filter (<i>T</i><i><sub>8</sub></i>) (&gt;=
+          0).  Typical value = 0,2.
+      t9:
+        slot_uri: cim:Pss2B.t9
+        range: Seconds
+        multivalued: false
+        required: true
+        description: Lag of ramp tracking filter (<i>T</i><i><sub>9</sub></i>) (&gt;=
+          0).  Typical value = 0,1.
+      t10:
+        slot_uri: cim:Pss2B.t10
+        range: Seconds
+        multivalued: false
+        required: true
+        description: Lead/lag time constant (<i>T</i><i><sub>10</sub></i>) (&gt;=
+          0).  Typical value = 0.
+      t11:
+        slot_uri: cim:Pss2B.t11
+        range: Seconds
+        multivalued: false
+        required: true
+        description: Lead/lag time constant (<i>T</i><i><sub>11</sub></i>) (&gt;=
+          0).  Typical value = 0.
+      ks1:
+        slot_uri: cim:Pss2B.ks1
+        range: PU
+        multivalued: false
+        required: true
+        description: Stabilizer gain (<i>Ks1</i>).  Typical value = 12.
+      ks2:
+        slot_uri: cim:Pss2B.ks2
+        range: PU
+        multivalued: false
+        required: true
+        description: 'Gain on signal #2 (<i>Ks2</i>).  Typical value = 0,2.'
+      ks3:
+        slot_uri: cim:Pss2B.ks3
+        range: PU
+        multivalued: false
+        required: true
+        description: 'Gain on signal #2 input before ramp-tracking filter (<i>Ks3</i>).  Typical
+          value = 1.'
+      ks4:
+        slot_uri: cim:Pss2B.ks4
+        range: PU
+        multivalued: false
+        required: true
+        description: 'Gain on signal #2 input after ramp-tracking filter (<i>Ks4</i>).  Typical
+          value = 1.'
+      n:
+        slot_uri: cim:Pss2B.n
+        range: integer
+        multivalued: false
+        required: true
+        description: Order of ramp tracking filter (<i>n</i>).  Typical value = 1.
+      m:
+        slot_uri: cim:Pss2B.m
+        range: integer
+        multivalued: false
+        required: true
+        description: Denominator order of ramp tracking filter (<i>m</i>).  Typical
+          value = 5.
+      vstmax:
+        slot_uri: cim:Pss2B.vstmax
+        range: PU
+        multivalued: false
+        required: true
+        description: Stabilizer output maximum limit (<i>Vstmax</i>) (&gt; Pss2B.vstmin).  Typical
+          value = 0,1.
+      vstmin:
+        slot_uri: cim:Pss2B.vstmin
+        range: PU
+        multivalued: false
+        required: true
+        description: Stabilizer output minimum limit (<i>Vstmin</i>) (&lt; Pss2B.vstmax).  Typical
+          value = -0,1.
+      a:
+        slot_uri: cim:Pss2B.a
+        range: float
+        multivalued: false
+        required: true
+        description: Numerator constant (<i>a</i>).  Typical value = 1.
+      ta:
+        slot_uri: cim:Pss2B.ta
+        range: Seconds
+        multivalued: false
+        required: true
+        description: Lead constant (<i>T</i><i><sub>a</sub></i>) (&gt;= 0).  Typical
+          value = 0.
+      tb:
+        slot_uri: cim:Pss2B.tb
+        range: Seconds
+        multivalued: false
+        required: true
+        description: Lag time constant (<i>T</i><i><sub>b</sub></i>) (&gt;= 0).  Typical
+          value = 0.
+    is_a: PowerSystemStabilizerDynamics
+    description: Modified IEEE PSS2B.  Extra lead/lag (or rate) block added at end
+      (up to 4 lead/lags total).
+  Pss2ST:
+    class_uri: cim:Pss2ST
+    attributes:
+      inputSignal1Type:
+        slot_uri: cim:Pss2ST.inputSignal1Type
+        range: InputSignalKind
+        multivalued: false
+        required: true
+        description: 'Type of input signal #1 (rotorAngularFrequencyDeviation, busFrequencyDeviation,
+          generatorElectricalPower, generatorAcceleratingPower, busVoltage, or busVoltageDerivative
+          - shall be different than Pss2ST.inputSignal2Type).  Typical value = rotorAngularFrequencyDeviation.'
+      inputSignal2Type:
+        slot_uri: cim:Pss2ST.inputSignal2Type
+        range: InputSignalKind
+        multivalued: false
+        required: true
+        description: 'Type of input signal #2 (rotorAngularFrequencyDeviation, busFrequencyDeviation,
+          generatorElectricalPower, generatorAcceleratingPower, busVoltage, or busVoltageDerivative
+          - shall be different than Pss2ST.inputSignal1Type).  Typical value = busVoltageDerivative.'
+      k1:
+        slot_uri: cim:Pss2ST.k1
+        range: PU
+        multivalued: false
+        required: true
+        description: Gain (<i>K</i><i><sub>1</sub></i>).
+      k2:
+        slot_uri: cim:Pss2ST.k2
+        range: PU
+        multivalued: false
+        required: true
+        description: Gain (<i>K</i><i><sub>2</sub></i>).
+      t1:
+        slot_uri: cim:Pss2ST.t1
+        range: Seconds
+        multivalued: false
+        required: true
+        description: Time constant (<i>T</i><i><sub>1</sub></i>) (&gt;= 0).
+      t2:
+        slot_uri: cim:Pss2ST.t2
+        range: Seconds
+        multivalued: false
+        required: true
+        description: Time constant (<i>T</i><i><sub>2</sub></i>) (&gt;= 0).
+      t3:
+        slot_uri: cim:Pss2ST.t3
+        range: Seconds
+        multivalued: false
+        required: true
+        description: Time constant (<i>T</i><i><sub>3</sub></i>) (&gt;= 0).
+      t4:
+        slot_uri: cim:Pss2ST.t4
+        range: Seconds
+        multivalued: false
+        required: true
+        description: Time constant (<i>T</i><i><sub>4</sub></i>) (&gt;= 0).
+      t5:
+        slot_uri: cim:Pss2ST.t5
+        range: Seconds
+        multivalued: false
+        required: true
+        description: Time constant (<i>T</i><i><sub>5</sub></i>) (&gt;= 0).
+      t6:
+        slot_uri: cim:Pss2ST.t6
+        range: Seconds
+        multivalued: false
+        required: true
+        description: Time constant (<i>T</i><i><sub>6</sub></i>) (&gt;= 0).
+      t7:
+        slot_uri: cim:Pss2ST.t7
+        range: Seconds
+        multivalued: false
+        required: true
+        description: Time constant (<i>T</i><i><sub>7</sub></i>) (&gt;= 0).
+      t8:
+        slot_uri: cim:Pss2ST.t8
+        range: Seconds
+        multivalued: false
+        required: true
+        description: Time constant (<i>T</i><i><sub>8</sub></i>) (&gt;= 0).
+      t9:
+        slot_uri: cim:Pss2ST.t9
+        range: Seconds
+        multivalued: false
+        required: true
+        description: Time constant (<i>T</i><i><sub>9</sub></i>) (&gt;= 0).
+      t10:
+        slot_uri: cim:Pss2ST.t10
+        range: Seconds
+        multivalued: false
+        required: true
+        description: Time constant (<i>T</i><i><sub>10</sub></i>) (&gt;= 0).
+      lsmax:
+        slot_uri: cim:Pss2ST.lsmax
+        range: PU
+        multivalued: false
+        required: true
+        description: Limiter (<i>L</i><i><sub>SMAX</sub></i>) (&gt; Pss2ST.lsmin).
+      lsmin:
+        slot_uri: cim:Pss2ST.lsmin
+        range: PU
+        multivalued: false
+        required: true
+        description: Limiter (<i>L</i><i><sub>SMIN</sub></i>) (&lt; Pss2ST.lsmax).
+      vcu:
+        slot_uri: cim:Pss2ST.vcu
+        range: PU
+        multivalued: false
+        required: true
+        description: Cutoff limiter (<i>V</i><i><sub>CU</sub></i>).
+      vcl:
+        slot_uri: cim:Pss2ST.vcl
+        range: PU
+        multivalued: false
+        required: true
+        description: Cutoff limiter (<i>V</i><i><sub>CL</sub></i>).
+    is_a: PowerSystemStabilizerDynamics
+    description: PTI microprocessor-based stabilizer type 1.
+  Pss5:
+    class_uri: cim:Pss5
+    attributes:
+      kpe:
+        slot_uri: cim:Pss5.kpe
+        range: float
+        multivalued: false
+        required: true
+        description: Electric power input gain (<i>K</i><i><sub>PE</sub></i>).  Typical
+          value = 0,3.
+      kf:
+        slot_uri: cim:Pss5.kf
+        range: float
+        multivalued: false
+        required: true
+        description: Frequency/shaft speed input gain (<i>K</i><i><sub>F</sub></i>).  Typical
+          value = 5.
+      isfreq:
+        slot_uri: cim:Pss5.isfreq
+        range: boolean
+        multivalued: false
+        required: true
+        description: 'Selector for frequency/shaft speed input (<i>isFreq</i>).
+
+          true = speed (same meaning as InputSignaKind.rotorSpeed)
+
+          false = frequency (same meaning as InputSignalKind.busFrequency).
+
+          Typical value = true (same meaning as InputSignalKind.rotorSpeed).'
+      kpss:
+        slot_uri: cim:Pss5.kpss
+        range: float
+        multivalued: false
+        required: true
+        description: PSS gain (<i>K</i><i><sub>PSS</sub></i>).  Typical value = 1.
+      ctw2:
+        slot_uri: cim:Pss5.ctw2
+        range: boolean
+        multivalued: false
+        required: true
+        description: 'Selector for second washout enabling (<i>C</i><i><sub>TW2</sub></i>).
+
+          true = second washout filter is bypassed
+
+          false = second washout filter in use.
+
+          Typical value = true.'
+      tw1:
+        slot_uri: cim:Pss5.tw1
+        range: Seconds
+        multivalued: false
+        required: true
+        description: First washout (<i>T</i><i><sub>W1</sub></i>) (&gt;= 0).  Typical
+          value = 3,5.
+      tw2:
+        slot_uri: cim:Pss5.tw2
+        range: Seconds
+        multivalued: false
+        required: true
+        description: Second washout (<i>T</i><i><sub>W2</sub></i>) (&gt;= 0).  Typical
+          value = 0.
+      tl1:
+        slot_uri: cim:Pss5.tl1
+        range: Seconds
+        multivalued: false
+        required: true
+        description: Lead/lag time constant (<i>T</i><i><sub>L1</sub></i>) (&gt;=
+          0).  Typical value = 0.
+      tl2:
+        slot_uri: cim:Pss5.tl2
+        range: Seconds
+        multivalued: false
+        required: true
+        description: Lead/lag time constant (<i>T</i><i><sub>L2</sub></i>) (&gt;=
+          0).  If = 0, both blocks are bypassed.  Typical value = 0.
+      tl3:
+        slot_uri: cim:Pss5.tl3
+        range: Seconds
+        multivalued: false
+        required: true
+        description: Lead/lag time constant (<i>T</i><i><sub>L3</sub></i>) (&gt;=
+          0).  Typical value = 0.
+      tl4:
+        slot_uri: cim:Pss5.tl4
+        range: Seconds
+        multivalued: false
+        required: true
+        description: Lead/lag time constant (T<sub>L4</sub>) (&gt;= 0).  If = 0, both
+          blocks are bypassed.  Typical value = 0.
+      vsmn:
+        slot_uri: cim:Pss5.vsmn
+        range: PU
+        multivalued: false
+        required: true
+        description: Stabilizer output maximum limit (<i>V</i><i><sub>SMN</sub></i>).  Typical
+          value = -0,1.
+      vsmx:
+        slot_uri: cim:Pss5.vsmx
+        range: PU
+        multivalued: false
+        required: true
+        description: Stabilizer output minimum limit (<i>V</i><i><sub>SMX</sub></i>).  Typical
+          value = 0,1.
+      tpe:
+        slot_uri: cim:Pss5.tpe
+        range: Seconds
+        multivalued: false
+        required: true
+        description: Electric power filter time constant (<i>T</i><i><sub>PE</sub></i>)
+          (&gt;= 0).  Typical value = 0,05.
+      pmin:
+        slot_uri: cim:Pss5.pmin
+        range: PU
+        multivalued: false
+        required: true
+        description: Minimum power PSS enabling (<i>Pmin</i>).  Typical value = 0,25.
+      deadband:
+        slot_uri: cim:Pss5.deadband
+        range: PU
+        multivalued: false
+        required: true
+        description: Stabilizer output deadband (<i>DEADBAND</i>).  Typical value
+          = 0.
+      vadat:
+        slot_uri: cim:Pss5.vadat
+        range: boolean
+        multivalued: false
+        required: true
+        description: '<font color="#0f0f0f">Signal selector (<i>V</i><i><sub>adAtt</sub></i>).</font>
+
+          <font color="#0f0f0f">true = closed (generator power is greater than <i>Pmin</i>)</font>
+
+          <font color="#0f0f0f">false = open (<i>Pe</i> is smaller than <i>Pmin</i>).</font>
+
+          <font color="#0f0f0f">Typical value = true.</font>'
+    is_a: PowerSystemStabilizerDynamics
+    description: Detailed Italian PSS.
+  PssELIN2:
+    class_uri: cim:PssELIN2
+    attributes:
+      ts1:
+        slot_uri: cim:PssELIN2.ts1
+        range: Seconds
+        multivalued: false
+        required: true
+        description: Time constant (<i>Ts1</i>) (&gt;= 0).  Typical value = 0.
+      ts2:
+        slot_uri: cim:PssELIN2.ts2
+        range: Seconds
+        multivalued: false
+        required: true
+        description: Time constant (<i>Ts2</i>) (&gt;= 0).  Typical value = 1.
+      ts3:
+        slot_uri: cim:PssELIN2.ts3
+        range: Seconds
+        multivalued: false
+        required: true
+        description: Time constant (<i>Ts3</i>) (&gt;= 0).  Typical value = 1.
+      ts4:
+        slot_uri: cim:PssELIN2.ts4
+        range: Seconds
+        multivalued: false
+        required: true
+        description: Time constant (<i>Ts4</i>) (&gt;= 0).  Typical value = 0,1.
+      ts5:
+        slot_uri: cim:PssELIN2.ts5
+        range: Seconds
+        multivalued: false
+        required: true
+        description: Time constant (<i>Ts5</i>) (&gt;= 0).  Typical value = 0.
+      ts6:
+        slot_uri: cim:PssELIN2.ts6
+        range: Seconds
+        multivalued: false
+        required: true
+        description: Time constant (<i>Ts6</i>) (&gt;= 0).  Typical value = 1.
+      ks1:
+        slot_uri: cim:PssELIN2.ks1
+        range: PU
+        multivalued: false
+        required: true
+        description: Gain (<i>Ks1</i>).  Typical value = 1.
+      ks2:
+        slot_uri: cim:PssELIN2.ks2
+        range: PU
+        multivalued: false
+        required: true
+        description: Gain (<i>Ks2</i>).  Typical value = 0,1.
+      ppss:
+        slot_uri: cim:PssELIN2.ppss
+        range: PU
+        multivalued: false
+        required: true
+        description: Coefficient (<i>p_PSS</i>) (&gt;= 0 and &lt;= 4).  Typical value
+          = 0,1.
+      apss:
+        slot_uri: cim:PssELIN2.apss
+        range: PU
+        multivalued: false
+        required: true
+        description: Coefficient (<i>a_PSS</i>).  Typical value = 0,1.
+      psslim:
+        slot_uri: cim:PssELIN2.psslim
+        range: PU
+        multivalued: false
+        required: true
+        description: PSS limiter (<i>psslim</i>).  Typical value = 0,1.
+    is_a: PowerSystemStabilizerDynamics
+    description: Power system stabilizer typically associated with ExcELIN2 (though
+      PssIEEE2B or Pss2B can also be used).
+  PssPTIST1:
+    class_uri: cim:PssPTIST1
+    attributes:
+      m:
+        slot_uri: cim:PssPTIST1.m
+        range: PU
+        multivalued: false
+        required: true
+        description: (<i>M</i>).  <i>M </i>= 2 x <i>H</i>.  Typical value = 5.
+      tf:
+        slot_uri: cim:PssPTIST1.tf
+        range: Seconds
+        multivalued: false
+        required: true
+        description: Time constant (<i>Tf</i>) (&gt;= 0).  Typical value = 0,2.
+      tp:
+        slot_uri: cim:PssPTIST1.tp
+        range: Seconds
+        multivalued: false
+        required: true
+        description: Time constant (<i>Tp</i>) (&gt;= 0).  Typical value = 0,2.
+      t1:
+        slot_uri: cim:PssPTIST1.t1
+        range: Seconds
+        multivalued: false
+        required: true
+        description: Time constant (<i>T1</i>) (&gt;= 0).  Typical value = 0,3.
+      t2:
+        slot_uri: cim:PssPTIST1.t2
+        range: Seconds
+        multivalued: false
+        required: true
+        description: Time constant (<i>T2</i>) (&gt;= 0).  Typical value = 1.
+      t3:
+        slot_uri: cim:PssPTIST1.t3
+        range: Seconds
+        multivalued: false
+        required: true
+        description: Time constant (<i>T3</i>) (&gt;= 0).  Typical value = 0,2.
+      t4:
+        slot_uri: cim:PssPTIST1.t4
+        range: Seconds
+        multivalued: false
+        required: true
+        description: Time constant (<i>T4</i>) (&gt;= 0).  Typical value = 0,05.
+      k:
+        slot_uri: cim:PssPTIST1.k
+        range: PU
+        multivalued: false
+        required: true
+        description: Gain (<i>K</i>).  Typical value = 9.
+      dtf:
+        slot_uri: cim:PssPTIST1.dtf
+        range: Seconds
+        multivalued: false
+        required: true
+        description: Time step frequency calculation (<i>deltatf</i>) (&gt;= 0).  Typical
+          value = 0,025.
+      dtc:
+        slot_uri: cim:PssPTIST1.dtc
+        range: Seconds
+        multivalued: false
+        required: true
+        description: Time step related to activation of controls (<i>deltatc</i>)
+          (&gt;= 0).  Typical value = 0,025.
+      dtp:
+        slot_uri: cim:PssPTIST1.dtp
+        range: Seconds
+        multivalued: false
+        required: true
+        description: Time step active power calculation (<i>deltatp</i>) (&gt;= 0).  Typical
+          value = 0,0125.
+    is_a: PowerSystemStabilizerDynamics
+    description: PTI microprocessor-based stabilizer type 1.
+  PssPTIST3:
+    class_uri: cim:PssPTIST3
+    attributes:
+      m:
+        slot_uri: cim:PssPTIST3.m
+        range: PU
+        multivalued: false
+        required: true
+        description: (<i>M</i>).  <i>M</i> = 2 x <i>H</i>.  Typical value = 5.
+      tf:
+        slot_uri: cim:PssPTIST3.tf
+        range: Seconds
+        multivalued: false
+        required: true
+        description: Time constant (<i>Tf</i>) (&gt;= 0).  Typical value = 0,2.
+      tp:
+        slot_uri: cim:PssPTIST3.tp
+        range: Seconds
+        multivalued: false
+        required: true
+        description: Time constant (<i>Tp</i>) (&gt;= 0).  Typical value = 0,2.
+      t1:
+        slot_uri: cim:PssPTIST3.t1
+        range: Seconds
+        multivalued: false
+        required: true
+        description: Time constant (<i>T1</i>) (&gt;= 0).  Typical value = 0,3.
+      t2:
+        slot_uri: cim:PssPTIST3.t2
+        range: Seconds
+        multivalued: false
+        required: true
+        description: Time constant (<i>T2</i>) (&gt;= 0).  Typical value = 1.
+      t3:
+        slot_uri: cim:PssPTIST3.t3
+        range: Seconds
+        multivalued: false
+        required: true
+        description: Time constant (<i>T3</i>) (&gt;= 0).  Typical value = 0,2.
+      t4:
+        slot_uri: cim:PssPTIST3.t4
+        range: Seconds
+        multivalued: false
+        required: true
+        description: Time constant (<i>T4</i>) (&gt;= 0).  Typical value = 0,05.
+      k:
+        slot_uri: cim:PssPTIST3.k
+        range: PU
+        multivalued: false
+        required: true
+        description: Gain (<i>K</i>).  Typical value = 9.
+      dtf:
+        slot_uri: cim:PssPTIST3.dtf
+        range: Seconds
+        multivalued: false
+        required: true
+        description: Time step frequency calculation (<i>deltatf</i>) (&gt;= 0).  Typical
+          value = 0,025 (0,03 for 50 Hz).
+      dtc:
+        slot_uri: cim:PssPTIST3.dtc
+        range: Seconds
+        multivalued: false
+        required: true
+        description: Time step related to activation of controls (<i>deltatc</i>)
+          (&gt;= 0).  Typical value = 0,025 (0,03 for 50 Hz).
+      dtp:
+        slot_uri: cim:PssPTIST3.dtp
+        range: Seconds
+        multivalued: false
+        required: true
+        description: Time step active power calculation (<i>deltatp</i>) (&gt;= 0).  Typical
+          value = 0,0125  (0,015 for 50 Hz).
+      t5:
+        slot_uri: cim:PssPTIST3.t5
+        range: Seconds
+        multivalued: false
+        required: true
+        description: Time constant (<i>T5</i>) (&gt;= 0).
+      t6:
+        slot_uri: cim:PssPTIST3.t6
+        range: Seconds
+        multivalued: false
+        required: true
+        description: Time constant (<i>T6</i>) (&gt;= 0).
+      a0:
+        slot_uri: cim:PssPTIST3.a0
+        range: PU
+        multivalued: false
+        required: true
+        description: Filter coefficient (<i>A0</i>).
+      a1:
+        slot_uri: cim:PssPTIST3.a1
+        range: PU
+        multivalued: false
+        required: true
+        description: Limiter (<i>Al</i>).
+      a2:
+        slot_uri: cim:PssPTIST3.a2
+        range: PU
+        multivalued: false
+        required: true
+        description: Filter coefficient (<i>A2</i>).
+      b0:
+        slot_uri: cim:PssPTIST3.b0
+        range: PU
+        multivalued: false
+        required: true
+        description: Filter coefficient (<i>B0</i>).
+      b1:
+        slot_uri: cim:PssPTIST3.b1
+        range: PU
+        multivalued: false
+        required: true
+        description: Filter coefficient (<i>B1</i>).
+      b2:
+        slot_uri: cim:PssPTIST3.b2
+        range: PU
+        multivalued: false
+        required: true
+        description: Filter coefficient (<i>B2</i>).
+      a3:
+        slot_uri: cim:PssPTIST3.a3
+        range: PU
+        multivalued: false
+        required: true
+        description: Filter coefficient (<i>A3</i>).
+      a4:
+        slot_uri: cim:PssPTIST3.a4
+        range: PU
+        multivalued: false
+        required: true
+        description: Filter coefficient (<i>A4</i>).
+      a5:
+        slot_uri: cim:PssPTIST3.a5
+        range: PU
+        multivalued: false
+        required: true
+        description: Filter coefficient (<i>A5</i>).
+      b3:
+        slot_uri: cim:PssPTIST3.b3
+        range: PU
+        multivalued: false
+        required: true
+        description: Filter coefficient (<i>B3</i>).
+      b4:
+        slot_uri: cim:PssPTIST3.b4
+        range: PU
+        multivalued: false
+        required: true
+        description: Filter coefficient (<i>B4</i>).
+      b5:
+        slot_uri: cim:PssPTIST3.b5
+        range: PU
+        multivalued: false
+        required: true
+        description: Filter coefficient (<i>B5</i>).
+      athres:
+        slot_uri: cim:PssPTIST3.athres
+        range: PU
+        multivalued: false
+        required: true
+        description: Threshold value above which output averaging will be bypassed
+          (<i>Athres</i>).  Typical value = 0,005.
+      dl:
+        slot_uri: cim:PssPTIST3.dl
+        range: PU
+        multivalued: false
+        required: true
+        description: Limiter (<i>Dl</i>).
+      al:
+        slot_uri: cim:PssPTIST3.al
+        range: PU
+        multivalued: false
+        required: true
+        description: Limiter (<i>Al</i>).
+      lthres:
+        slot_uri: cim:PssPTIST3.lthres
+        range: PU
+        multivalued: false
+        required: true
+        description: Threshold value (<i>Lthres</i>).
+      pmin:
+        slot_uri: cim:PssPTIST3.pmin
+        range: PU
+        multivalued: false
+        required: true
+        description: (<i>Pmin</i>).
+      isw:
+        slot_uri: cim:PssPTIST3.isw
+        range: boolean
+        multivalued: false
+        required: true
+        description: 'Digital/analogue output switch (<i>Isw</i>).
+
+          true = produce analogue output
+
+          false = convert to digital output, using tap selection table.'
+      nav:
+        slot_uri: cim:PssPTIST3.nav
+        range: float
+        multivalued: false
+        required: true
+        description: Number of control outputs to average (<i>NAV</i>) (1 &lt;=  <i>NAV</i>
+          &lt;= 16).  Typical value = 4.
+      ncl:
+        slot_uri: cim:PssPTIST3.ncl
+        range: float
+        multivalued: false
+        required: true
+        description: Number of counts at limit to active limit function (<i>NCL</i>)
+          (&gt; 0).
+      ncr:
+        slot_uri: cim:PssPTIST3.ncr
+        range: float
+        multivalued: false
+        required: true
+        description: Number of counts until reset after limit function is triggered
+          (<i>NCR</i>).
+    is_a: PowerSystemStabilizerDynamics
+    description: PTI microprocessor-based stabilizer type 3.
+  PssRQB:
+    class_uri: cim:PssRQB
+    attributes:
+      ki2:
+        slot_uri: cim:PssRQB.ki2
+        range: float
+        multivalued: false
+        required: true
+        description: Speed input gain (<i>Ki2</i>). Typical value = 3,43.
+      ki3:
+        slot_uri: cim:PssRQB.ki3
+        range: float
+        multivalued: false
+        required: true
+        description: Electrical power input gain (<i>Ki3</i>). Typical value = -11,45.
+      ki4:
+        slot_uri: cim:PssRQB.ki4
+        range: float
+        multivalued: false
+        required: true
+        description: Mechanical power input gain (<i>Ki4</i>). Typical value = 11,86.
+      t4m:
+        slot_uri: cim:PssRQB.t4m
+        range: Seconds
+        multivalued: false
+        required: true
+        description: Input time constant (<i>T4M</i>) (&gt;= 0). Typical value = 5.
+      tomd:
+        slot_uri: cim:PssRQB.tomd
+        range: Seconds
+        multivalued: false
+        required: true
+        description: Speed delay (<i>TOMD</i>) (&gt;= 0). Typical value = 0,02.
+      tomsl:
+        slot_uri: cim:PssRQB.tomsl
+        range: Seconds
+        multivalued: false
+        required: true
+        description: Speed time constant (<i>TOMSL</i>) (&gt;= 0). Typical value =
+          0,04.
+      t4mom:
+        slot_uri: cim:PssRQB.t4mom
+        range: Seconds
+        multivalued: false
+        required: true
+        description: Speed time constant (<i>T4MOM</i>) (&gt;= 0). Typical value =
+          1,27.
+      sibv:
+        slot_uri: cim:PssRQB.sibv
+        range: PU
+        multivalued: false
+        required: true
+        description: Speed deadband (<i>SIBV</i>). Typical value = 0,006.
+      kdpm:
+        slot_uri: cim:PssRQB.kdpm
+        range: float
+        multivalued: false
+        required: true
+        description: Lead lag gain (<i>KDPM</i>). Typical value = 0,185.
+      t4f:
+        slot_uri: cim:PssRQB.t4f
+        range: Seconds
+        multivalued: false
+        required: true
+        description: Lead lag time constant (<i>T4F</i>) (&gt;= 0). Typical value
+          = 0,045.
+    is_a: PowerSystemStabilizerDynamics
+    description: Power system stabilizer type RQB. This power system stabilizer is
+      intended to be used together with excitation system type ExcRQB, which is primarily
+      used in nuclear or thermal generating units.
+  PssSB4:
+    class_uri: cim:PssSB4
+    attributes:
+      tt:
+        slot_uri: cim:PssSB4.tt
+        range: Seconds
+        multivalued: false
+        required: true
+        description: Time constant (<i>Tt</i>) (&gt;= 0).  Typical value = 0,18.
+      kx:
+        slot_uri: cim:PssSB4.kx
+        range: PU
+        multivalued: false
+        required: true
+        description: Gain (<i>Kx</i>).  Typical value = 2,7.
+      tx2:
+        slot_uri: cim:PssSB4.tx2
+        range: Seconds
+        multivalued: false
+        required: true
+        description: Time constant (<i>Tx2</i>) (&gt;= 0).  Typical value = 5,0.
+      ta:
+        slot_uri: cim:PssSB4.ta
+        range: Seconds
+        multivalued: false
+        required: true
+        description: Time constant (<i>Ta</i>) (&gt;= 0).  Typical value = 0,37.
+      tx1:
+        slot_uri: cim:PssSB4.tx1
+        range: Seconds
+        multivalued: false
+        required: true
+        description: Reset time constant (<i>Tx1</i>) (&gt;= 0).  Typical value =
+          0,035.
+      tb:
+        slot_uri: cim:PssSB4.tb
+        range: Seconds
+        multivalued: false
+        required: true
+        description: Time constant (<i>Tb</i>) (&gt;= 0).  Typical value = 0,37.
+      tc:
+        slot_uri: cim:PssSB4.tc
+        range: Seconds
+        multivalued: false
+        required: true
+        description: Time constant (<i>Tc</i>) (&gt;= 0).  Typical value = 0,035.
+      td:
+        slot_uri: cim:PssSB4.td
+        range: Seconds
+        multivalued: false
+        required: true
+        description: Time constant (<i>Td</i>) (&gt;= 0).  Typical value = 0,0.
+      te:
+        slot_uri: cim:PssSB4.te
+        range: Seconds
+        multivalued: false
+        required: true
+        description: Time constant (<i>Te</i>) (&gt;= 0).  Typical value = 0,0169.
+      vsmax:
+        slot_uri: cim:PssSB4.vsmax
+        range: PU
+        multivalued: false
+        required: true
+        description: Limiter (<i>Vsmax</i>) (&gt; PssSB4.vsmin).  Typical value =
+          0,062.
+      vsmin:
+        slot_uri: cim:PssSB4.vsmin
+        range: PU
+        multivalued: false
+        required: true
+        description: Limiter (<i>Vsmin</i>) (&lt; PssSB4.vsmax).  Typical value =
+          -0,062.
+    is_a: PowerSystemStabilizerDynamics
+    description: Power sensitive stabilizer model.
+  PssSH:
+    class_uri: cim:PssSH
+    attributes:
+      k:
+        slot_uri: cim:PssSH.k
+        range: PU
+        multivalued: false
+        required: true
+        description: Main gain (<i>K</i>).  Typical value = 1.
+      k0:
+        slot_uri: cim:PssSH.k0
+        range: PU
+        multivalued: false
+        required: true
+        description: Gain 0 (<i>K0</i>).  Typical value = 0,012.
+      k1:
+        slot_uri: cim:PssSH.k1
+        range: PU
+        multivalued: false
+        required: true
+        description: Gain 1 (<i>K1</i>).  Typical value = 0,488.
+      k2:
+        slot_uri: cim:PssSH.k2
+        range: PU
+        multivalued: false
+        required: true
+        description: Gain 2 (<i>K2</i>).  Typical value = 0,064.
+      k3:
+        slot_uri: cim:PssSH.k3
+        range: PU
+        multivalued: false
+        required: true
+        description: Gain 3 (<i>K3</i>).  Typical value = 0,224.
+      k4:
+        slot_uri: cim:PssSH.k4
+        range: PU
+        multivalued: false
+        required: true
+        description: Gain 4 (<i>K4</i>).  Typical value = 0,1.
+      td:
+        slot_uri: cim:PssSH.td
+        range: Seconds
+        multivalued: false
+        required: true
+        description: Input time constant (<i>T</i><i><sub>d</sub></i>) (&gt;= 0).  Typical
+          value = 10.
+      t1:
+        slot_uri: cim:PssSH.t1
+        range: Seconds
+        multivalued: false
+        required: true
+        description: Time constant 1 (<i>T1</i>) (&gt; 0).  Typical value = 0,076.
+      t2:
+        slot_uri: cim:PssSH.t2
+        range: Seconds
+        multivalued: false
+        required: true
+        description: Time constant 2 (<i>T2</i>) (&gt; 0).  Typical value = 0,086.
+      t3:
+        slot_uri: cim:PssSH.t3
+        range: Seconds
+        multivalued: false
+        required: true
+        description: Time constant 3 (<i>T3</i>) (&gt; 0).   Typical value = 1,068.
+      t4:
+        slot_uri: cim:PssSH.t4
+        range: Seconds
+        multivalued: false
+        required: true
+        description: Time constant 4 (<i>T4</i>) (&gt; 0).  Typical value = 1,913.
+      vsmax:
+        slot_uri: cim:PssSH.vsmax
+        range: PU
+        multivalued: false
+        required: true
+        description: Output maximum limit (<i>Vsmax</i>) (&gt; PssSH.vsmin).  Typical
+          value = 0,1.
+      vsmin:
+        slot_uri: cim:PssSH.vsmin
+        range: PU
+        multivalued: false
+        required: true
+        description: Output minimum limit (<i>Vsmin</i>) (&lt; PssSH.vsmax).  Typical
+          value = -0,1.
+    is_a: PowerSystemStabilizerDynamics
+    description: "Siemens<sup>TM</sup> \u201CH infinity\u201D power system stabilizer\
+      \ with generator electrical power input.\n[Footnote: Siemens \"H infinity\"\
+      \ power system stabilizers are an example of suitable products available commercially.\
+      \ This information is given for the convenience of users of this document and\
+      \ does not constitute an endorsement by IEC of these products.]"
+  PssSK:
+    class_uri: cim:PssSK
+    attributes:
+      k1:
+        slot_uri: cim:PssSK.k1
+        range: PU
+        multivalued: false
+        required: true
+        description: Gain <i>P</i> (<i>K</i><i><sub>1</sub></i>).  Typical value =
+          -0,3.
+      k2:
+        slot_uri: cim:PssSK.k2
+        range: PU
+        multivalued: false
+        required: true
+        description: Gain <i>f</i><i><sub>E</sub></i><i> </i>(<i>K</i><i><sub>2</sub></i>).  Typical
+          value = -0,15.
+      k3:
+        slot_uri: cim:PssSK.k3
+        range: PU
+        multivalued: false
+        required: true
+        description: Gain <i>I</i><i><sub>f</sub></i><i> </i>(<i>K</i><i><sub>3</sub></i>).  Typical
+          value = 10.
+      t1:
+        slot_uri: cim:PssSK.t1
+        range: Seconds
+        multivalued: false
+        required: true
+        description: Denominator time constant (<i>T</i><i><sub>1</sub></i>) (&gt;
+          0,005).  Typical value = 0,3.
+      t2:
+        slot_uri: cim:PssSK.t2
+        range: Seconds
+        multivalued: false
+        required: true
+        description: Filter time constant (<i>T</i><i><sub>2</sub></i>) (&gt; 0,005).  Typical
+          value = 0,35.
+      t3:
+        slot_uri: cim:PssSK.t3
+        range: Seconds
+        multivalued: false
+        required: true
+        description: Denominator time constant (<i>T</i><i><sub>3</sub></i>) (&gt;
+          0,005).  Typical value = 0,22.
+      t4:
+        slot_uri: cim:PssSK.t4
+        range: Seconds
+        multivalued: false
+        required: true
+        description: Filter time constant (<i>T</i><i><sub>4</sub></i>) (&gt; 0,005).  Typical
+          value = 0,02.
+      t5:
+        slot_uri: cim:PssSK.t5
+        range: Seconds
+        multivalued: false
+        required: true
+        description: Denominator time constant (<i>T</i><i><sub>5</sub></i>) (&gt;
+          0,005).  Typical value = 0,02.
+      t6:
+        slot_uri: cim:PssSK.t6
+        range: Seconds
+        multivalued: false
+        required: true
+        description: Filter time constant (<i>T</i><i><sub>6</sub></i>) (&gt; 0,005).  Typical
+          value = 0,02.
+      vsmax:
+        slot_uri: cim:PssSK.vsmax
+        range: PU
+        multivalued: false
+        required: true
+        description: Stabilizer output maximum limit (<i>V</i><i><sub>SMAX</sub></i>)
+          (&gt; PssSK.vsmin).  Typical value = 0,4.
+      vsmin:
+        slot_uri: cim:PssSK.vsmin
+        range: PU
+        multivalued: false
+        required: true
+        description: Stabilizer output minimum limit (<i>V</i><i><sub>SMIN</sub></i>)
+          (&lt; PssSK.vsmax).  Typical value = -0.4.
+    is_a: PowerSystemStabilizerDynamics
+    description: Slovakian PSS with three inputs.
+  PssSTAB2A:
+    class_uri: cim:PssSTAB2A
+    attributes:
+      k2:
+        slot_uri: cim:PssSTAB2A.k2
+        range: PU
+        multivalued: false
+        required: true
+        description: Gain (<i>K2</i>).  Typical value = 1,0.
+      k3:
+        slot_uri: cim:PssSTAB2A.k3
+        range: PU
+        multivalued: false
+        required: true
+        description: Gain (<i>K3</i>).  Typical value = 0,25.
+      k4:
+        slot_uri: cim:PssSTAB2A.k4
+        range: PU
+        multivalued: false
+        required: true
+        description: Gain (<i>K4</i>).  Typical value = 0,075.
+      k5:
+        slot_uri: cim:PssSTAB2A.k5
+        range: PU
+        multivalued: false
+        required: true
+        description: Gain (<i>K5</i>).  Typical value = 2,5.
+      t2:
+        slot_uri: cim:PssSTAB2A.t2
+        range: Seconds
+        multivalued: false
+        required: true
+        description: Time constant (<i>T2</i>).  Typical value = 4,0.
+      t3:
+        slot_uri: cim:PssSTAB2A.t3
+        range: Seconds
+        multivalued: false
+        required: true
+        description: Time constant (<i>T3</i>).  Typical value = 2,0.
+      t5:
+        slot_uri: cim:PssSTAB2A.t5
+        range: Seconds
+        multivalued: false
+        required: true
+        description: Time constant (<i>T5</i>).  Typical value = 4,5.
+      hlim:
+        slot_uri: cim:PssSTAB2A.hlim
+        range: PU
+        multivalued: false
+        required: true
+        description: Stabilizer output limiter (<i>H</i><i><sub>LIM</sub></i>).  Typical
+          value = 0,5.
+    is_a: PowerSystemStabilizerDynamics
+    description: 'Power system stabilizer part of an ABB excitation system.
+
+      [Footnote: ABB excitation systems are an example of suitable products available
+      commercially. This information is given for the convenience of users of this
+      document and does not constitute an endorsement by IEC of these products.]'
+  PssWECC:
+    class_uri: cim:PssWECC
+    attributes:
+      inputSignal1Type:
+        slot_uri: cim:PssWECC.inputSignal1Type
+        range: InputSignalKind
+        multivalued: false
+        required: true
+        description: 'Type of input signal #1 (rotorAngularFrequencyDeviation, busFrequencyDeviation,
+          generatorElectricalPower, generatorAcceleratingPower, busVoltage, or busVoltageDerivative
+          - shall be different than PssWECC.inputSignal2Type).  Typical value = rotorAngularFrequencyDeviation.'
+      inputSignal2Type:
+        slot_uri: cim:PssWECC.inputSignal2Type
+        range: InputSignalKind
+        multivalued: false
+        required: true
+        description: 'Type of input signal #2 (rotorAngularFrequencyDeviation, busFrequencyDeviation,
+          generatorElectricalPower, generatorAcceleratingPower, busVoltage, busVoltageDerivative
+          - shall be different than PssWECC.inputSignal1Type).  Typical value = busVoltageDerivative.'
+      k1:
+        slot_uri: cim:PssWECC.k1
+        range: PU
+        multivalued: false
+        required: true
+        description: Input signal 1 gain (<i>K</i><i><sub>1</sub></i>).  Typical value
+          = 1,13.
+      t1:
+        slot_uri: cim:PssWECC.t1
+        range: Seconds
+        multivalued: false
+        required: true
+        description: Input signal 1 transducer time constant (<i>T</i><i><sub>1</sub></i>)
+          (&gt;= 0).  Typical value = 0,037.
+      k2:
+        slot_uri: cim:PssWECC.k2
+        range: PU
+        multivalued: false
+        required: true
+        description: Input signal 2 gain (<i>K</i><i><sub>2</sub></i>).  Typical value
+          = 0,0.
+      t2:
+        slot_uri: cim:PssWECC.t2
+        range: Seconds
+        multivalued: false
+        required: true
+        description: Input signal 2 transducer time constant (<i>T</i><i><sub>2</sub></i>)
+          (&gt;= 0).  Typical value = 0,0.
+      t3:
+        slot_uri: cim:PssWECC.t3
+        range: Seconds
+        multivalued: false
+        required: true
+        description: Stabilizer washout time constant (<i>T</i><i><sub>3</sub></i>)
+          (&gt;= 0).  Typical value = 9,5.
+      t4:
+        slot_uri: cim:PssWECC.t4
+        range: Seconds
+        multivalued: false
+        required: true
+        description: Stabilizer washout time lag constant (<i>T</i><i><sub>4</sub></i>)
+          (&gt;= 0).  Typical value = 9,5.
+      t5:
+        slot_uri: cim:PssWECC.t5
+        range: Seconds
+        multivalued: false
+        required: true
+        description: Lead time constant (<i>T</i><i><sub>5</sub></i>) (&gt;= 0).  Typical
+          value = 1,7.
+      t6:
+        slot_uri: cim:PssWECC.t6
+        range: Seconds
+        multivalued: false
+        required: true
+        description: Lag time constant (<i>T</i><i><sub>6</sub></i>) (&gt;= 0).  Typical
+          value = 1,5.
+      t7:
+        slot_uri: cim:PssWECC.t7
+        range: Seconds
+        multivalued: false
+        required: true
+        description: Lead time constant (<i>T</i><i><sub>7</sub></i>) (&gt;= 0).  Typical
+          value = 1,7.
+      t8:
+        slot_uri: cim:PssWECC.t8
+        range: Seconds
+        multivalued: false
+        required: true
+        description: Lag time constant (<i>T</i><i><sub>8</sub></i>) (&gt;= 0).  Typical
+          value = 1,5.
+      t10:
+        slot_uri: cim:PssWECC.t10
+        range: Seconds
+        multivalued: false
+        required: true
+        description: Lag time constant (<i>T</i><i><sub>10</sub></i>) (&gt;= 0).  Typical
+          value = 0.
+      t9:
+        slot_uri: cim:PssWECC.t9
+        range: Seconds
+        multivalued: false
+        required: true
+        description: Lead time constant (<i>T</i><i><sub>9</sub></i>) (&gt;= 0).  Typical
+          value = 0.
+      vsmax:
+        slot_uri: cim:PssWECC.vsmax
+        range: PU
+        multivalued: false
+        required: true
+        description: Maximum output signal (<i>Vsmax</i>) (&gt; PssWECC.vsmin). Typical
+          value = 0,05.
+      vsmin:
+        slot_uri: cim:PssWECC.vsmin
+        range: PU
+        multivalued: false
+        required: true
+        description: Minimum output signal (<i>Vsmin</i>) (&lt; PssWECC.vsmax).  Typical
+          value = -0,05.
+      vcu:
+        slot_uri: cim:PssWECC.vcu
+        range: PU
+        multivalued: false
+        required: true
+        description: Maximum value for voltage compensator output (<i>V</i><i><sub>CU</sub></i>).
+          Typical value = 0.
+      vcl:
+        slot_uri: cim:PssWECC.vcl
+        range: PU
+        multivalued: false
+        required: true
+        description: Minimum value for voltage compensator output (<i>V</i><i><sub>CL</sub></i>).
+          Typical value = 0.
+    is_a: PowerSystemStabilizerDynamics
+    description: Dual input power system stabilizer, based on IEEE type 2, with modified
+      output limiter defined by WECC (Western Electricity Coordinating Council, USA).
+  DiscontinuousExcitationControlDynamics:
+    class_uri: cim:DiscontinuousExcitationControlDynamics
+    attributes:
+      RemoteInputSignal:
+        slot_uri: cim:DiscontinuousExcitationControlDynamics.RemoteInputSignal
+        range: RemoteInputSignal
+        multivalued: false
+        required: false
+        description: Remote input signal used by this discontinuous excitation control
+          system model.
+      ExcitationSystemDynamics:
+        slot_uri: cim:DiscontinuousExcitationControlDynamics.ExcitationSystemDynamics
+        range: ExcitationSystemDynamics
+        multivalued: false
+        required: true
+        description: Excitation system model with which this discontinuous excitation
+          control model is associated.
+    is_a: DynamicsFunctionBlock
+    description: Discontinuous excitation control function block whose behaviour is
+      described by reference to a standard model <font color="#0f0f0f">or by definition
+      of a user-defined model</font>.
+  DiscExcContIEEEDEC1A:
+    class_uri: cim:DiscExcContIEEEDEC1A
+    attributes:
+      vtlmt:
+        slot_uri: cim:DiscExcContIEEEDEC1A.vtlmt
+        range: PU
+        multivalued: false
+        required: true
+        description: Voltage reference (<i>V</i><i><sub>TLMT</sub></i>).  Typical
+          value = 1,1.
+      vomax:
+        slot_uri: cim:DiscExcContIEEEDEC1A.vomax
+        range: PU
+        multivalued: false
+        required: true
+        description: Limiter (<i>V</i><i><sub>OMAX</sub></i>) (&gt; DiscExcContIEEEDEC1A.vomin).  Typical
+          value = 0,3.
+      vomin:
+        slot_uri: cim:DiscExcContIEEEDEC1A.vomin
+        range: PU
+        multivalued: false
+        required: true
+        description: Limiter (<i>V</i><i><sub>OMIN</sub></i>) (&lt; DiscExcContIEEEDEC1A.vomax).  Typical
+          value = 0,1.
+      ketl:
+        slot_uri: cim:DiscExcContIEEEDEC1A.ketl
+        range: PU
+        multivalued: false
+        required: true
+        description: Terminal voltage limiter gain (<i>K</i><i><sub>ETL</sub></i>).  Typical
+          value = 47.
+      vtc:
+        slot_uri: cim:DiscExcContIEEEDEC1A.vtc
+        range: PU
+        multivalued: false
+        required: true
+        description: Terminal voltage level reference (<i>V</i><i><sub>TC</sub></i>).  Typical
+          value = 0,95.
+      val:
+        slot_uri: cim:DiscExcContIEEEDEC1A.val
+        range: PU
+        multivalued: false
+        required: true
+        description: Regulator voltage reference (<i>V</i><i><sub>AL</sub></i>).  Typical
+          value = 5,5.
+      esc:
+        slot_uri: cim:DiscExcContIEEEDEC1A.esc
+        range: PU
+        multivalued: false
+        required: true
+        description: Speed change reference (<i>E</i><i><sub>SC</sub></i>).  Typical
+          value = 0,0015.
+      kan:
+        slot_uri: cim:DiscExcContIEEEDEC1A.kan
+        range: PU
+        multivalued: false
+        required: true
+        description: Discontinuous controller gain (<i>K</i><i><sub>AN</sub></i>).  Typical
+          value = 400.
+      tan:
+        slot_uri: cim:DiscExcContIEEEDEC1A.tan
+        range: Seconds
+        multivalued: false
+        required: true
+        description: Discontinuous controller time constant (<i>T</i><i><sub>AN</sub></i>)
+          (&gt;= 0).  Typical value = 0,08.
+      tw5:
+        slot_uri: cim:DiscExcContIEEEDEC1A.tw5
+        range: Seconds
+        multivalued: false
+        required: true
+        description: DEC washout time constant (<i>T</i><i><sub>W</sub></i><sub>5</sub>)
+          (&gt;= 0).  Typical value = 5.
+      vsmax:
+        slot_uri: cim:DiscExcContIEEEDEC1A.vsmax
+        range: PU
+        multivalued: false
+        required: true
+        description: Limiter (<i>V</i><i><sub>SMAX</sub></i>)(&gt; DiscExcContIEEEDEC1A.vsmin).  Typical
+          value = 0,2.
+      vsmin:
+        slot_uri: cim:DiscExcContIEEEDEC1A.vsmin
+        range: PU
+        multivalued: false
+        required: true
+        description: Limiter (<i>V</i><i><sub>SMIN</sub></i>) (&lt; DiscExcContIEEEDEC1A.vsmax).  Typical
+          value = -0,066.
+      td:
+        slot_uri: cim:DiscExcContIEEEDEC1A.td
+        range: Seconds
+        multivalued: false
+        required: true
+        description: Time constant (<i>T</i><i><sub>D</sub></i>) (&gt;= 0).  Typical
+          value = 0,03.
+      tl1:
+        slot_uri: cim:DiscExcContIEEEDEC1A.tl1
+        range: Seconds
+        multivalued: false
+        required: true
+        description: Time constant (<i>T</i><i><sub>L</sub></i><sub>1</sub>) (&gt;=
+          0).  Typical value = 0,025.
+      tl2:
+        slot_uri: cim:DiscExcContIEEEDEC1A.tl2
+        range: Seconds
+        multivalued: false
+        required: true
+        description: Time constant (<i>T</i><i><sub>L</sub></i><sub>2</sub>) (&gt;=
+          0).  Typical value = 1,25.
+      vtm:
+        slot_uri: cim:DiscExcContIEEEDEC1A.vtm
+        range: PU
+        multivalued: false
+        required: true
+        description: Voltage limits (<i>V</i><i><sub>TM</sub></i>).  Typical value
+          = 1,13.
+      vtn:
+        slot_uri: cim:DiscExcContIEEEDEC1A.vtn
+        range: PU
+        multivalued: false
+        required: true
+        description: Voltage limits (<i>V</i><i><sub>TN</sub></i>).  Typical value
+          = 1,12.
+      vanmax:
+        slot_uri: cim:DiscExcContIEEEDEC1A.vanmax
+        range: PU
+        multivalued: false
+        required: true
+        description: Limiter for Van (<i>V</i><i><sub>ANMAX</sub></i>).
+    is_a: DiscontinuousExcitationControlDynamics
+    description: 'IEEE type DEC1A discontinuous excitation control model that boosts
+      generator excitation to a level higher than that demanded by the voltage regulator
+      and stabilizer immediately following a system fault.
+
+      Reference: IEEE 421.5-2005, 12.2.'
+  DiscExcContIEEEDEC2A:
+    class_uri: cim:DiscExcContIEEEDEC2A
+    attributes:
+      vk:
+        slot_uri: cim:DiscExcContIEEEDEC2A.vk
+        range: PU
+        multivalued: false
+        required: true
+        description: Discontinuous controller input reference (<i>V</i><i><sub>K</sub></i>).
+      td1:
+        slot_uri: cim:DiscExcContIEEEDEC2A.td1
+        range: Seconds
+        multivalued: false
+        required: true
+        description: Discontinuous controller time constant (<i>T</i><i><sub>D1</sub></i>)
+          (&gt;= 0).
+      td2:
+        slot_uri: cim:DiscExcContIEEEDEC2A.td2
+        range: Seconds
+        multivalued: false
+        required: true
+        description: Discontinuous controller washout time constant (<i>T</i><i><sub>D2</sub></i>)
+          (&gt;= 0).
+      vdmin:
+        slot_uri: cim:DiscExcContIEEEDEC2A.vdmin
+        range: PU
+        multivalued: false
+        required: true
+        description: Limiter (<i>V</i><i><sub>DMIN</sub></i>) (&lt; DiscExcContIEEEDEC2A.vdmax).
+      vdmax:
+        slot_uri: cim:DiscExcContIEEEDEC2A.vdmax
+        range: PU
+        multivalued: false
+        required: true
+        description: Limiter (<i>V</i><i><sub>DMAX</sub></i>) (&gt; DiscExcContIEEEDEC2A.vdmin).
+    is_a: DiscontinuousExcitationControlDynamics
+    description: 'IEEE type DEC2A model for discontinuous excitation control. This
+      system provides transient excitation boosting via an open-loop control as initiated
+      by a trigger signal generated remotely.
+
+      Reference: IEEE 421.5-2005 12.3.'
+  DiscExcContIEEEDEC3A:
+    class_uri: cim:DiscExcContIEEEDEC3A
+    attributes:
+      vtmin:
+        slot_uri: cim:DiscExcContIEEEDEC3A.vtmin
+        range: PU
+        multivalued: false
+        required: true
+        description: Terminal undervoltage comparison level (<i>V</i><i><sub>TMIN</sub></i>).
+      tdr:
+        slot_uri: cim:DiscExcContIEEEDEC3A.tdr
+        range: Seconds
+        multivalued: false
+        required: true
+        description: Reset time delay (<i>T</i><i><sub>DR</sub></i>) (&gt;= 0).
+    is_a: DiscontinuousExcitationControlDynamics
+    description: 'IEEE type DEC3A model. In some systems, the stabilizer output is
+      disconnected from the regulator immediately following a severe fault to prevent
+      the stabilizer from competing with action of voltage regulator during the first
+      swing.
+
+      Reference: IEEE 421.5-2005 12.4.'
+  PFVArControllerType1Dynamics:
+    class_uri: cim:PFVArControllerType1Dynamics
+    attributes:
+      RemoteInputSignal:
+        slot_uri: cim:PFVArControllerType1Dynamics.RemoteInputSignal
+        range: RemoteInputSignal
+        multivalued: false
+        required: false
+        description: Remote input signal used by this power factor or VAr controller
+          type 1 model.
+      ExcitationSystemDynamics:
+        slot_uri: cim:PFVArControllerType1Dynamics.ExcitationSystemDynamics
+        range: ExcitationSystemDynamics
+        multivalued: false
+        required: true
+        description: Excitation system model with which this power actor or VAr controller
+          type 1 model is associated.
+      VoltageAdjusterDynamics:
+        slot_uri: cim:PFVArControllerType1Dynamics.VoltageAdjusterDynamics
+        range: VoltageAdjusterDynamics
+        multivalued: false
+        required: false
+        description: Voltage adjuster model associated with this power factor or VAr
+          controller type 1 model.
+    is_a: DynamicsFunctionBlock
+    description: Power factor or VAr controller type 1 function block whose behaviour
+      is described by reference to a standard model <font color="#0f0f0f">or by definition
+      of a user-defined model.</font>
+  PFVArType1IEEEPFController:
+    class_uri: cim:PFVArType1IEEEPFController
+    attributes:
+      ovex:
+        slot_uri: cim:PFVArType1IEEEPFController.ovex
+        range: boolean
+        multivalued: false
+        required: true
+        description: 'Overexcitation Flag (<i>OVEX</i>)
+
+          true = overexcited
+
+          false = underexcited.'
+      tpfc:
+        slot_uri: cim:PFVArType1IEEEPFController.tpfc
+        range: Seconds
+        multivalued: false
+        required: true
+        description: PF controller time delay (<i>T</i><i><sub>PFC</sub></i>) (&gt;=
+          0).  Typical value = 5.
+      vitmin:
+        slot_uri: cim:PFVArType1IEEEPFController.vitmin
+        range: PU
+        multivalued: false
+        required: true
+        description: Minimum machine terminal current needed to enable pf/var controller
+          (<i>V</i><i><sub>ITMIN</sub></i>).
+      vpf:
+        slot_uri: cim:PFVArType1IEEEPFController.vpf
+        range: PU
+        multivalued: false
+        required: true
+        description: Synchronous machine power factor (<i>V</i><i><sub>PF</sub></i>).
+      vpfcbw:
+        slot_uri: cim:PFVArType1IEEEPFController.vpfcbw
+        range: float
+        multivalued: false
+        required: true
+        description: PF controller deadband (<i>V</i><i><sub>PFC_BW</sub></i>).  Typical
+          value = 0,05.
+      vpfref:
+        slot_uri: cim:PFVArType1IEEEPFController.vpfref
+        range: PU
+        multivalued: false
+        required: true
+        description: PF controller reference (<i>V</i><i><sub>PFREF</sub></i>).
+      vvtmax:
+        slot_uri: cim:PFVArType1IEEEPFController.vvtmax
+        range: PU
+        multivalued: false
+        required: true
+        description: Maximum machine terminal voltage needed for pf/var controller
+          to be enabled (<i>V</i><i><sub>VTMAX</sub></i>) (&gt; PFVArType1IEEEPFController.vvtmin).
+      vvtmin:
+        slot_uri: cim:PFVArType1IEEEPFController.vvtmin
+        range: PU
+        multivalued: false
+        required: true
+        description: Minimum machine terminal voltage needed to enable pf/var controller
+          (<i>V</i><i><sub>VTMIN</sub></i>) (&lt; PFVArType1IEEEPFController.vvtmax).
+    is_a: PFVArControllerType1Dynamics
+    description: 'IEEE PF controller type 1 which operates by moving the voltage reference
+      directly.
+
+      Reference: IEEE 421.5-2005, 11.2.'
+  PFVArType1IEEEVArController:
+    class_uri: cim:PFVArType1IEEEVArController
+    attributes:
+      tvarc:
+        slot_uri: cim:PFVArType1IEEEVArController.tvarc
+        range: Seconds
+        multivalued: false
+        required: true
+        description: Var controller time delay (<i>T</i><i><sub>VARC</sub></i>) (&gt;=
+          0).  Typical value = 5.
+      vvar:
+        slot_uri: cim:PFVArType1IEEEVArController.vvar
+        range: PU
+        multivalued: false
+        required: true
+        description: Synchronous machine power factor (<i>V</i><i><sub>VAR</sub></i>).
+      vvarcbw:
+        slot_uri: cim:PFVArType1IEEEVArController.vvarcbw
+        range: float
+        multivalued: false
+        required: true
+        description: Var controller deadband (<i>V</i><i><sub>VARC_BW</sub></i>).  Typical
+          value = 0,02.
+      vvarref:
+        slot_uri: cim:PFVArType1IEEEVArController.vvarref
+        range: PU
+        multivalued: false
+        required: true
+        description: Var controller reference (<i>V</i><i><sub>VARREF</sub></i>).
+      vvtmax:
+        slot_uri: cim:PFVArType1IEEEVArController.vvtmax
+        range: PU
+        multivalued: false
+        required: true
+        description: Maximum machine terminal voltage needed for pf/VAr controller
+          to be enabled (<i>V</i><i><sub>VTMAX</sub></i>) (&gt; PVFArType1IEEEVArController.vvtmin).
+      vvtmin:
+        slot_uri: cim:PFVArType1IEEEVArController.vvtmin
+        range: PU
+        multivalued: false
+        required: true
+        description: Minimum machine terminal voltage needed to enable pf/var controller
+          (<i>V</i><i><sub>VTMIN</sub></i>) (&lt; PVFArType1IEEEVArController.vvtmax).
+    is_a: PFVArControllerType1Dynamics
+    description: 'IEEE VAR controller type 1 which operates by moving the voltage
+      reference directly.
+
+      Reference: IEEE 421.5-2005, 11.3.'
+  VoltageAdjusterDynamics:
+    class_uri: cim:VoltageAdjusterDynamics
+    attributes:
+      PFVArControllerType1Dynamics:
+        slot_uri: cim:VoltageAdjusterDynamics.PFVArControllerType1Dynamics
+        range: PFVArControllerType1Dynamics
+        multivalued: false
+        required: true
+        description: Power factor or VAr controller type 1 model with which this voltage
+          adjuster is associated.
+    is_a: DynamicsFunctionBlock
+    description: Voltage adjuster function block whose behaviour is described by reference
+      to a standard model <font color="#0f0f0f">or by definition of a user-defined
+      model.</font>
+  VAdjIEEE:
+    class_uri: cim:VAdjIEEE
+    attributes:
+      vadjf:
+        slot_uri: cim:VAdjIEEE.vadjf
+        range: float
+        multivalued: false
+        required: true
+        description: Set high to provide a continuous raise or lower (<i>V</i><i><sub>ADJF</sub></i>).
+      adjslew:
+        slot_uri: cim:VAdjIEEE.adjslew
+        range: float
+        multivalued: false
+        required: true
+        description: Rate at which output of adjuster changes (<i>ADJ_SLEW</i>).  Unit
+          = s / PU.  Typical value = 300.
+      vadjmax:
+        slot_uri: cim:VAdjIEEE.vadjmax
+        range: PU
+        multivalued: false
+        required: true
+        description: Maximum output of the adjuster (<i>V</i><i><sub>ADJMAX</sub></i>)
+          (&gt; VAdjIEEE.vadjmin).  Typical value = 1,1.
+      vadjmin:
+        slot_uri: cim:VAdjIEEE.vadjmin
+        range: PU
+        multivalued: false
+        required: true
+        description: Minimum output of the adjuster (<i>V</i><i><sub>ADJMIN</sub></i>)
+          (&lt; VAdjIEEE.vadjmax).  Typical value = 0,9.
+      taon:
+        slot_uri: cim:VAdjIEEE.taon
+        range: Seconds
+        multivalued: false
+        required: true
+        description: Time that adjuster pulses are on (<i>T</i><i><sub>AON</sub></i>)
+          (&gt;= 0).  Typical value = 0,1.
+      taoff:
+        slot_uri: cim:VAdjIEEE.taoff
+        range: Seconds
+        multivalued: false
+        required: true
+        description: Time that adjuster pulses are off (<i>T</i><i><sub>AOFF</sub></i>)
+          (&gt;= 0).  Typical value = 0,5.
+    is_a: VoltageAdjusterDynamics
+    description: 'IEEE voltage adjuster which is used to represent the voltage adjuster
+      in either a power factor or VAr control system.
+
+      Reference: IEEE 421.5-2005, 11.1.'
+  PFVArControllerType2Dynamics:
+    class_uri: cim:PFVArControllerType2Dynamics
+    attributes:
+      ExcitationSystemDynamics:
+        slot_uri: cim:PFVArControllerType2Dynamics.ExcitationSystemDynamics
+        range: ExcitationSystemDynamics
+        multivalued: false
+        required: true
+        description: Excitation system model with which this power factor or VAr controller
+          type 2 is associated.
+    is_a: DynamicsFunctionBlock
+    description: Power factor or VAr controller type 2 function block whose behaviour
+      is described by reference to a standard model <font color="#0f0f0f">or by definition
+      of a user-defined model.</font>
+  PFVArType2IEEEPFController:
+    class_uri: cim:PFVArType2IEEEPFController
+    attributes:
+      pfref:
+        slot_uri: cim:PFVArType2IEEEPFController.pfref
+        range: PU
+        multivalued: false
+        required: true
+        description: Power factor reference (<i>P</i><i><sub>FREF</sub></i>).
+      vref:
+        slot_uri: cim:PFVArType2IEEEPFController.vref
+        range: PU
+        multivalued: false
+        required: true
+        description: Voltage regulator reference (<i>V</i><i><sub>REF</sub></i>).
+      vclmt:
+        slot_uri: cim:PFVArType2IEEEPFController.vclmt
+        range: PU
+        multivalued: false
+        required: true
+        description: Maximum output of the pf controller (<i>V</i><i><sub>CLMT</sub></i>).  Typical
+          value = 0,1.
+      kp:
+        slot_uri: cim:PFVArType2IEEEPFController.kp
+        range: PU
+        multivalued: false
+        required: true
+        description: Proportional gain of the pf controller (<i>K</i><i><sub>P</sub></i>).  Typical
+          value = 1.
+      ki:
+        slot_uri: cim:PFVArType2IEEEPFController.ki
+        range: PU
+        multivalued: false
+        required: true
+        description: Integral gain of the pf controller (<i>K</i><i><sub>I</sub></i>).  Typical
+          value = 1.
+      vs:
+        slot_uri: cim:PFVArType2IEEEPFController.vs
+        range: float
+        multivalued: false
+        required: true
+        description: Generator sensing voltage (<i>V</i><i><sub>S</sub></i>).
+      exlon:
+        slot_uri: cim:PFVArType2IEEEPFController.exlon
+        range: boolean
+        multivalued: false
+        required: true
+        description: 'Overexcitation or under excitation flag (<i>EXLON</i>)
+
+          true = 1 (not in the overexcitation or underexcitation state, integral action
+          is active)
+
+          false = 0 (in the overexcitation or underexcitation state, so integral action
+          is disabled to allow the limiter to play its role).'
+    is_a: PFVArControllerType2Dynamics
+    description: 'IEEE PF controller type 2 which is a summing point type controller
+      making up the outside loop of a two-loop system. This controller is implemented
+      as a slow PI type controller. The voltage regulator forms the inner loop and
+      is implemented as a fast controller.
+
+      Reference: IEEE 421.5-2005, 11.4.'
+  PFVArType2IEEEVArController:
+    class_uri: cim:PFVArType2IEEEVArController
+    attributes:
+      qref:
+        slot_uri: cim:PFVArType2IEEEVArController.qref
+        range: PU
+        multivalued: false
+        required: true
+        description: Reactive power reference (<i>Q</i><i><sub>REF</sub></i>).
+      vref:
+        slot_uri: cim:PFVArType2IEEEVArController.vref
+        range: PU
+        multivalued: false
+        required: true
+        description: Voltage regulator reference (<i>V</i><i><sub>REF</sub></i>).
+      vclmt:
+        slot_uri: cim:PFVArType2IEEEVArController.vclmt
+        range: PU
+        multivalued: false
+        required: true
+        description: Maximum output of the pf controller (<i>V</i><i><sub>CLMT</sub></i>).
+      kp:
+        slot_uri: cim:PFVArType2IEEEVArController.kp
+        range: PU
+        multivalued: false
+        required: true
+        description: Proportional gain of the pf controller (<i>K</i><i><sub>P</sub></i>).
+      ki:
+        slot_uri: cim:PFVArType2IEEEVArController.ki
+        range: PU
+        multivalued: false
+        required: true
+        description: Integral gain of the pf controller (<i>K</i><i><sub>I</sub></i>).
+      vs:
+        slot_uri: cim:PFVArType2IEEEVArController.vs
+        range: float
+        multivalued: false
+        required: true
+        description: Generator sensing voltage (<i>V</i><i><sub>S</sub></i>).
+      exlon:
+        slot_uri: cim:PFVArType2IEEEVArController.exlon
+        range: boolean
+        multivalued: false
+        required: true
+        description: 'Overexcitation or under excitation flag (<i>EXLON</i>)
+
+          true = 1 (not in the overexcitation or underexcitation state, integral action
+          is active)
+
+          false = 0 (in the overexcitation or underexcitation state, so integral action
+          is disabled to allow the limiter to play its role).'
+    is_a: PFVArControllerType2Dynamics
+    description: 'IEEE VAR controller type 2 which is a summing point type controller.
+      It makes up the outside loop of a two-loop system. This controller is implemented
+      as a slow PI type controller, and the voltage regulator forms the inner loop
+      and is implemented as a fast controller.
+
+      Reference: IEEE 421.5-2005, 11.5.'
+  PFVArType2Common1:
+    class_uri: cim:PFVArType2Common1
+    attributes:
+      j:
+        slot_uri: cim:PFVArType2Common1.j
+        range: boolean
+        multivalued: false
+        required: true
+        description: 'Selector (<i>J</i>).
+
+          true = control mode for reactive power
+
+          false = control mode for power factor.'
+      kp:
+        slot_uri: cim:PFVArType2Common1.kp
+        range: PU
+        multivalued: false
+        required: true
+        description: Proportional gain (<i>Kp</i>).
+      ki:
+        slot_uri: cim:PFVArType2Common1.ki
+        range: PU
+        multivalued: false
+        required: true
+        description: Reset gain (<i>Ki</i>).
+      max:
+        slot_uri: cim:PFVArType2Common1.max
+        range: PU
+        multivalued: false
+        required: true
+        description: Output limit (<i>max</i>).
+      ref:
+        slot_uri: cim:PFVArType2Common1.ref
+        range: PU
+        multivalued: false
+        required: true
+        description: 'Reference value of reactive power or power factor (<i>Ref</i>).
+
+          The reference value is initialised by this model. This initialisation can
+          override the value exchanged by this attribute to represent a plant operator''s
+          change of the reference setting.'
+    is_a: PFVArControllerType2Dynamics
+    description: 'Power factor / reactive power regulator. This model represents the
+      power factor or reactive power controller such as the Basler SCP-250. The controller
+      measures power factor or reactive power (PU on generator rated power) and compares
+      it with the operator''s set point.
+
+      [Footnote: Basler SCP-250 is an example of a suitable product available commercially.
+      This information is given for the convenience of users of this document and
+      does not constitute an endorsement by IEC of this product.]'
+  VoltageCompensatorDynamics:
+    class_uri: cim:VoltageCompensatorDynamics
+    attributes:
+      RemoteInputSignal:
+        slot_uri: cim:VoltageCompensatorDynamics.RemoteInputSignal
+        range: RemoteInputSignal
+        multivalued: false
+        required: false
+        description: Remote input signal used by this voltage compensator model.
+      ExcitationSystemDynamics:
+        slot_uri: cim:VoltageCompensatorDynamics.ExcitationSystemDynamics
+        range: ExcitationSystemDynamics
+        multivalued: false
+        required: true
+        description: Excitation system model with which this voltage compensator is
+          associated.
+    is_a: DynamicsFunctionBlock
+    description: Voltage compensator function block whose behaviour is described by
+      reference to a standard model <font color="#0f0f0f">or by definition of a user-defined
+      model.</font>
+  VCompIEEEType1:
+    class_uri: cim:VCompIEEEType1
+    attributes:
+      rc:
+        slot_uri: cim:VCompIEEEType1.rc
+        range: PU
+        multivalued: false
+        required: true
+        description: <font color="#0f0f0f">Resistive component of compensation of
+          a generator (<i>Rc</i>) (&gt;= 0).</font>
+      xc:
+        slot_uri: cim:VCompIEEEType1.xc
+        range: PU
+        multivalued: false
+        required: true
+        description: <font color="#0f0f0f">Reactive component of compensation of a
+          generator (<i>Xc</i>) (&gt;= 0).</font>
+      tr:
+        slot_uri: cim:VCompIEEEType1.tr
+        range: Seconds
+        multivalued: false
+        required: true
+        description: <font color="#0f0f0f">Time constant which is used for the combined
+          voltage sensing and compensation signal (<i>Tr</i>) (&gt;= 0).</font>
+    is_a: VoltageCompensatorDynamics
+    description: "<font color=\"#0f0f0f\">Terminal voltage transducer and load compensator\
+      \ as defined in IEEE 421.5-2005, 4. This model is common to all excitation system\
+      \ models described in the IEEE Standard. </font>\n<font color=\"#0f0f0f\">Parameter\
+      \ details:</font>\n<ol>\n\t<li><font color=\"#0f0f0f\">If <i>Rc</i> and <i>Xc</i>\
+      \ are set to zero, the l</font>oad compensation is not employed and the behaviour\
+      \ is as a simple sensing circuit.</li>\n</ol>\n<ol>\n\t<li>If all parameters\
+      \ (<i>Rc</i>, <i>Xc</i> and <i>Tr</i>) are set to zero, the standard model VCompIEEEType1\
+      \ is bypassed.</li>\n</ol>\nReference: IEEE 421.5-2005 4."
+  VCompIEEEType2:
+    class_uri: cim:VCompIEEEType2
+    attributes:
+      tr:
+        slot_uri: cim:VCompIEEEType2.tr
+        range: Seconds
+        multivalued: false
+        required: true
+        description: <font color="#0f0f0f">Time constant which is used for the combined
+          voltage sensing and compensation signal (<i>Tr</i>) (&gt;= 0).</font>
+      GenICompensationForGenJ:
+        slot_uri: cim:VCompIEEEType2.GenICompensationForGenJ
+        range: GenICompensationForGenJ
+        multivalued: true
+        required: true
+        description: Compensation of this voltage compensator's generator for current
+          flow out of another generator.
+    is_a: VoltageCompensatorDynamics
+    description: "<font color=\"#0f0f0f\">Terminal voltage transducer and load compensator\
+      \ as defined in IEEE 421.5-2005, 4. This model is designed to cover the following\
+      \ types of compensation: </font>\n<ul>\n\t<li><font color=\"#0f0f0f\">reactive\
+      \ droop;</font></li>\n\t<li><font color=\"#0f0f0f\">transformer-drop or line-drop\
+      \ compensation;</font></li>\n\t<li><font color=\"#0f0f0f\">reactive differential\
+      \ compensation known also as cross-current compensation.</font></li>\n</ul>\n\
+      <font color=\"#0f0f0f\">Reference: IEEE 421.5-2005, 4.</font>"
+  GenICompensationForGenJ:
+    class_uri: cim:GenICompensationForGenJ
+    attributes:
+      SynchronousMachineDynamics:
+        slot_uri: cim:GenICompensationForGenJ.SynchronousMachineDynamics
+        range: SynchronousMachineDynamics
+        multivalued: false
+        required: true
+        description: Standard synchronous machine out of which current flow is being
+          compensated for.
+      VcompIEEEType2:
+        slot_uri: cim:GenICompensationForGenJ.VcompIEEEType2
+        range: VCompIEEEType2
+        multivalued: false
+        required: true
+        description: The standard IEEE type 2 voltage compensator of this compensation.
+      rcij:
+        slot_uri: cim:GenICompensationForGenJ.rcij
+        range: PU
+        multivalued: false
+        required: true
+        description: <font color="#0f0f0f">Resistive component of compensation of
+          generator associated with this IEEE type 2 voltage compensator for current
+          flow out of another generator (<i>Rcij</i>).</font>
+      xcij:
+        slot_uri: cim:GenICompensationForGenJ.xcij
+        range: PU
+        multivalued: false
+        required: true
+        description: <font color="#0f0f0f">Reactive component of compensation of generator
+          associated with this IEEE type 2 voltage compensator for current flow out
+          of another generator (<i>Xcij</i>).</font>
+    is_a: IdentifiedObject
+    description: Resistive and reactive components of compensation for generator associated
+      with IEEE type 2 voltage compensator for current flow out of another generator
+      in the interconnection.
+  WindAeroConstIEC:
+    class_uri: cim:WindAeroConstIEC
+    attributes:
+      WindGenTurbineType1aIEC:
+        slot_uri: cim:WindAeroConstIEC.WindGenTurbineType1aIEC
+        range: WindGenTurbineType1aIEC
+        multivalued: false
+        required: true
+        description: Wind turbine type 1A model with which this wind aerodynamic model
+          is associated.
+    is_a: IdentifiedObject
+    description: 'Constant aerodynamic torque model which assumes that the aerodynamic
+      torque is constant.
+
+      Reference: IEC 61400-27-1:2015, 5.6.1.1.'
+  WindAeroOneDimIEC:
+    class_uri: cim:WindAeroOneDimIEC
+    attributes:
+      ka:
+        slot_uri: cim:WindAeroOneDimIEC.ka
+        range: float
+        multivalued: false
+        required: true
+        description: Aerodynamic gain (<i>k</i><i><sub>a</sub></i>). It is a type-dependent
+          parameter.
+      thetaomega:
+        slot_uri: cim:WindAeroOneDimIEC.thetaomega
+        range: AngleDegrees
+        multivalued: false
+        required: true
+        description: Initial pitch angle (<i>theta</i><i><sub>omega0</sub></i>). It
+          is a case-dependent parameter.
+      WindTurbineType3IEC:
+        slot_uri: cim:WindAeroOneDimIEC.WindTurbineType3IEC
+        range: WindTurbineType3IEC
+        multivalued: false
+        required: true
+        description: Wind turbine type 3 model with which this wind aerodynamic model
+          is associated.
+    is_a: IdentifiedObject
+    description: "One-dimensional aerodynamic model.  \nReference: IEC 61400-27-1:2015,\
+      \ 5.6.1.2."
+  WindAeroTwoDimIEC:
+    class_uri: cim:WindAeroTwoDimIEC
+    attributes:
+      dpomega:
+        slot_uri: cim:WindAeroTwoDimIEC.dpomega
+        range: PU
+        multivalued: false
+        required: true
+        description: Partial derivative of aerodynamic power with respect to changes
+          in WTR speed (<i>dp</i><i><sub>omega</sub></i>). It is a type-dependent
+          parameter.
+      dptheta:
+        slot_uri: cim:WindAeroTwoDimIEC.dptheta
+        range: PU
+        multivalued: false
+        required: true
+        description: Partial derivative of aerodynamic power with respect to changes
+          in pitch angle (<i>dp</i><i><sub>theta</sub></i>). It is a type-dependent
+          parameter.
+      dpv1:
+        slot_uri: cim:WindAeroTwoDimIEC.dpv1
+        range: PU
+        multivalued: false
+        required: true
+        description: Partial derivative (<i>dp</i><i><sub>v1</sub></i>). It is a type-dependent
+          parameter.
+      omegazero:
+        slot_uri: cim:WindAeroTwoDimIEC.omegazero
+        range: PU
+        multivalued: false
+        required: true
+        description: Rotor speed if the wind turbine is not derated (<i>omega</i><i><sub>0</sub></i>).
+          It is a type-dependent parameter.
+      pavail:
+        slot_uri: cim:WindAeroTwoDimIEC.pavail
+        range: PU
+        multivalued: false
+        required: true
+        description: Available aerodynamic power (<i>p</i><i><sub>avail</sub></i><i>)</i>.
+          It is a case-dependent parameter.
+      thetazero:
+        slot_uri: cim:WindAeroTwoDimIEC.thetazero
+        range: AngleDegrees
+        multivalued: false
+        required: true
+        description: Pitch angle if the wind turbine is not derated (<i>theta</i><i><sub>0</sub></i>).
+          It is a case-dependent parameter.
+      thetav2:
+        slot_uri: cim:WindAeroTwoDimIEC.thetav2
+        range: AngleDegrees
+        multivalued: false
+        required: true
+        description: Blade angle at twice rated wind speed (<i>theta</i><i><sub>v2</sub></i>).
+          It is a type-dependent parameter.
+      WindTurbineType3IEC:
+        slot_uri: cim:WindAeroTwoDimIEC.WindTurbineType3IEC
+        range: WindTurbineType3IEC
+        multivalued: false
+        required: true
+        description: Wind turbine type 3 model with which this wind aerodynamic model
+          is associated.
+    is_a: IdentifiedObject
+    description: "Two-dimensional aerodynamic model.  \nReference: IEC 61400-27-1:2015,\
+      \ 5.6.1.3."
+  WindContCurrLimIEC:
+    class_uri: cim:WindContCurrLimIEC
+    attributes:
+      imax:
+        slot_uri: cim:WindContCurrLimIEC.imax
+        range: PU
+        multivalued: false
+        required: true
+        description: Maximum continuous current at the wind turbine terminals (<i>i</i><i><sub>max</sub></i>).
+          It is a type-dependent parameter.
+      imaxdip:
+        slot_uri: cim:WindContCurrLimIEC.imaxdip
+        range: PU
+        multivalued: false
+        required: true
+        description: Maximum current during voltage dip at the wind turbine terminals
+          (<i>i</i><i><sub>maxdip</sub></i>). It is a project-dependent parameter.
+      kpqu:
+        slot_uri: cim:WindContCurrLimIEC.kpqu
+        range: PU
+        multivalued: false
+        required: true
+        description: Partial derivative of reactive current limit (<i>K</i><i><sub>pqu</sub></i>)
+          versus voltage. It is a type-dependent parameter.
+      mdfslim:
+        slot_uri: cim:WindContCurrLimIEC.mdfslim
+        range: boolean
+        multivalued: false
+        required: true
+        description: 'Limitation of type 3 stator current (<i>M</i><i><sub>DFSLim</sub></i>).
+          <i>M</i><i><sub>DFSLim</sub></i><sub> </sub>= 1 for wind turbines type 4.
+          It is a type-dependent parameter.
+
+          false= total current limitation (0 in the IEC model)
+
+          true=stator current limitation (1 in the IEC model).'
+      mqpri:
+        slot_uri: cim:WindContCurrLimIEC.mqpri
+        range: boolean
+        multivalued: false
+        required: true
+        description: 'Prioritisation of Q control during UVRT (<i>M</i><i><sub>qpri</sub></i>).
+          It is a project-dependent parameter.
+
+          true = reactive power priority (1 in the IEC model)
+
+          false = active power priority (0 in the IEC model).'
+      tufiltcl:
+        slot_uri: cim:WindContCurrLimIEC.tufiltcl
+        range: Seconds
+        multivalued: false
+        required: true
+        description: Voltage measurement filter time constant (<i>T</i><i><sub>ufiltcl</sub></i>)
+          (&gt;= 0). It is a type-dependent parameter.
+      upqumax:
+        slot_uri: cim:WindContCurrLimIEC.upqumax
+        range: PU
+        multivalued: false
+        required: true
+        description: Wind turbine voltage in the operation point where zero reactive
+          current can be delivered (<i>u</i><i><sub>pqumax</sub></i>). It is a type-dependent
+          parameter.
+      WindTurbineType3or4IEC:
+        slot_uri: cim:WindContCurrLimIEC.WindTurbineType3or4IEC
+        range: WindTurbineType3or4IEC
+        multivalued: false
+        required: true
+        description: Wind turbine type 3 or type 4 model with which this wind control
+          current limitation model is associated.
+      WindDynamicsLookupTable:
+        slot_uri: cim:WindContCurrLimIEC.WindDynamicsLookupTable
+        range: WindDynamicsLookupTable
+        multivalued: true
+        required: true
+        description: The wind dynamics lookup table associated with this current control
+          limitation model.
+    is_a: IdentifiedObject
+    description: 'Current limitation model.  The current limitation model combines
+      the physical limits and the control limits.
+
+      Reference: IEC 61400-27-1:2015, 5.6.5.8.'
+  WindContPitchAngleIEC:
+    class_uri: cim:WindContPitchAngleIEC
+    attributes:
+      dthetamax:
+        slot_uri: cim:WindContPitchAngleIEC.dthetamax
+        range: float
+        multivalued: false
+        required: true
+        description: Maximum pitch positive ramp rate (<i>dtheta</i><i><sub>max</sub></i>)
+          (&gt; WindContPitchAngleIEC.dthetamin). It is a type-dependent parameter.
+          Unit = degrees / s.
+      dthetamin:
+        slot_uri: cim:WindContPitchAngleIEC.dthetamin
+        range: float
+        multivalued: false
+        required: true
+        description: Maximum pitch negative ramp rate (<i>dtheta</i><i><sub>min</sub></i><i>)</i>
+          (&lt; WindContPitchAngleIEC.dthetamax). It is a type-dependent parameter.
+          Unit = degrees / s.
+      kic:
+        slot_uri: cim:WindContPitchAngleIEC.kic
+        range: PU
+        multivalued: false
+        required: true
+        description: Power PI controller integration gain (<i>K</i><i><sub>Ic</sub></i>).
+          It is a type-dependent parameter.
+      kiomega:
+        slot_uri: cim:WindContPitchAngleIEC.kiomega
+        range: PU
+        multivalued: false
+        required: true
+        description: Speed PI controller integration gain (<i>K</i><i><sub>Iomega</sub></i>).
+          It is a type-dependent parameter.
+      kpc:
+        slot_uri: cim:WindContPitchAngleIEC.kpc
+        range: PU
+        multivalued: false
+        required: true
+        description: Power PI controller proportional gain (<i>K</i><i><sub>Pc</sub></i>).
+          It is a type-dependent parameter.
+      kpomega:
+        slot_uri: cim:WindContPitchAngleIEC.kpomega
+        range: PU
+        multivalued: false
+        required: true
+        description: Speed PI controller proportional gain (<i>K</i><i><sub>Pomega</sub></i>).
+          It is a type-dependent parameter.
+      kpx:
+        slot_uri: cim:WindContPitchAngleIEC.kpx
+        range: PU
+        multivalued: false
+        required: true
+        description: Pitch cross coupling gain (<i>K</i><i><sub>PX</sub></i>). It
+          is a type-dependent parameter.
+      thetamax:
+        slot_uri: cim:WindContPitchAngleIEC.thetamax
+        range: AngleDegrees
+        multivalued: false
+        required: true
+        description: Maximum pitch angle (<i>theta</i><i><sub>max</sub></i>) (&gt;
+          WindContPitchAngleIEC.thetamin). It is a type-dependent parameter.
+      thetamin:
+        slot_uri: cim:WindContPitchAngleIEC.thetamin
+        range: AngleDegrees
+        multivalued: false
+        required: true
+        description: Minimum pitch angle (<i>theta</i><i><sub>min</sub></i>) (&lt;
+          WindContPitchAngleIEC.thetamax). It is a type-dependent parameter.
+      ttheta:
+        slot_uri: cim:WindContPitchAngleIEC.ttheta
+        range: Seconds
+        multivalued: false
+        required: true
+        description: Pitch time constant (<i>ttheta</i>) (&gt;= 0). It is a type-dependent
+          parameter.
+      WindTurbineType3IEC:
+        slot_uri: cim:WindContPitchAngleIEC.WindTurbineType3IEC
+        range: WindTurbineType3IEC
+        multivalued: false
+        required: true
+        description: Wind turbine type 3 model with which this pitch control model
+          is associated.
+    is_a: IdentifiedObject
+    description: 'Pitch angle control model.
+
+      Reference: IEC 61400-27-1:2015, 5.6.5.2.'
+  WindContPType3IEC:
+    class_uri: cim:WindContPType3IEC
+    attributes:
+      dpmax:
+        slot_uri: cim:WindContPType3IEC.dpmax
+        range: PU
+        multivalued: false
+        required: true
+        description: Maximum wind turbine power ramp rate (<i>dp</i><i><sub>max</sub></i>).
+          It is a type-dependent parameter.
+      dprefmax:
+        slot_uri: cim:WindContPType3IEC.dprefmax
+        range: PU
+        multivalued: false
+        required: true
+        description: Maximum ramp rate of wind turbine reference power (<i>dp</i><i><sub>refmax</sub></i>).
+          It is a project-dependent parameter.
+      dprefmin:
+        slot_uri: cim:WindContPType3IEC.dprefmin
+        range: PU
+        multivalued: false
+        required: true
+        description: Minimum ramp rate of wind turbine reference power (<i>dp</i><i><sub>refmin</sub></i>).
+          It is a project-dependent parameter.
+      dthetamax:
+        slot_uri: cim:WindContPType3IEC.dthetamax
+        range: PU
+        multivalued: false
+        required: true
+        description: Ramp limitation of torque, required in some grid codes (<i>dt</i><i><sub>max</sub></i>).
+          It is a project-dependent parameter.
+      dthetamaxuvrt:
+        slot_uri: cim:WindContPType3IEC.dthetamaxuvrt
+        range: PU
+        multivalued: false
+        required: true
+        description: Limitation of torque rise rate during UVRT (<i>dtheta</i><i><sub>maxUVRT</sub></i>).
+          It is a project-dependent parameter.
+      kdtd:
+        slot_uri: cim:WindContPType3IEC.kdtd
+        range: PU
+        multivalued: false
+        required: true
+        description: Gain for active drive train damping (<i>K</i><i><sub>DTD</sub></i>).
+          It is a type-dependent parameter.
+      kip:
+        slot_uri: cim:WindContPType3IEC.kip
+        range: PU
+        multivalued: false
+        required: true
+        description: PI controller integration parameter (<i>K</i><sub>Ip</sub>).
+          It is a type-dependent parameter.
+      kpp:
+        slot_uri: cim:WindContPType3IEC.kpp
+        range: PU
+        multivalued: false
+        required: true
+        description: PI controller proportional gain (<i>K</i><sub>Pp</sub>). It is
+          a type-dependent parameter.
+      mpuvrt:
+        slot_uri: cim:WindContPType3IEC.mpuvrt
+        range: boolean
+        multivalued: false
+        required: true
+        description: 'Enable UVRT power control mode (<i>M</i><i><sub>pUVRT</sub></i><sub>)</sub>.  It
+          is a project-dependent parameter.
+
+          true = voltage control (1 in the IEC model)
+
+          false = reactive power control (0 in the IEC model).'
+      omegaoffset:
+        slot_uri: cim:WindContPType3IEC.omegaoffset
+        range: PU
+        multivalued: false
+        required: true
+        description: Offset to reference value that limits controller action during
+          rotor speed changes (<i>omega</i><i><sub>offset</sub></i>). It is a case-dependent
+          parameter.
+      pdtdmax:
+        slot_uri: cim:WindContPType3IEC.pdtdmax
+        range: PU
+        multivalued: false
+        required: true
+        description: Maximum active drive train damping power (<i>p</i><sub>DTDmax</sub>).
+          It is a type-dependent parameter.
+      tdvs:
+        slot_uri: cim:WindContPType3IEC.tdvs
+        range: Seconds
+        multivalued: false
+        required: true
+        description: Time<sub> </sub>delay after deep voltage sags (<i>T</i><i><sub>DVS</sub></i>)
+          (&gt;= 0). It is a project-dependent parameter.
+      thetaemin:
+        slot_uri: cim:WindContPType3IEC.thetaemin
+        range: PU
+        multivalued: false
+        required: true
+        description: Minimum electrical generator torque (<i>t</i><sub>emin</sub>).
+          It is a type-dependent parameter.
+      thetauscale:
+        slot_uri: cim:WindContPType3IEC.thetauscale
+        range: PU
+        multivalued: false
+        required: true
+        description: Voltage scaling factor of reset-torque (<i>t</i><sub>uscale</sub>).
+          It is a project-dependent parameter.
+      tomegafiltp3:
+        slot_uri: cim:WindContPType3IEC.tomegafiltp3
+        range: Seconds
+        multivalued: false
+        required: true
+        description: Filter time constant for generator speed measurement (<i>T</i><sub>omegafiltp3</sub>)
+          (&gt;= 0). It is a type-dependent parameter.
+      tpfiltp3:
+        slot_uri: cim:WindContPType3IEC.tpfiltp3
+        range: Seconds
+        multivalued: false
+        required: true
+        description: Filter time constant for power measurement (<i>T</i><sub>pfiltp3</sub>)
+          (&gt;= 0). It is a type-dependent parameter.
+      tpord:
+        slot_uri: cim:WindContPType3IEC.tpord
+        range: PU
+        multivalued: false
+        required: true
+        description: Time constant in power order lag (<i>T</i><sub>pord</sub>). It
+          is a type-dependent parameter.
+      tufiltp3:
+        slot_uri: cim:WindContPType3IEC.tufiltp3
+        range: Seconds
+        multivalued: false
+        required: true
+        description: Filter time constant for voltage measurement (<i>T</i><sub>ufiltp3</sub>)
+          (&gt;= 0). It is a type-dependent parameter.
+      tomegaref:
+        slot_uri: cim:WindContPType3IEC.tomegaref
+        range: Seconds
+        multivalued: false
+        required: true
+        description: Time constant in speed reference filter (<i>T</i><sub>omega,ref</sub>)
+          (&gt;= 0). It is a type-dependent parameter.
+      udvs:
+        slot_uri: cim:WindContPType3IEC.udvs
+        range: PU
+        multivalued: false
+        required: true
+        description: Voltage limit for hold UVRT status after deep voltage sags (<i>u</i><i><sub>DVS</sub></i>).
+          It is a project-dependent parameter.
+      updip:
+        slot_uri: cim:WindContPType3IEC.updip
+        range: PU
+        multivalued: false
+        required: true
+        description: Voltage dip threshold for P-control (<i>u</i><sub>Pdip</sub>).  Part
+          of turbine control, often different (e.g 0.8) from converter thresholds.
+          It is a project-dependent parameter.
+      omegadtd:
+        slot_uri: cim:WindContPType3IEC.omegadtd
+        range: PU
+        multivalued: false
+        required: true
+        description: Active drive train damping frequency (<i>omega</i><i><sub>DTD</sub></i>).
+          It can be calculated from two mass model parameters. It is a type-dependent
+          parameter.
+      zeta:
+        slot_uri: cim:WindContPType3IEC.zeta
+        range: float
+        multivalued: false
+        required: true
+        description: Coefficient for active drive train damping (<i>zeta</i>). It
+          is a type-dependent parameter.
+      WindTurbineType3IEC:
+        slot_uri: cim:WindContPType3IEC.WindTurbineType3IEC
+        range: WindTurbineType3IEC
+        multivalued: false
+        required: true
+        description: Wind turbine type 3 model with which this wind control P type
+          3 model is associated.
+      WindDynamicsLookupTable:
+        slot_uri: cim:WindContPType3IEC.WindDynamicsLookupTable
+        range: WindDynamicsLookupTable
+        multivalued: true
+        required: true
+        description: The wind dynamics lookup table associated with this P control
+          type 3 model.
+    is_a: IdentifiedObject
+    description: 'P control model type 3.
+
+      Reference: IEC 61400-27-1:2015, 5.6.5.4.'
+  WindContPType4aIEC:
+    class_uri: cim:WindContPType4aIEC
+    attributes:
+      dpmaxp4a:
+        slot_uri: cim:WindContPType4aIEC.dpmaxp4a
+        range: PU
+        multivalued: false
+        required: true
+        description: Maximum wind turbine power ramp rate (<i>dp</i><i><sub>maxp4A</sub></i>).
+          It is a project-dependent parameter.
+      tpordp4a:
+        slot_uri: cim:WindContPType4aIEC.tpordp4a
+        range: Seconds
+        multivalued: false
+        required: true
+        description: Time constant in power order lag (<i>T</i><i><sub>pordp4A</sub></i>)
+          (&gt;= 0). It is a type-dependent parameter.
+      tufiltp4a:
+        slot_uri: cim:WindContPType4aIEC.tufiltp4a
+        range: Seconds
+        multivalued: false
+        required: true
+        description: Voltage measurement filter time constant (<i>T</i><i><sub>ufiltp4A</sub></i>)
+          (&gt;= 0). It is a type-dependent parameter.
+      WindTurbineType4aIEC:
+        slot_uri: cim:WindContPType4aIEC.WindTurbineType4aIEC
+        range: WindTurbineType4aIEC
+        multivalued: false
+        required: true
+        description: Wind turbine type 4A model with which this wind control P type
+          4A model is associated.
+    is_a: IdentifiedObject
+    description: 'P control model type 4A.
+
+      Reference: IEC 61400-27-1:2015, 5.6.5.5.'
+  WindContPType4bIEC:
+    class_uri: cim:WindContPType4bIEC
+    attributes:
+      dpmaxp4b:
+        slot_uri: cim:WindContPType4bIEC.dpmaxp4b
+        range: PU
+        multivalued: false
+        required: true
+        description: Maximum wind turbine power ramp rate (<i>dp</i><i><sub>maxp4B</sub></i>).
+          It is a project-dependent parameter.
+      tpaero:
+        slot_uri: cim:WindContPType4bIEC.tpaero
+        range: Seconds
+        multivalued: false
+        required: true
+        description: Time constant in aerodynamic power response (<i>T</i><i><sub>paero</sub></i>)
+          (&gt;= 0). It is a type-dependent parameter.
+      tpordp4b:
+        slot_uri: cim:WindContPType4bIEC.tpordp4b
+        range: Seconds
+        multivalued: false
+        required: true
+        description: Time constant in power order lag (<i>T</i><i><sub>pordp4B</sub></i>)
+          (&gt;= 0). It is a type-dependent parameter.
+      tufiltp4b:
+        slot_uri: cim:WindContPType4bIEC.tufiltp4b
+        range: Seconds
+        multivalued: false
+        required: true
+        description: Voltage measurement filter time constant (<i>T</i><i><sub>ufiltp4B</sub></i>)
+          (&gt;= 0). It is a type-dependent parameter.
+      WindTurbineType4bIEC:
+        slot_uri: cim:WindContPType4bIEC.WindTurbineType4bIEC
+        range: WindTurbineType4bIEC
+        multivalued: false
+        required: true
+        description: Wind turbine type 4B model with which this wind control P type
+          4B model is associated.
+    is_a: IdentifiedObject
+    description: 'P control model type 4B.
+
+      Reference: IEC 61400-27-1:2015, 5.6.5.6.'
+  WindContQIEC:
+    class_uri: cim:WindContQIEC
+    attributes:
+      iqh1:
+        slot_uri: cim:WindContQIEC.iqh1
+        range: PU
+        multivalued: false
+        required: true
+        description: Maximum reactive current injection during dip (<i>i</i><i><sub>qh1</sub></i>).
+          It is a type-dependent parameter.
+      iqmax:
+        slot_uri: cim:WindContQIEC.iqmax
+        range: PU
+        multivalued: false
+        required: true
+        description: Maximum reactive current injection (<i>i</i><i><sub>qmax</sub></i>)
+          (&gt; WindContQIEC.iqmin). It is a type-dependent parameter.
+      iqmin:
+        slot_uri: cim:WindContQIEC.iqmin
+        range: PU
+        multivalued: false
+        required: true
+        description: Minimum reactive current injection (<i>i</i><i><sub>qmin</sub></i>)
+          (&lt; WindContQIEC.iqmax). It is a type-dependent parameter.
+      iqpost:
+        slot_uri: cim:WindContQIEC.iqpost
+        range: PU
+        multivalued: false
+        required: true
+        description: Post fault reactive current injection (<i>i</i><i><sub>qpost</sub></i>).
+          It is a project-dependent parameter.
+      kiq:
+        slot_uri: cim:WindContQIEC.kiq
+        range: PU
+        multivalued: false
+        required: true
+        description: Reactive power PI controller integration gain (<i>K</i><i><sub>I,q</sub></i>).
+          It is a type-dependent parameter.
+      kiu:
+        slot_uri: cim:WindContQIEC.kiu
+        range: PU
+        multivalued: false
+        required: true
+        description: Voltage PI controller integration gain (<i>K</i><i><sub>I,u</sub></i>).
+          It is a type-dependent parameter.
+      kpq:
+        slot_uri: cim:WindContQIEC.kpq
+        range: PU
+        multivalued: false
+        required: true
+        description: Reactive power PI controller proportional gain (<i>K</i><i><sub>P,q</sub></i>).
+          It is a type-dependent parameter.
+      kpu:
+        slot_uri: cim:WindContQIEC.kpu
+        range: PU
+        multivalued: false
+        required: true
+        description: Voltage PI controller proportional gain (<i>K</i><i><sub>P,u</sub></i>).
+          It is a type-dependent parameter.
+      kqv:
+        slot_uri: cim:WindContQIEC.kqv
+        range: PU
+        multivalued: false
+        required: true
+        description: Voltage scaling factor for UVRT current (<i>K</i><i><sub>qv</sub></i>).
+          It is a project-dependent parameter.
+      tpfiltq:
+        slot_uri: cim:WindContQIEC.tpfiltq
+        range: Seconds
+        multivalued: false
+        required: true
+        description: Power measurement filter time constant (<i>T</i><i><sub>pfiltq</sub></i>)
+          (&gt;= 0). It is a type-dependent parameter.
+      rdroop:
+        slot_uri: cim:WindContQIEC.rdroop
+        range: PU
+        multivalued: false
+        required: true
+        description: Resistive component of voltage drop impedance (<i>r</i><i><sub>droop</sub></i>)
+          (&gt;= 0). It is a project-dependent parameter.
+      tufiltq:
+        slot_uri: cim:WindContQIEC.tufiltq
+        range: Seconds
+        multivalued: false
+        required: true
+        description: Voltage measurement filter time constant (<i>T</i><i><sub>ufiltq</sub></i>)
+          (&gt;= 0). It is a type-dependent parameter.
+      tpost:
+        slot_uri: cim:WindContQIEC.tpost
+        range: Seconds
+        multivalued: false
+        required: true
+        description: Length of time period where post fault reactive power is injected
+          (<i>T</i><i><sub>post</sub></i>) (&gt;= 0). It is a project-dependent parameter.
+      tqord:
+        slot_uri: cim:WindContQIEC.tqord
+        range: Seconds
+        multivalued: false
+        required: true
+        description: Time constant in reactive power order lag (<i>T</i><i><sub>qord</sub></i>)
+          (&gt;= 0). It is a type-dependent parameter.
+      udb1:
+        slot_uri: cim:WindContQIEC.udb1
+        range: PU
+        multivalued: false
+        required: true
+        description: Voltage deadband lower limit (<i>u</i><i><sub>db1</sub></i>).
+          It is a type-dependent parameter.
+      udb2:
+        slot_uri: cim:WindContQIEC.udb2
+        range: PU
+        multivalued: false
+        required: true
+        description: Voltage deadband upper limit (<i>u</i><i><sub>db2</sub></i>).
+          It is a type-dependent parameter.
+      umax:
+        slot_uri: cim:WindContQIEC.umax
+        range: PU
+        multivalued: false
+        required: true
+        description: Maximum voltage in voltage PI controller integral term (<i>u</i><i><sub>max</sub></i>)
+          (&gt; WindContQIEC.umin). It is a type-dependent parameter.
+      umin:
+        slot_uri: cim:WindContQIEC.umin
+        range: PU
+        multivalued: false
+        required: true
+        description: Minimum voltage in voltage PI controller integral term (<i>u</i><i><sub>min</sub></i>)
+          (&lt; WindContQIEC.umax). It is a type-dependent parameter.
+      uqdip:
+        slot_uri: cim:WindContQIEC.uqdip
+        range: PU
+        multivalued: false
+        required: true
+        description: Voltage threshold for UVRT detection in Q control (<i>u</i><i><sub>qdip</sub></i>).
+          It is a type-dependent parameter.
+      uref0:
+        slot_uri: cim:WindContQIEC.uref0
+        range: PU
+        multivalued: false
+        required: true
+        description: User-defined bias in voltage reference (<i>u</i><i><sub>ref0</sub></i>).
+          It is a case-dependent parameter.
+      windQcontrolModesType:
+        slot_uri: cim:WindContQIEC.windQcontrolModesType
+        range: WindQcontrolModeKind
+        multivalued: false
+        required: true
+        description: Types of general wind turbine Q control modes (<i>M</i><i><sub>qG</sub></i>).  It
+          is a project-dependent parameter.
+      windUVRTQcontrolModesType:
+        slot_uri: cim:WindContQIEC.windUVRTQcontrolModesType
+        range: WindUVRTQcontrolModeKind
+        multivalued: false
+        required: true
+        description: Types of UVRT Q control modes (<i>M</i><i><sub>qUVRT</sub></i>).
+          It is a project-dependent parameter.
+      xdroop:
+        slot_uri: cim:WindContQIEC.xdroop
+        range: PU
+        multivalued: false
+        required: true
+        description: Inductive component of voltage drop impedance (<i>x</i><i><sub>droop</sub></i>)
+          (&gt;= 0). It is a project-dependent parameter.
+      WindTurbineType3or4IEC:
+        slot_uri: cim:WindContQIEC.WindTurbineType3or4IEC
+        range: WindTurbineType3or4IEC
+        multivalued: false
+        required: true
+        description: Wind turbine type 3 or type 4 model with which this reactive
+          control model is associated.
+    is_a: IdentifiedObject
+    description: 'Q control model.
+
+      Reference: IEC 61400-27-1:2015, 5.6.5.7.'
+  WindContQLimIEC:
+    class_uri: cim:WindContQLimIEC
+    attributes:
+      qmax:
+        slot_uri: cim:WindContQLimIEC.qmax
+        range: PU
+        multivalued: false
+        required: true
+        description: Maximum reactive power (<i>q</i><i><sub>max</sub></i>) (&gt;
+          WindContQLimIEC.qmin). It is a type-dependent parameter.
+      qmin:
+        slot_uri: cim:WindContQLimIEC.qmin
+        range: PU
+        multivalued: false
+        required: true
+        description: Minimum reactive power (<i>q</i><i><sub>min</sub></i>) (&lt;
+          WindContQLimIEC.qmax). It is a type-dependent parameter.
+      WindTurbineType3or4IEC:
+        slot_uri: cim:WindContQLimIEC.WindTurbineType3or4IEC
+        range: WindTurbineType3or4IEC
+        multivalued: false
+        required: false
+        description: Wind generator type 3 or type 4 model with which this constant
+          Q limitation model is associated.
+    is_a: IdentifiedObject
+    description: 'Constant Q limitation model.
+
+      Reference: IEC 61400-27-1:2015, 5.6.5.9.'
+  WindContQPQULimIEC:
+    class_uri: cim:WindContQPQULimIEC
+    attributes:
+      tpfiltql:
+        slot_uri: cim:WindContQPQULimIEC.tpfiltql
+        range: Seconds
+        multivalued: false
+        required: true
+        description: Power measurement filter time constant for Q capacity (<i>T</i><i><sub>pfiltql</sub></i>)
+          (&gt;= 0). It is a type-dependent parameter.
+      tufiltql:
+        slot_uri: cim:WindContQPQULimIEC.tufiltql
+        range: Seconds
+        multivalued: false
+        required: true
+        description: Voltage measurement filter time constant for Q capacity (<i>T</i><i><sub>ufiltql</sub></i>)
+          (&gt;= 0). It is a type-dependent parameter.
+      WindTurbineType3or4IEC:
+        slot_uri: cim:WindContQPQULimIEC.WindTurbineType3or4IEC
+        range: WindTurbineType3or4IEC
+        multivalued: false
+        required: false
+        description: Wind generator type 3 or type 4 model with which this QP and
+          QU limitation model is associated.
+      WindDynamicsLookupTable:
+        slot_uri: cim:WindContQPQULimIEC.WindDynamicsLookupTable
+        range: WindDynamicsLookupTable
+        multivalued: true
+        required: true
+        description: The wind dynamics lookup table associated with this QP and QU
+          limitation model.
+    is_a: IdentifiedObject
+    description: 'QP and QU limitation model.
+
+      Reference: IEC 61400-27-1:2015, 5.6.5.10.'
+  WindContRotorRIEC:
+    class_uri: cim:WindContRotorRIEC
+    attributes:
+      kirr:
+        slot_uri: cim:WindContRotorRIEC.kirr
+        range: PU
+        multivalued: false
+        required: true
+        description: Integral gain in rotor resistance PI controller (<i>K</i><i><sub>Irr</sub></i>).
+          It is a type-dependent parameter.
+      komegafilt:
+        slot_uri: cim:WindContRotorRIEC.komegafilt
+        range: float
+        multivalued: false
+        required: true
+        description: Filter gain for generator speed measurement (<i>K</i><i><sub>omegafilt</sub></i>).
+          It is a type-dependent parameter.
+      kpfilt:
+        slot_uri: cim:WindContRotorRIEC.kpfilt
+        range: float
+        multivalued: false
+        required: true
+        description: Filter gain for power measurement (<i>K</i><i><sub>pfilt</sub></i>).
+          It is a type-dependent parameter.
+      kprr:
+        slot_uri: cim:WindContRotorRIEC.kprr
+        range: PU
+        multivalued: false
+        required: true
+        description: Proportional gain in rotor resistance PI controller (<i>K</i><i><sub>Prr</sub></i>).
+          It is a type-dependent parameter.
+      rmax:
+        slot_uri: cim:WindContRotorRIEC.rmax
+        range: PU
+        multivalued: false
+        required: true
+        description: Maximum rotor resistance (<i>r</i><i><sub>max</sub></i>) (&gt;
+          WindContRotorRIEC.rmin). It is a type-dependent parameter.
+      rmin:
+        slot_uri: cim:WindContRotorRIEC.rmin
+        range: PU
+        multivalued: false
+        required: true
+        description: Minimum rotor resistance (<i>r</i><i><sub>min</sub></i>) (&lt;
+          WindContRotorRIEC.rmax). It is a type-dependent parameter.
+      tomegafiltrr:
+        slot_uri: cim:WindContRotorRIEC.tomegafiltrr
+        range: Seconds
+        multivalued: false
+        required: true
+        description: Filter time constant for generator speed measurement (<i>T</i><i><sub>omegafiltrr</sub></i>)
+          (&gt;= 0). It is a type-dependent parameter.
+      tpfiltrr:
+        slot_uri: cim:WindContRotorRIEC.tpfiltrr
+        range: Seconds
+        multivalued: false
+        required: true
+        description: Filter time constant for power measurement (<i>T</i><i><sub>pfiltrr</sub></i>)
+          (&gt;= 0). It is a type-dependent parameter.
+      WindDynamicsLookupTable:
+        slot_uri: cim:WindContRotorRIEC.WindDynamicsLookupTable
+        range: WindDynamicsLookupTable
+        multivalued: true
+        required: true
+        description: The wind dynamics lookup table associated with this rotor resistance
+          control model.
+      WindGenTurbineType2IEC:
+        slot_uri: cim:WindContRotorRIEC.WindGenTurbineType2IEC
+        range: WindGenTurbineType2IEC
+        multivalued: false
+        required: true
+        description: Wind turbine type 2 model with whitch this wind control rotor
+          resistance model is associated.
+    is_a: IdentifiedObject
+    description: 'Rotor resistance control model.
+
+      Reference: IEC 61400-27-1:2015, 5.6.5.3.'
+  WindDynamicsLookupTable:
+    class_uri: cim:WindDynamicsLookupTable
+    attributes:
+      WindContCurrLimIEC:
+        slot_uri: cim:WindDynamicsLookupTable.WindContCurrLimIEC
+        range: WindContCurrLimIEC
+        multivalued: false
+        required: false
+        description: The current control limitation model with which this wind dynamics
+          lookup table is associated.
+      WindContPType3IEC:
+        slot_uri: cim:WindDynamicsLookupTable.WindContPType3IEC
+        range: WindContPType3IEC
+        multivalued: false
+        required: false
+        description: The P control type 3 model with which this wind dynamics lookup
+          table is associated.
+      WindContQPQULimIEC:
+        slot_uri: cim:WindDynamicsLookupTable.WindContQPQULimIEC
+        range: WindContQPQULimIEC
+        multivalued: false
+        required: false
+        description: The QP and QU limitation model with which this wind dynamics
+          lookup table is associated.
+      WindContRotorRIEC:
+        slot_uri: cim:WindDynamicsLookupTable.WindContRotorRIEC
+        range: WindContRotorRIEC
+        multivalued: false
+        required: false
+        description: The rotor resistance control model with which this wind dynamics
+          lookup table is associated.
+      input:
+        slot_uri: cim:WindDynamicsLookupTable.input
+        range: float
+        multivalued: false
+        required: true
+        description: Input value (<i>x</i>) for the lookup table function.
+      lookupTableFunctionType:
+        slot_uri: cim:WindDynamicsLookupTable.lookupTableFunctionType
+        range: WindLookupTableFunctionKind
+        multivalued: false
+        required: true
+        description: Type of the lookup table function.
+      output:
+        slot_uri: cim:WindDynamicsLookupTable.output
+        range: float
+        multivalued: false
+        required: true
+        description: Output value (<i>y</i>) for the lookup table function.
+      sequence:
+        slot_uri: cim:WindDynamicsLookupTable.sequence
+        range: integer
+        multivalued: false
+        required: true
+        description: Sequence numbers of the pairs of the input (<i>x</i>) and the
+          output (<i>y</i>) of the lookup table function.
+      WindPlantFreqPcontrolIEC:
+        slot_uri: cim:WindDynamicsLookupTable.WindPlantFreqPcontrolIEC
+        range: WindPlantFreqPcontrolIEC
+        multivalued: false
+        required: false
+        description: The frequency and active power wind plant control model with
+          which this wind dynamics lookup table is associated.
+      WindProtectionIEC:
+        slot_uri: cim:WindDynamicsLookupTable.WindProtectionIEC
+        range: WindProtectionIEC
+        multivalued: false
+        required: false
+        description: The grid protection model with which this wind dynamics lookup
+          table is associated.
+      WindPlantReactiveControlIEC:
+        slot_uri: cim:WindDynamicsLookupTable.WindPlantReactiveControlIEC
+        range: WindPlantReactiveControlIEC
+        multivalued: false
+        required: false
+        description: The voltage and reactive power wind plant control model with
+          which this wind dynamics lookup table is associated.
+      WindGenType3bIEC:
+        slot_uri: cim:WindDynamicsLookupTable.WindGenType3bIEC
+        range: WindGenType3bIEC
+        multivalued: false
+        required: false
+        description: The generator type 3B model with which this wind dynamics lookup
+          table is associated.
+      WindPitchContPowerIEC:
+        slot_uri: cim:WindDynamicsLookupTable.WindPitchContPowerIEC
+        range: WindPitchContPowerIEC
+        multivalued: false
+        required: false
+        description: The pitch control power model with which this wind dynamics lookup
+          table is associated.
+    is_a: IdentifiedObject
+    description: Look up table for the purpose of wind standard models.
+  WindGenTurbineType1aIEC:
+    class_uri: cim:WindGenTurbineType1aIEC
+    attributes:
+      WindAeroConstIEC:
+        slot_uri: cim:WindGenTurbineType1aIEC.WindAeroConstIEC
+        range: WindAeroConstIEC
+        multivalued: false
+        required: true
+        description: Wind aerodynamic model associated with this wind turbine type
+          1A model.
+    is_a: WindTurbineType1or2IEC
+    description: 'Wind turbine IEC type 1A.
+
+      Reference: IEC 61400-27-1:2015, 5.5.2.2.'
+  WindGenTurbineType1bIEC:
+    class_uri: cim:WindGenTurbineType1bIEC
+    attributes:
+      WindPitchContPowerIEC:
+        slot_uri: cim:WindGenTurbineType1bIEC.WindPitchContPowerIEC
+        range: WindPitchContPowerIEC
+        multivalued: false
+        required: true
+        description: Pitch control power model associated with this wind turbine type
+          1B model.
+    is_a: WindTurbineType1or2IEC
+    description: 'Wind turbine IEC type 1B.
+
+
+      Reference: IEC 61400-27-1:2015, 5.5.2.3.'
+  WindGenTurbineType2IEC:
+    class_uri: cim:WindGenTurbineType2IEC
+    attributes:
+      WindContRotorRIEC:
+        slot_uri: cim:WindGenTurbineType2IEC.WindContRotorRIEC
+        range: WindContRotorRIEC
+        multivalued: false
+        required: true
+        description: Wind control rotor resistance model associated with wind turbine
+          type 2 model.
+      WindPitchContPowerIEC:
+        slot_uri: cim:WindGenTurbineType2IEC.WindPitchContPowerIEC
+        range: WindPitchContPowerIEC
+        multivalued: false
+        required: true
+        description: Pitch control power model associated with this wind turbine type
+          2 model.
+    is_a: WindTurbineType1or2IEC
+    description: 'Wind turbine IEC type 2.
+
+
+      Reference: IEC 61400-27-1:2015, 5.5.3.'
+  WindGenType3aIEC:
+    class_uri: cim:WindGenType3aIEC
+    attributes:
+      kpc:
+        slot_uri: cim:WindGenType3aIEC.kpc
+        range: float
+        multivalued: false
+        required: true
+        description: Current PI controller proportional gain (<i>K</i><i><sub>Pc</sub></i>).
+          It is a type-dependent parameter.
+      tic:
+        slot_uri: cim:WindGenType3aIEC.tic
+        range: Seconds
+        multivalued: false
+        required: true
+        description: Current PI controller integration time constant (<i>T</i><i><sub>Ic</sub></i>)
+          (&gt;= 0). It is a type-dependent parameter.
+      WindTurbineType4IEC:
+        slot_uri: cim:WindGenType3aIEC.WindTurbineType4IEC
+        range: WindTurbineType4IEC
+        multivalued: false
+        required: false
+        description: Wind turbine type 4 model with which this wind generator type
+          3A model is associated.
+    is_a: WindGenType3IEC
+    description: 'IEC type 3A generator set model.
+
+      Reference: IEC 61400-27-1:2015, 5.6.3.2.'
+  WindGenType3bIEC:
+    class_uri: cim:WindGenType3bIEC
+    attributes:
+      WindDynamicsLookupTable:
+        slot_uri: cim:WindGenType3bIEC.WindDynamicsLookupTable
+        range: WindDynamicsLookupTable
+        multivalued: true
+        required: true
+        description: The wind dynamics lookup table associated with this generator
+          type 3B model.
+      mwtcwp:
+        slot_uri: cim:WindGenType3bIEC.mwtcwp
+        range: boolean
+        multivalued: false
+        required: true
+        description: 'Crowbar control mode (<i>M</i><i><sub>WTcwp</sub></i>). It is
+          a case-dependent parameter.
+
+          true = 1 in the IEC model
+
+          false = 0 in the IEC model.'
+      tg:
+        slot_uri: cim:WindGenType3bIEC.tg
+        range: Seconds
+        multivalued: false
+        required: true
+        description: Current generation time constant (<i>T</i><i><sub>g</sub></i>)
+          (&gt;= 0). It is a type-dependent parameter.
+      two:
+        slot_uri: cim:WindGenType3bIEC.two
+        range: Seconds
+        multivalued: false
+        required: true
+        description: Time constant for crowbar washout filter (<i>T</i><i><sub>wo</sub></i>)
+          (&gt;= 0). It is a case-dependent parameter.
+    is_a: WindGenType3IEC
+    description: 'IEC type 3B generator set model.
+
+      Reference: IEC 61400-27-1:2015, 5.6.3.3.'
+  WindGenType3IEC:
+    class_uri: cim:WindGenType3IEC
+    attributes:
+      dipmax:
+        slot_uri: cim:WindGenType3IEC.dipmax
+        range: PU
+        multivalued: false
+        required: true
+        description: Maximum active current ramp rate (<i>di</i><i><sub>pmax</sub></i>).
+          It is a project-dependent parameter.
+      diqmax:
+        slot_uri: cim:WindGenType3IEC.diqmax
+        range: PU
+        multivalued: false
+        required: true
+        description: Maximum reactive current ramp rate (<i>di</i><i><sub>qmax</sub></i>).
+          It is a project-dependent parameter.
+      xs:
+        slot_uri: cim:WindGenType3IEC.xs
+        range: PU
+        multivalued: false
+        required: true
+        description: Electromagnetic transient reactance (<i>x</i><i><sub>S</sub></i>).
+          It is a type-dependent parameter.
+      WindTurbineType3IEC:
+        slot_uri: cim:WindGenType3IEC.WindTurbineType3IEC
+        range: WindTurbineType3IEC
+        multivalued: false
+        required: false
+        description: Wind turbine type 3 model with which this wind generator type
+          3 is associated.
+    is_a: IdentifiedObject
+    description: Parent class supporting relationships to IEC wind turbines type 3
+      generator models of IEC type 3A and 3B.
+  WindGenType4IEC:
+    class_uri: cim:WindGenType4IEC
+    attributes:
+      dipmax:
+        slot_uri: cim:WindGenType4IEC.dipmax
+        range: PU
+        multivalued: false
+        required: true
+        description: Maximum active current ramp rate (<i>di</i><i><sub>pmax</sub></i>).
+          It is a project-dependent parameter.
+      diqmin:
+        slot_uri: cim:WindGenType4IEC.diqmin
+        range: PU
+        multivalued: false
+        required: true
+        description: Minimum reactive current ramp rate (<i>di</i><i><sub>qmin</sub></i>).
+          It is a project-dependent parameter.
+      diqmax:
+        slot_uri: cim:WindGenType4IEC.diqmax
+        range: PU
+        multivalued: false
+        required: true
+        description: Maximum reactive current ramp rate (<i>di</i><i><sub>qmax</sub></i>).
+          It is a project-dependent parameter.
+      tg:
+        slot_uri: cim:WindGenType4IEC.tg
+        range: Seconds
+        multivalued: false
+        required: true
+        description: Time constant (<i>T</i><i><sub>g</sub></i>) (&gt;= 0). It is
+          a type-dependent parameter.
+      WindTurbineType4aIEC:
+        slot_uri: cim:WindGenType4IEC.WindTurbineType4aIEC
+        range: WindTurbineType4aIEC
+        multivalued: false
+        required: false
+        description: Wind turbine type 4A model with which this wind generator type
+          4 model is associated.
+      WindTurbineType4bIEC:
+        slot_uri: cim:WindGenType4IEC.WindTurbineType4bIEC
+        range: WindTurbineType4bIEC
+        multivalued: false
+        required: false
+        description: Wind turbine type 4B model with which this wind generator type
+          4 model is associated.
+    is_a: IdentifiedObject
+    description: 'IEC type 4 generator set model.
+
+      Reference: IEC 61400-27-1:2015, 5.6.3.4.'
+  WindMechIEC:
+    class_uri: cim:WindMechIEC
+    attributes:
+      cdrt:
+        slot_uri: cim:WindMechIEC.cdrt
+        range: PU
+        multivalued: false
+        required: true
+        description: Drive train damping (<i>c</i><i><sub>drt</sub></i><i>)</i>. It
+          is a type-dependent parameter.
+      hgen:
+        slot_uri: cim:WindMechIEC.hgen
+        range: Seconds
+        multivalued: false
+        required: true
+        description: Inertia constant of generator (<i>H</i><i><sub>gen</sub></i>)
+          (&gt;= 0). It is a type-dependent parameter.
+      hwtr:
+        slot_uri: cim:WindMechIEC.hwtr
+        range: Seconds
+        multivalued: false
+        required: true
+        description: Inertia constant of wind turbine rotor (<i>H</i><i><sub>WTR</sub></i>)
+          (&gt;= 0). It is a type-dependent parameter.
+      kdrt:
+        slot_uri: cim:WindMechIEC.kdrt
+        range: PU
+        multivalued: false
+        required: true
+        description: Drive train stiffness (<i>k</i><i><sub>drt</sub></i>). It is
+          a type-dependent parameter.
+      WindTurbineType3IEC:
+        slot_uri: cim:WindMechIEC.WindTurbineType3IEC
+        range: WindTurbineType3IEC
+        multivalued: false
+        required: false
+        description: Wind turbine type 3 model with which this wind mechanical model
+          is associated.
+      WindTurbineType1or2IEC:
+        slot_uri: cim:WindMechIEC.WindTurbineType1or2IEC
+        range: WindTurbineType1or2IEC
+        multivalued: false
+        required: false
+        description: Wind generator type 1 or type 2 model with which this wind mechanical
+          model is associated.
+      WindTurbineType4bIEC:
+        slot_uri: cim:WindMechIEC.WindTurbineType4bIEC
+        range: WindTurbineType4bIEC
+        multivalued: false
+        required: false
+        description: Wind turbine type 4B model with which this wind mechanical model
+          is associated.
+    is_a: IdentifiedObject
+    description: 'Two mass model.
+
+      Reference: IEC 61400-27-1:2015, 5.6.2.1.'
+  WindPitchContPowerIEC:
+    class_uri: cim:WindPitchContPowerIEC
+    attributes:
+      WindDynamicsLookupTable:
+        slot_uri: cim:WindPitchContPowerIEC.WindDynamicsLookupTable
+        range: WindDynamicsLookupTable
+        multivalued: true
+        required: true
+        description: The wind dynamics lookup table associated with this pitch control
+          power model.
+      WindGenTurbineType1bIEC:
+        slot_uri: cim:WindPitchContPowerIEC.WindGenTurbineType1bIEC
+        range: WindGenTurbineType1bIEC
+        multivalued: false
+        required: false
+        description: Wind turbine type 1B model with which this pitch control power
+          model is associated.
+      WindGenTurbineType2IEC:
+        slot_uri: cim:WindPitchContPowerIEC.WindGenTurbineType2IEC
+        range: WindGenTurbineType2IEC
+        multivalued: false
+        required: false
+        description: Wind turbine type 2 model with which this pitch control power
+          model is associated.
+      dpmax:
+        slot_uri: cim:WindPitchContPowerIEC.dpmax
+        range: PU
+        multivalued: false
+        required: true
+        description: Rate limit for increasing power (<i>dp</i><i><sub>max</sub></i>)
+          (&gt; WindPitchContPowerIEC.dpmin). It is a type-dependent parameter.
+      dpmin:
+        slot_uri: cim:WindPitchContPowerIEC.dpmin
+        range: PU
+        multivalued: false
+        required: true
+        description: Rate limit for decreasing power (<i>dp</i><i><sub>min</sub></i>)
+          (&lt; WindPitchContPowerIEC.dpmax). It is a type-dependent parameter.
+      pmin:
+        slot_uri: cim:WindPitchContPowerIEC.pmin
+        range: PU
+        multivalued: false
+        required: true
+        description: Minimum power setting (<i>p</i><i><sub>min</sub></i>). It is
+          a type-dependent parameter.
+      pset:
+        slot_uri: cim:WindPitchContPowerIEC.pset
+        range: PU
+        multivalued: false
+        required: true
+        description: If <i>p</i><i><sub>init</sub></i><sub> </sub>&lt; <i>p</i><i><sub>set</sub></i><sub>
+          </sub>then power will be ramped down to <i>p</i><i><sub>min</sub></i>. It
+          is (<i>p</i><i><sub>set</sub></i>) in the IEC 61400-27-1:2015. It is a type-dependent
+          parameter.
+      t1:
+        slot_uri: cim:WindPitchContPowerIEC.t1
+        range: Seconds
+        multivalued: false
+        required: true
+        description: Lag time constant (<i>T</i><i><sub>1</sub></i>) (&gt;= 0). It
+          is a type-dependent parameter.
+      tr:
+        slot_uri: cim:WindPitchContPowerIEC.tr
+        range: Seconds
+        multivalued: false
+        required: true
+        description: Voltage measurement time constant (<i>T</i><i><sub>r</sub></i>)
+          (&gt;= 0). It is a type-dependent parameter.
+      uuvrt:
+        slot_uri: cim:WindPitchContPowerIEC.uuvrt
+        range: PU
+        multivalued: false
+        required: true
+        description: Dip detection threshold (<i>u</i><i><sub>UVRT</sub></i>). It
+          is a type-dependent parameter.
+    is_a: IdentifiedObject
+    description: 'Pitch control power model.
+
+      Reference: IEC 61400-27-1:2015, 5.6.5.1.'
+  WindPlantDynamics:
+    class_uri: cim:WindPlantDynamics
+    attributes:
+      RemoteInputSignal:
+        slot_uri: cim:WindPlantDynamics.RemoteInputSignal
+        range: RemoteInputSignal
+        multivalued: false
+        required: false
+        description: The remote signal with which this power plant is associated.
+      WindTurbineType3or4Dynamics:
+        slot_uri: cim:WindPlantDynamics.WindTurbineType3or4Dynamics
+        range: WindTurbineType3or4Dynamics
+        multivalued: true
+        required: true
+        description: The wind turbine type 3 or type 4 associated with this wind plant.
+    is_a: DynamicsFunctionBlock
+    description: Parent class supporting relationships to wind turbines type 3 and
+      type 4 and wind plant IEC and user-defined wind plants including their control
+      models.
+  WindPlantFreqPcontrolIEC:
+    class_uri: cim:WindPlantFreqPcontrolIEC
+    attributes:
+      WindDynamicsLookupTable:
+        slot_uri: cim:WindPlantFreqPcontrolIEC.WindDynamicsLookupTable
+        range: WindDynamicsLookupTable
+        multivalued: true
+        required: true
+        description: The wind dynamics lookup table associated with this frequency
+          and active power wind plant model.
+      dprefmax:
+        slot_uri: cim:WindPlantFreqPcontrolIEC.dprefmax
+        range: PU
+        multivalued: false
+        required: true
+        description: Maximum ramp rate of <i>p</i><i><sub>WTref</sub></i> request
+          from the plant controller to the wind turbines (<i>dp</i><i><sub>refmax</sub></i>)
+          (&gt; WindPlantFreqPcontrolIEC.dprefmin). It is a case-dependent parameter.
+      dprefmin:
+        slot_uri: cim:WindPlantFreqPcontrolIEC.dprefmin
+        range: PU
+        multivalued: false
+        required: true
+        description: Minimum (negative) ramp rate of <i>p</i><i><sub>WTref</sub></i>
+          request from the plant controller to the wind turbines (<i>dp</i><i><sub>refmin</sub></i>)
+          (&lt; WindPlantFreqPcontrolIEC.dprefmax). It is a project-dependent parameter.
+      dpwprefmax:
+        slot_uri: cim:WindPlantFreqPcontrolIEC.dpwprefmax
+        range: PU
+        multivalued: false
+        required: true
+        description: Maximum positive ramp rate for wind plant power reference (<i>dp</i><i><sub>WPrefmax</sub></i>)
+          (&gt; WindPlantFreqPcontrolIEC.dpwprefmin). It is a project-dependent parameter.
+      dpwprefmin:
+        slot_uri: cim:WindPlantFreqPcontrolIEC.dpwprefmin
+        range: PU
+        multivalued: false
+        required: true
+        description: Maximum negative ramp rate for wind plant power reference (<i>dp</i><i><sub>WPrefmin</sub></i>)
+          (&lt; WindPlantFreqPcontrolIEC.dpwprefmax). It is a project-dependent parameter.
+      prefmax:
+        slot_uri: cim:WindPlantFreqPcontrolIEC.prefmax
+        range: PU
+        multivalued: false
+        required: true
+        description: Maximum <i>p</i><i><sub>WTref</sub></i> request from the plant
+          controller to the wind turbines (<i>p</i><i><sub>refmax</sub></i>) (&gt;
+          WindPlantFreqPcontrolIEC.prefmin). It is a project-dependent parameter.
+      prefmin:
+        slot_uri: cim:WindPlantFreqPcontrolIEC.prefmin
+        range: PU
+        multivalued: false
+        required: true
+        description: Minimum <i>p</i><i><sub>WTref</sub></i> request from the plant
+          controller to the wind turbines (<i>p</i><i><sub>refmin</sub></i>) (&lt;
+          WindPlantFreqPcontrolIEC.prefmax). It is a project-dependent parameter.
+      kiwpp:
+        slot_uri: cim:WindPlantFreqPcontrolIEC.kiwpp
+        range: float
+        multivalued: false
+        required: true
+        description: Plant P controller integral gain (<i>K</i><i><sub>IWPp</sub></i>).
+          It is a project-dependent parameter.
+      kiwppmax:
+        slot_uri: cim:WindPlantFreqPcontrolIEC.kiwppmax
+        range: PU
+        multivalued: false
+        required: true
+        description: Maximum PI integrator term (<i>K</i><i><sub>IWPpmax</sub></i>)
+          (&gt; WindPlantFreqPcontrolIEC.kiwppmin). It is a project-dependent parameter.
+      kiwppmin:
+        slot_uri: cim:WindPlantFreqPcontrolIEC.kiwppmin
+        range: PU
+        multivalued: false
+        required: true
+        description: Minimum PI integrator term (<i>K</i><i><sub>IWPpmin</sub></i>)
+          (&lt; WindPlantFreqPcontrolIEC.kiwppmax). It is a project-dependent parameter.
+      kpwpp:
+        slot_uri: cim:WindPlantFreqPcontrolIEC.kpwpp
+        range: float
+        multivalued: false
+        required: true
+        description: Plant P controller proportional gain (<i>K</i><i><sub>PWPp</sub></i>).
+          It is a project-dependent parameter.
+      kwppref:
+        slot_uri: cim:WindPlantFreqPcontrolIEC.kwppref
+        range: PU
+        multivalued: false
+        required: true
+        description: Power reference gain (<i>K</i><i><sub>WPpref</sub></i>). It is
+          a project-dependent parameter.
+      tpft:
+        slot_uri: cim:WindPlantFreqPcontrolIEC.tpft
+        range: Seconds
+        multivalued: false
+        required: true
+        description: Lead time constant in reference value transfer function (<i>T</i><i><sub>pft</sub></i>)
+          (&gt;= 0). It is a project-dependent parameter.
+      tpfv:
+        slot_uri: cim:WindPlantFreqPcontrolIEC.tpfv
+        range: Seconds
+        multivalued: false
+        required: true
+        description: Lag time constant in reference value transfer function (<i>T</i><i><sub>pfv</sub></i>)
+          (&gt;= 0). It is a project-dependent parameter.
+      twpffiltp:
+        slot_uri: cim:WindPlantFreqPcontrolIEC.twpffiltp
+        range: Seconds
+        multivalued: false
+        required: true
+        description: Filter time constant for frequency measurement (<i>T</i><i><sub>WPffiltp</sub></i>)
+          (&gt;= 0). It is a project-dependent parameter.
+      twppfiltp:
+        slot_uri: cim:WindPlantFreqPcontrolIEC.twppfiltp
+        range: Seconds
+        multivalued: false
+        required: true
+        description: Filter time constant for active power measurement (<i>T</i><i><sub>WPpfiltp</sub></i>)
+          (&gt;= 0). It is a project-dependent parameter.
+      WindPlantIEC:
+        slot_uri: cim:WindPlantFreqPcontrolIEC.WindPlantIEC
+        range: WindPlantIEC
+        multivalued: false
+        required: true
+        description: Wind plant model with which this wind plant frequency and active
+          power control is associated.
+    is_a: IdentifiedObject
+    description: 'Frequency and active power controller model.
+
+      Reference: IEC 61400-27-1:2015, Annex D.'
+  WindPlantIEC:
+    class_uri: cim:WindPlantIEC
+    attributes:
+      WindPlantFreqPcontrolIEC:
+        slot_uri: cim:WindPlantIEC.WindPlantFreqPcontrolIEC
+        range: WindPlantFreqPcontrolIEC
+        multivalued: false
+        required: true
+        description: Wind plant frequency and active power control model associated
+          with this wind plant.
+      WindPlantReactiveControlIEC:
+        slot_uri: cim:WindPlantIEC.WindPlantReactiveControlIEC
+        range: WindPlantReactiveControlIEC
+        multivalued: false
+        required: true
+        description: Wind plant model with which this wind reactive control is associated.
+    is_a: WindPlantDynamics
+    description: "Simplified IEC type plant level model. \nReference: IEC 61400-27-1:2015,\
+      \ Annex D."
+  WindPlantReactiveControlIEC:
+    class_uri: cim:WindPlantReactiveControlIEC
+    attributes:
+      WindDynamicsLookupTable:
+        slot_uri: cim:WindPlantReactiveControlIEC.WindDynamicsLookupTable
+        range: WindDynamicsLookupTable
+        multivalued: true
+        required: true
+        description: The wind dynamics lookup table associated with this voltage and
+          reactive power wind plant model.
+      WindPlantIEC:
+        slot_uri: cim:WindPlantReactiveControlIEC.WindPlantIEC
+        range: WindPlantIEC
+        multivalued: false
+        required: true
+        description: Wind plant reactive control model associated with this wind plant.
+      dxrefmax:
+        slot_uri: cim:WindPlantReactiveControlIEC.dxrefmax
+        range: PU
+        multivalued: false
+        required: true
+        description: Maximum positive ramp rate for wind turbine reactive power/voltage
+          reference (<i>dx</i><i><sub>refmax</sub></i>) (&gt; WindPlantReactiveControlIEC.dxrefmin).
+          It is a project-dependent parameter.
+      dxrefmin:
+        slot_uri: cim:WindPlantReactiveControlIEC.dxrefmin
+        range: PU
+        multivalued: false
+        required: true
+        description: Maximum negative ramp rate for wind turbine reactive power/voltage
+          reference (<i>dx</i><i><sub>refmin</sub></i>) (&lt; WindPlantReactiveControlIEC.dxrefmax).
+          It is a project-dependent parameter.
+      kiwpx:
+        slot_uri: cim:WindPlantReactiveControlIEC.kiwpx
+        range: float
+        multivalued: false
+        required: true
+        description: Plant Q controller integral gain (<i>K</i><i><sub>IWPx</sub></i>).
+          It is a project-dependent parameter.
+      kiwpxmax:
+        slot_uri: cim:WindPlantReactiveControlIEC.kiwpxmax
+        range: PU
+        multivalued: false
+        required: true
+        description: Maximum reactive power/voltage reference from integration (<i>K</i><i><sub>IWPxmax</sub></i>)
+          (&gt; WindPlantReactiveControlIEC.kiwpxmin). It is a project-dependent parameter.
+      kiwpxmin:
+        slot_uri: cim:WindPlantReactiveControlIEC.kiwpxmin
+        range: PU
+        multivalued: false
+        required: true
+        description: Minimum reactive power/voltage reference from integration (<i>K</i><i><sub>IWPxmin</sub></i>)
+          (&lt; WindPlantReactiveControlIEC.kiwpxmax). It is a project-dependent parameter.
+      kpwpx:
+        slot_uri: cim:WindPlantReactiveControlIEC.kpwpx
+        range: float
+        multivalued: false
+        required: true
+        description: Plant Q controller proportional gain (<i>K</i><i><sub>PWPx</sub></i>).
+          It is a project-dependent parameter.
+      kwpqref:
+        slot_uri: cim:WindPlantReactiveControlIEC.kwpqref
+        range: PU
+        multivalued: false
+        required: true
+        description: Reactive power reference gain (<i>K</i><i><sub>WPqref</sub></i>).
+          It is a project-dependent parameter.
+      kwpqu:
+        slot_uri: cim:WindPlantReactiveControlIEC.kwpqu
+        range: PU
+        multivalued: false
+        required: true
+        description: Plant voltage control droop (<i>K</i><i><sub>WPqu</sub></i>).
+          It is a project-dependent parameter.
+      tuqfilt:
+        slot_uri: cim:WindPlantReactiveControlIEC.tuqfilt
+        range: Seconds
+        multivalued: false
+        required: true
+        description: Filter time constant for voltage-dependent reactive power (<i>T</i><i><sub>uqfilt</sub></i>)
+          (&gt;= 0). It is a project-dependent parameter.
+      twppfiltq:
+        slot_uri: cim:WindPlantReactiveControlIEC.twppfiltq
+        range: Seconds
+        multivalued: false
+        required: true
+        description: Filter time constant for active power measurement (<i>T</i><i><sub>WPpfiltq</sub></i>)
+          (&gt;= 0). It is a project-dependent parameter.
+      twpqfiltq:
+        slot_uri: cim:WindPlantReactiveControlIEC.twpqfiltq
+        range: Seconds
+        multivalued: false
+        required: true
+        description: Filter time constant for reactive power measurement (<i>T</i><i><sub>WPqfiltq</sub></i>)
+          (&gt;= 0). It is a project-dependent parameter.
+      twpufiltq:
+        slot_uri: cim:WindPlantReactiveControlIEC.twpufiltq
+        range: Seconds
+        multivalued: false
+        required: true
+        description: Filter time constant for voltage measurement (<i>T</i><i><sub>WPufiltq</sub></i>)
+          (&gt;= 0). It is a project-dependent parameter.
+      txft:
+        slot_uri: cim:WindPlantReactiveControlIEC.txft
+        range: Seconds
+        multivalued: false
+        required: true
+        description: Lead time constant in reference value transfer function (<i>T</i><i><sub>xft</sub></i>)
+          (&gt;= 0). It is a project-dependent parameter.
+      txfv:
+        slot_uri: cim:WindPlantReactiveControlIEC.txfv
+        range: Seconds
+        multivalued: false
+        required: true
+        description: Lag time constant in reference value transfer function (<i>T</i><i><sub>xfv</sub></i>)
+          (&gt;= 0). It is a project-dependent parameter.
+      uwpqdip:
+        slot_uri: cim:WindPlantReactiveControlIEC.uwpqdip
+        range: PU
+        multivalued: false
+        required: true
+        description: Voltage threshold for UVRT detection in Q control (<i>u</i><i><sub>WPqdip</sub></i>).
+          It is a project-dependent parameter.
+      windPlantQcontrolModesType:
+        slot_uri: cim:WindPlantReactiveControlIEC.windPlantQcontrolModesType
+        range: WindPlantQcontrolModeKind
+        multivalued: false
+        required: true
+        description: Reactive power/voltage controller mode (<i>M</i><i><sub>WPqmode</sub></i>).
+          It is a case-dependent parameter.
+      xrefmax:
+        slot_uri: cim:WindPlantReactiveControlIEC.xrefmax
+        range: PU
+        multivalued: false
+        required: true
+        description: Maximum <i>x</i><sub>WTref</sub> (<i>q</i><i><sub>WTref</sub></i>
+          or delta<i> u</i><i><sub>WTref</sub></i>) request from the plant controller
+          (<i>x</i><i><sub>refmax</sub></i>) (&gt; WindPlantReactiveControlIEC.xrefmin).
+          It is a case-dependent parameter.
+      xrefmin:
+        slot_uri: cim:WindPlantReactiveControlIEC.xrefmin
+        range: PU
+        multivalued: false
+        required: true
+        description: Minimum <i>x</i><i><sub>WTref</sub></i> (<i>q</i><i><sub>WTref</sub></i>
+          or delta <i>u</i><i><sub>WTref</sub></i>) request from the plant controller
+          (<i>x</i><i><sub>refmin</sub></i>) (&lt; WindPlantReactiveControlIEC.xrefmax).
+          It is a project-dependent parameter.
+    is_a: IdentifiedObject
+    description: 'Simplified plant voltage and reactive power control model for use
+      with type 3 and type 4 wind turbine models.
+
+      Reference: IEC 61400-27-1:2015, Annex D.'
+  WindProtectionIEC:
+    class_uri: cim:WindProtectionIEC
+    attributes:
+      WindDynamicsLookupTable:
+        slot_uri: cim:WindProtectionIEC.WindDynamicsLookupTable
+        range: WindDynamicsLookupTable
+        multivalued: true
+        required: true
+        description: The wind dynamics lookup table associated with this grid protection
+          model.
+      dfimax:
+        slot_uri: cim:WindProtectionIEC.dfimax
+        range: PU
+        multivalued: false
+        required: true
+        description: Maximum rate of change of frequency (<i>dF</i><i><sub>max</sub></i>).
+          It is a type-dependent parameter.
+      fover:
+        slot_uri: cim:WindProtectionIEC.fover
+        range: PU
+        multivalued: false
+        required: true
+        description: Wind turbine over frequency protection activation threshold (<i>f</i><i><sub>over</sub></i>).
+          It is a project-dependent parameter.
+      funder:
+        slot_uri: cim:WindProtectionIEC.funder
+        range: PU
+        multivalued: false
+        required: true
+        description: Wind turbine under frequency protection activation threshold
+          (<i>f</i><i><sub>under</sub></i>). It is a project-dependent parameter.
+      mzc:
+        slot_uri: cim:WindProtectionIEC.mzc
+        range: boolean
+        multivalued: false
+        required: true
+        description: "Zero crossing measurement mode (<i>Mzc</i>).  It is a type-dependent\
+          \ parameter. \ntrue = WT protection system uses zero crossings to detect\
+          \ frequency (1 in the IEC model)\nfalse = WT protection system does not\
+          \ use zero crossings to detect frequency (0 in the IEC model)."
+      tfma:
+        slot_uri: cim:WindProtectionIEC.tfma
+        range: Seconds
+        multivalued: false
+        required: true
+        description: Time interval of moving average window (<i>TfMA</i>) (&gt;= 0).  It
+          is a type-dependent parameter.
+      uover:
+        slot_uri: cim:WindProtectionIEC.uover
+        range: PU
+        multivalued: false
+        required: true
+        description: Wind turbine over voltage protection activation threshold (<i>u</i><i><sub>over</sub></i>).
+          It is a project-dependent parameter.
+      uunder:
+        slot_uri: cim:WindProtectionIEC.uunder
+        range: PU
+        multivalued: false
+        required: true
+        description: Wind turbine under voltage protection activation threshold (<i>u</i><i><sub>under</sub></i>).
+          It is a project-dependent parameter.
+      WindTurbineType3or4IEC:
+        slot_uri: cim:WindProtectionIEC.WindTurbineType3or4IEC
+        range: WindTurbineType3or4IEC
+        multivalued: false
+        required: false
+        description: Wind generator type 3 or type 4 model with which this wind turbine
+          protection model is associated.
+      WindTurbineType1or2IEC:
+        slot_uri: cim:WindProtectionIEC.WindTurbineType1or2IEC
+        range: WindTurbineType1or2IEC
+        multivalued: false
+        required: false
+        description: Wind generator type 1 or type 2 model with which this wind turbine
+          protection model is associated.
+    is_a: IdentifiedObject
+    description: 'The grid protection model includes protection against over- and
+      under-voltage, and against over- and under-frequency.
+
+      Reference: IEC 61400-27-1:2015, 5.6.6.'
+  WindRefFrameRotIEC:
+    class_uri: cim:WindRefFrameRotIEC
+    attributes:
+      tpll:
+        slot_uri: cim:WindRefFrameRotIEC.tpll
+        range: Seconds
+        multivalued: false
+        required: true
+        description: Time constant for PLL first order filter model (<i>T</i><i><sub>PLL</sub></i>)
+          (&gt;= 0). It is a type-dependent parameter.
+      upll1:
+        slot_uri: cim:WindRefFrameRotIEC.upll1
+        range: PU
+        multivalued: false
+        required: true
+        description: Voltage below which the angle of the voltage is filtered and
+          possibly also frozen (<i>u</i><i><sub>PLL1</sub></i>). It is a type-dependent
+          parameter.
+      upll2:
+        slot_uri: cim:WindRefFrameRotIEC.upll2
+        range: PU
+        multivalued: false
+        required: true
+        description: Voltage (<i>u</i><i><sub>PLL2</sub></i>) below which the angle
+          of the voltage is frozen if <i>u</i><i><sub>PLL2</sub></i><sub> </sub>is
+          smaller or equal to <i>u</i><i><sub>PLL1</sub></i> . It is a type-dependent
+          parameter.
+      WindTurbineType3or4IEC:
+        slot_uri: cim:WindRefFrameRotIEC.WindTurbineType3or4IEC
+        range: WindTurbineType3or4IEC
+        multivalued: false
+        required: true
+        description: Wind turbine type 3 or type 4 model with which this reference
+          frame rotation model is associated.
+    is_a: IdentifiedObject
+    description: 'Reference frame rotation model.
+
+      Reference: IEC 61400-27-1:2015, 5.6.3.5.'
+  WindTurbineType1or2Dynamics:
+    class_uri: cim:WindTurbineType1or2Dynamics
+    attributes:
+      RemoteInputSignal:
+        slot_uri: cim:WindTurbineType1or2Dynamics.RemoteInputSignal
+        range: RemoteInputSignal
+        multivalued: false
+        required: false
+        description: Remote input signal used by this wind generator type 1 or type
+          2 model.
+      AsynchronousMachineDynamics:
+        slot_uri: cim:WindTurbineType1or2Dynamics.AsynchronousMachineDynamics
+        range: AsynchronousMachineDynamics
+        multivalued: false
+        required: true
+        description: Asynchronous machine model with which this wind generator type
+          1 or type 2 model is associated.
+    is_a: DynamicsFunctionBlock
+    description: Parent class supporting relationships to wind turbines type 1 and
+      type 2 and their control models.  Generator model for wind turbine of type 1
+      or type 2 is a standard asynchronous generator model.
+  WindTurbineType1or2IEC:
+    class_uri: cim:WindTurbineType1or2IEC
+    attributes:
+      WindMechIEC:
+        slot_uri: cim:WindTurbineType1or2IEC.WindMechIEC
+        range: WindMechIEC
+        multivalued: false
+        required: true
+        description: Wind mechanical model associated with this wind generator type
+          1 or type 2 model.
+      WindProtectionIEC:
+        slot_uri: cim:WindTurbineType1or2IEC.WindProtectionIEC
+        range: WindProtectionIEC
+        multivalued: false
+        required: true
+        description: Wind turbune protection model associated with this wind generator
+          type 1 or type 2 model.
+    is_a: WindTurbineType1or2Dynamics
+    description: 'Parent class supporting relationships to IEC wind turbines type
+      1 and type 2 including their control models.
+
+      Generator model for wind turbine of IEC type 1 or type 2 is a standard asynchronous
+      generator model.
+
+      Reference: IEC 61400-27-1:2015, 5.5.2 and 5.5.3.'
+  WindTurbineType3IEC:
+    class_uri: cim:WindTurbineType3IEC
+    attributes:
+      WindAeroOneDimIEC:
+        slot_uri: cim:WindTurbineType3IEC.WindAeroOneDimIEC
+        range: WindAeroOneDimIEC
+        multivalued: false
+        required: false
+        description: Wind aerodynamic model associated with this wind generator type
+          3 model.
+      WindAeroTwoDimIEC:
+        slot_uri: cim:WindTurbineType3IEC.WindAeroTwoDimIEC
+        range: WindAeroTwoDimIEC
+        multivalued: false
+        required: false
+        description: Wind aerodynamic model associated with this wind turbine type
+          3 model.
+      WindContPitchAngleIEC:
+        slot_uri: cim:WindTurbineType3IEC.WindContPitchAngleIEC
+        range: WindContPitchAngleIEC
+        multivalued: false
+        required: true
+        description: Wind control pitch angle model associated with this wind turbine
+          type 3.
+      WindContPType3IEC:
+        slot_uri: cim:WindTurbineType3IEC.WindContPType3IEC
+        range: WindContPType3IEC
+        multivalued: false
+        required: true
+        description: Wind control P type 3 model associated with this wind turbine
+          type 3 model.
+      WindGenType3IEC:
+        slot_uri: cim:WindTurbineType3IEC.WindGenType3IEC
+        range: WindGenType3IEC
+        multivalued: false
+        required: false
+        description: Wind generator type 3 model associated with this wind turbine
+          type 3 model.
+      WindMechIEC:
+        slot_uri: cim:WindTurbineType3IEC.WindMechIEC
+        range: WindMechIEC
+        multivalued: false
+        required: true
+        description: Wind mechanical model associated with this wind turbine type
+          3 model.
+    is_a: WindTurbineType3or4IEC
+    description: Parent class supporting relationships to IEC wind turbines type 3
+      including their control models.
+  WindTurbineType3or4Dynamics:
+    class_uri: cim:WindTurbineType3or4Dynamics
+    attributes:
+      PowerElectronicsConnection:
+        slot_uri: cim:WindTurbineType3or4Dynamics.PowerElectronicsConnection
+        range: PowerElectronicsConnection
+        multivalued: false
+        required: true
+        description: The power electronics connection associated with this wind turbine
+          type 3 or type 4 dynamics model.
+      RemoteInputSignal:
+        slot_uri: cim:WindTurbineType3or4Dynamics.RemoteInputSignal
+        range: RemoteInputSignal
+        multivalued: false
+        required: false
+        description: Remote input signal used by these wind turbine type 3 or type
+          4 models.
+      WindPlantDynamics:
+        slot_uri: cim:WindTurbineType3or4Dynamics.WindPlantDynamics
+        range: WindPlantDynamics
+        multivalued: false
+        required: false
+        description: The wind plant with which the wind turbines type 3 or type 4
+          are associated.
+    is_a: DynamicsFunctionBlock
+    description: Parent class supporting relationships to wind turbines type 3 and
+      type 4 and wind plant including their control models.
+  WindTurbineType3or4IEC:
+    class_uri: cim:WindTurbineType3or4IEC
+    attributes:
+      WindContCurrLimIEC:
+        slot_uri: cim:WindTurbineType3or4IEC.WindContCurrLimIEC
+        range: WindContCurrLimIEC
+        multivalued: false
+        required: true
+        description: Wind control current limitation model associated with this wind
+          turbine type 3 or type 4 model.
+      WIndContQIEC:
+        slot_uri: cim:WindTurbineType3or4IEC.WIndContQIEC
+        range: WindContQIEC
+        multivalued: false
+        required: true
+        description: Wind control Q model associated with this wind turbine type 3
+          or type 4 model.
+      WindContQLimIEC:
+        slot_uri: cim:WindTurbineType3or4IEC.WindContQLimIEC
+        range: WindContQLimIEC
+        multivalued: false
+        required: false
+        description: Constant Q limitation model associated with this wind generator
+          type 3 or type 4 model.
+      WindContQPQULimIEC:
+        slot_uri: cim:WindTurbineType3or4IEC.WindContQPQULimIEC
+        range: WindContQPQULimIEC
+        multivalued: false
+        required: false
+        description: QP and QU limitation model associated with this wind generator
+          type 3 or type 4 model.
+      WindProtectionIEC:
+        slot_uri: cim:WindTurbineType3or4IEC.WindProtectionIEC
+        range: WindProtectionIEC
+        multivalued: false
+        required: true
+        description: Wind turbune protection model associated with this wind generator
+          type 3 or type 4 model.
+      WindRefFrameRotIEC:
+        slot_uri: cim:WindTurbineType3or4IEC.WindRefFrameRotIEC
+        range: WindRefFrameRotIEC
+        multivalued: false
+        required: true
+        description: Reference frame rotation model associated with this wind turbine
+          type 3 or type 4 model.
+    is_a: WindTurbineType3or4Dynamics
+    description: Parent class supporting relationships to IEC wind turbines type 3
+      and type 4 including their control models.
+  WindTurbineType4aIEC:
+    class_uri: cim:WindTurbineType4aIEC
+    attributes:
+      WindContPType4aIEC:
+        slot_uri: cim:WindTurbineType4aIEC.WindContPType4aIEC
+        range: WindContPType4aIEC
+        multivalued: false
+        required: true
+        description: Wind control P type 4A model associated with this wind turbine
+          type 4A model.
+      WindGenType4IEC:
+        slot_uri: cim:WindTurbineType4aIEC.WindGenType4IEC
+        range: WindGenType4IEC
+        multivalued: false
+        required: false
+        description: Wind generator type 4 model associated with this wind turbine
+          type 4A model.
+    is_a: WindTurbineType4IEC
+    description: 'Wind turbine IEC type 4A.
+
+      Reference: IEC 61400-27-1:2015, 5.5.5.2.'
+  WindTurbineType4bIEC:
+    class_uri: cim:WindTurbineType4bIEC
+    attributes:
+      WindContPType4bIEC:
+        slot_uri: cim:WindTurbineType4bIEC.WindContPType4bIEC
+        range: WindContPType4bIEC
+        multivalued: false
+        required: true
+        description: Wind control P type 4B model associated with this wind turbine
+          type 4B model.
+      WindGenType4IEC:
+        slot_uri: cim:WindTurbineType4bIEC.WindGenType4IEC
+        range: WindGenType4IEC
+        multivalued: false
+        required: false
+        description: Wind generator type 4 model associated with this wind turbine
+          type 4B model.
+      WindMechIEC:
+        slot_uri: cim:WindTurbineType4bIEC.WindMechIEC
+        range: WindMechIEC
+        multivalued: false
+        required: true
+        description: Wind mechanical model associated with this wind turbine type
+          4B model.
+    is_a: WindTurbineType4IEC
+    description: 'Wind turbine IEC type 4B.
+
+      Reference: IEC 61400-27-1:2015, 5.5.5.3.'
+  WindTurbineType4IEC:
+    class_uri: cim:WindTurbineType4IEC
+    attributes:
+      WindGenType3aIEC:
+        slot_uri: cim:WindTurbineType4IEC.WindGenType3aIEC
+        range: WindGenType3aIEC
+        multivalued: false
+        required: false
+        description: Wind generator type 3A model associated with this wind turbine
+          type 4 model.
+    is_a: WindTurbineType3or4IEC
+    description: Parent class supporting relationships to IEC wind turbines type 4
+      including their control models.
+  LoadComposite:
+    class_uri: cim:LoadComposite
+    attributes:
+      epvs:
+        slot_uri: cim:LoadComposite.epvs
+        range: float
+        multivalued: false
+        required: true
+        description: Active load-voltage dependence index (static) (<i>Epvs</i>).  Typical
+          value = 0,7.
+      epfs:
+        slot_uri: cim:LoadComposite.epfs
+        range: float
+        multivalued: false
+        required: true
+        description: Active load-frequency dependence index (static) (<i>Epfs</i>).  Typical
+          value = 1,5.
+      eqvs:
+        slot_uri: cim:LoadComposite.eqvs
+        range: float
+        multivalued: false
+        required: true
+        description: Reactive load-voltage dependence index (static) (<i>Eqvs</i>).  Typical
+          value = 2.
+      eqfs:
+        slot_uri: cim:LoadComposite.eqfs
+        range: float
+        multivalued: false
+        required: true
+        description: Reactive load-frequency dependence index (static) (<i>Eqfs</i>).  Typical
+          value = 0.
+      epvd:
+        slot_uri: cim:LoadComposite.epvd
+        range: float
+        multivalued: false
+        required: true
+        description: Active load-voltage dependence index (dynamic) (<i>Epvd</i>).  Typical
+          value = 0,7.
+      epfd:
+        slot_uri: cim:LoadComposite.epfd
+        range: float
+        multivalued: false
+        required: true
+        description: Active load-frequency dependence index (dynamic) (<i>Epfd</i>).  Typical
+          value = 1,5.
+      eqvd:
+        slot_uri: cim:LoadComposite.eqvd
+        range: float
+        multivalued: false
+        required: true
+        description: Reactive load-voltage dependence index (dynamic) (<i>Eqvd</i>).  Typical
+          value = 2.
+      eqfd:
+        slot_uri: cim:LoadComposite.eqfd
+        range: float
+        multivalued: false
+        required: true
+        description: Reactive load-frequency dependence index (dynamic) (<i>Eqfd</i>).  Typical
+          value = 0.
+      lfac:
+        slot_uri: cim:LoadComposite.lfac
+        range: float
+        multivalued: false
+        required: true
+        description: Loading factor (<i>L</i><i><sub>fac</sub></i>). The ratio of
+          initial <i>P</i> to motor MVA base.  Typical value = 0,8.
+      h:
+        slot_uri: cim:LoadComposite.h
+        range: Seconds
+        multivalued: false
+        required: true
+        description: Inertia constant (<i>H</i>) (&gt;= 0).  Typical value = 2,5.
+      pfrac:
+        slot_uri: cim:LoadComposite.pfrac
+        range: float
+        multivalued: false
+        required: true
+        description: Fraction of constant-power load to be represented by this motor
+          model (<i>P</i><i><sub>FRAC</sub></i>) (&gt;= 0,0 and &lt;= 1,0).  Typical
+          value = 0,5.
+    is_a: LoadDynamics
+    description: 'Combined static load and induction motor load effects.
+
+      The dynamics of the motor are simplified by linearizing the induction machine
+      equations.'
+  LoadGenericNonLinear:
+    class_uri: cim:LoadGenericNonLinear
+    attributes:
+      genericNonLinearLoadModelType:
+        slot_uri: cim:LoadGenericNonLinear.genericNonLinearLoadModelType
+        range: GenericNonLinearLoadModelKind
+        multivalued: false
+        required: true
+        description: Type of generic non-linear load model.
+      tp:
+        slot_uri: cim:LoadGenericNonLinear.tp
+        range: Seconds
+        multivalued: false
+        required: true
+        description: Time constant of lag function of active power (<i>T</i><i><sub>P</sub></i>)
+          (&gt; 0).
+      tq:
+        slot_uri: cim:LoadGenericNonLinear.tq
+        range: Seconds
+        multivalued: false
+        required: true
+        description: Time constant of lag function of reactive power (<i>T</i><i><sub>Q</sub></i>)
+          (&gt; 0).
+      ls:
+        slot_uri: cim:LoadGenericNonLinear.ls
+        range: float
+        multivalued: false
+        required: true
+        description: Steady state voltage index for active power (<i>LS</i>).
+      lt:
+        slot_uri: cim:LoadGenericNonLinear.lt
+        range: float
+        multivalued: false
+        required: true
+        description: Transient voltage index for active power (<i>LT</i>).
+      bs:
+        slot_uri: cim:LoadGenericNonLinear.bs
+        range: float
+        multivalued: false
+        required: true
+        description: Steady state voltage index for reactive power (<i>BS</i>).
+      bt:
+        slot_uri: cim:LoadGenericNonLinear.bt
+        range: float
+        multivalued: false
+        required: true
+        description: Transient voltage index for reactive power (<i>BT</i>).
+    is_a: LoadDynamics
+    description: Generic non-linear dynamic (GNLD) load. This model can be used in
+      mid-term and long-term voltage stability simulations (i.e., to study voltage
+      collapse), as it can replace a more detailed representation of aggregate load,
+      including induction motors, thermostatically controlled and static loads.
+  LoadDynamics:
+    class_uri: cim:LoadDynamics
+    attributes:
+      EnergyConsumer:
+        slot_uri: cim:LoadDynamics.EnergyConsumer
+        range: EnergyConsumer
+        multivalued: true
+        required: false
+        description: Energy consumer to which this dynamics load model applies.
+    is_a: IdentifiedObject
+    description: 'Load whose behaviour is described by reference to a standard model
+      <font color="#0f0f0f">or by definition of a user-defined model.</font>
+
+      A standard feature of dynamic load behaviour modelling is the ability to associate
+      the same behaviour to multiple energy consumers by means of a single load definition.  The
+      load model is always applied to individual bus loads (energy consumers).'
+  LoadAggregate:
+    class_uri: cim:LoadAggregate
+    attributes:
+      LoadMotor:
+        slot_uri: cim:LoadAggregate.LoadMotor
+        range: LoadMotor
+        multivalued: false
+        required: false
+        description: Aggregate motor (dynamic) load associated with this aggregate
+          load.
+      LoadStatic:
+        slot_uri: cim:LoadAggregate.LoadStatic
+        range: LoadStatic
+        multivalued: false
+        required: false
+        description: Aggregate static load associated with this aggregate load.
+    is_a: LoadDynamics
+    description: 'Aggregate loads are used to represent all or part of the real and
+      reactive load from one or more loads in the static (power flow) data. This load
+      is usually the aggregation of many individual load devices and the load model
+      is an approximate representation of the aggregate response of the load devices
+      to system disturbances.
+
+      Standard aggregate load model comprised of static and/or dynamic components.  A
+      static load model represents the sensitivity of the real and reactive power
+      consumed by the load to the amplitude and frequency of the bus voltage. A dynamic
+      load model can be used to represent the aggregate response of the motor components
+      of the load.'
+  LoadStatic:
+    class_uri: cim:LoadStatic
+    attributes:
+      LoadAggregate:
+        slot_uri: cim:LoadStatic.LoadAggregate
+        range: LoadAggregate
+        multivalued: false
+        required: true
+        description: Aggregate load to which this aggregate static load belongs.
+      staticLoadModelType:
+        slot_uri: cim:LoadStatic.staticLoadModelType
+        range: StaticLoadModelKind
+        multivalued: false
+        required: true
+        description: Type of static load model.  Typical value = constantZ.
+      kp1:
+        slot_uri: cim:LoadStatic.kp1
+        range: float
+        multivalued: false
+        required: false
+        description: First term voltage coefficient for active power (<i>K</i><i><sub>p1</sub></i>).  Not
+          used when .staticLoadModelType = constantZ.
+      kp2:
+        slot_uri: cim:LoadStatic.kp2
+        range: float
+        multivalued: false
+        required: false
+        description: Second term voltage coefficient for active power (<i>K</i><i><sub>p2</sub></i>).  Not
+          used when .staticLoadModelType = constantZ.
+      kp3:
+        slot_uri: cim:LoadStatic.kp3
+        range: float
+        multivalued: false
+        required: false
+        description: Third term voltage coefficient for active power (<i>K</i><i><sub>p3</sub></i>).  Not
+          used when .staticLoadModelType = constantZ.
+      kp4:
+        slot_uri: cim:LoadStatic.kp4
+        range: float
+        multivalued: false
+        required: false
+        description: Frequency coefficient for active power (<i>K</i><i><sub>p4</sub></i>)  (not
+          = 0 if .staticLoadModelType = zIP2).  Used only when .staticLoadModelType
+          = zIP2.
+      ep1:
+        slot_uri: cim:LoadStatic.ep1
+        range: float
+        multivalued: false
+        required: false
+        description: First term voltage exponent for active power (<i>Ep1</i>).  Used
+          only when .staticLoadModelType = exponential.
+      ep2:
+        slot_uri: cim:LoadStatic.ep2
+        range: float
+        multivalued: false
+        required: false
+        description: Second term voltage exponent for active power (<i>Ep2</i>).  Used
+          only when .staticLoadModelType = exponential.
+      ep3:
+        slot_uri: cim:LoadStatic.ep3
+        range: float
+        multivalued: false
+        required: false
+        description: Third term voltage exponent for active power (<i>Ep3</i>).  Used
+          only when .staticLoadModelType = exponential.
+      kpf:
+        slot_uri: cim:LoadStatic.kpf
+        range: float
+        multivalued: false
+        required: false
+        description: Frequency deviation coefficient for active power (<i>K</i><i><sub>pf</sub></i>).  Not
+          used when .staticLoadModelType = constantZ.
+      kq1:
+        slot_uri: cim:LoadStatic.kq1
+        range: float
+        multivalued: false
+        required: false
+        description: First term voltage coefficient for reactive power (<i>K</i><i><sub>q1</sub></i>).  Not
+          used when .staticLoadModelType = constantZ.
+      kq2:
+        slot_uri: cim:LoadStatic.kq2
+        range: float
+        multivalued: false
+        required: false
+        description: Second term voltage coefficient for reactive power (<i>K</i><i><sub>q2</sub></i>).  Not
+          used when .staticLoadModelType = constantZ.
+      kq3:
+        slot_uri: cim:LoadStatic.kq3
+        range: float
+        multivalued: false
+        required: false
+        description: Third term voltage coefficient for reactive power (<i>K</i><i><sub>q3</sub></i>).  Not
+          used when .staticLoadModelType = constantZ.
+      kq4:
+        slot_uri: cim:LoadStatic.kq4
+        range: float
+        multivalued: false
+        required: false
+        description: Frequency coefficient for reactive power (<i>K</i><i><sub>q4</sub></i>)  (not
+          = 0 when .staticLoadModelType = zIP2).  Used only when .staticLoadModelType
+          - zIP2.
+      eq1:
+        slot_uri: cim:LoadStatic.eq1
+        range: float
+        multivalued: false
+        required: false
+        description: First term voltage exponent for reactive power (<i>Eq1</i>).  Used
+          only when .staticLoadModelType = exponential.
+      eq2:
+        slot_uri: cim:LoadStatic.eq2
+        range: float
+        multivalued: false
+        required: false
+        description: Second term voltage exponent for reactive power (<i>Eq2</i>).  Used
+          only when .staticLoadModelType = exponential.
+      eq3:
+        slot_uri: cim:LoadStatic.eq3
+        range: float
+        multivalued: false
+        required: false
+        description: Third term voltage exponent for reactive power (<i>Eq3</i>).  Used
+          only when .staticLoadModelType = exponential.
+      kqf:
+        slot_uri: cim:LoadStatic.kqf
+        range: float
+        multivalued: false
+        required: false
+        description: Frequency deviation coefficient for reactive power (<i>K</i><i><sub>qf</sub></i>).  Not
+          used when .staticLoadModelType = constantZ.
+    is_a: IdentifiedObject
+    description: General static load. This model represents the sensitivity of the
+      real and reactive power consumed by the load to the amplitude and frequency
+      of the bus voltage.
+  LoadMotor:
+    class_uri: cim:LoadMotor
+    attributes:
+      LoadAggregate:
+        slot_uri: cim:LoadMotor.LoadAggregate
+        range: LoadAggregate
+        multivalued: false
+        required: true
+        description: Aggregate load to which this aggregate motor (dynamic) load belongs.
+      pfrac:
+        slot_uri: cim:LoadMotor.pfrac
+        range: float
+        multivalued: false
+        required: true
+        description: Fraction of constant-power load to be represented by this motor
+          model (<i>Pfrac</i>) (&gt;= 0,0 and &lt;= 1,0).  Typical value = 0,3.
+      lfac:
+        slot_uri: cim:LoadMotor.lfac
+        range: float
+        multivalued: false
+        required: true
+        description: Loading factor (<i>Lfac</i>). The ratio of initial <i>P</i> to
+          motor MVA base.  Typical value = 0,8.
+      ls:
+        slot_uri: cim:LoadMotor.ls
+        range: PU
+        multivalued: false
+        required: true
+        description: Synchronous reactance (<i>Ls</i>).  Typical value = 3,2.
+      lp:
+        slot_uri: cim:LoadMotor.lp
+        range: PU
+        multivalued: false
+        required: true
+        description: Transient reactance (<i>Lp</i>).  Typical value = 0,15.
+      lpp:
+        slot_uri: cim:LoadMotor.lpp
+        range: PU
+        multivalued: false
+        required: true
+        description: Subtransient reactance (<i>Lpp</i>).  Typical value = 0,15.
+      ra:
+        slot_uri: cim:LoadMotor.ra
+        range: PU
+        multivalued: false
+        required: true
+        description: Stator resistance (<i>Ra</i>).  Typical value = 0.
+      tpo:
+        slot_uri: cim:LoadMotor.tpo
+        range: Seconds
+        multivalued: false
+        required: true
+        description: Transient rotor time constant (<i>Tpo</i>) (&gt;= 0).  Typical
+          value = 1.
+      tppo:
+        slot_uri: cim:LoadMotor.tppo
+        range: Seconds
+        multivalued: false
+        required: true
+        description: Subtransient rotor time constant (<i>Tppo</i>) (&gt;= 0).  Typical
+          value = 0,02.
+      h:
+        slot_uri: cim:LoadMotor.h
+        range: Seconds
+        multivalued: false
+        required: true
+        description: Inertia constant (<i>H</i>) (&gt;= 0).  Typical value = 0,4.
+      d:
+        slot_uri: cim:LoadMotor.d
+        range: float
+        multivalued: false
+        required: true
+        description: Damping factor (<i>D</i>).  Unit = delta <i>P</i>/delta speed.  Typical
+          value = 2.
+      vt:
+        slot_uri: cim:LoadMotor.vt
+        range: PU
+        multivalued: false
+        required: true
+        description: Voltage threshold for tripping (<i>Vt</i>).  Typical value =
+          0,7.
+      tv:
+        slot_uri: cim:LoadMotor.tv
+        range: Seconds
+        multivalued: false
+        required: true
+        description: Voltage trip pickup time (<i>Tv</i>) (&gt;= 0).  Typical value
+          = 0,1.
+      tbkr:
+        slot_uri: cim:LoadMotor.tbkr
+        range: Seconds
+        multivalued: false
+        required: true
+        description: Circuit breaker operating time (<i>Tbkr</i>) (&gt;= 0).  Typical
+          value = 0,08.
+    is_a: IdentifiedObject
+    description: "Aggregate induction motor load. This model is used to represent\
+      \ a fraction of an ordinary load as \"induction motor load\".  It allows a load\
+      \ that is treated as an ordinary constant power in power flow analysis to be\
+      \ represented by an induction motor in dynamic simulation. This model is intended\
+      \ for representation of aggregations of many motors dispersed through a load\
+      \ represented at a high voltage bus but where there is no information on the\
+      \ characteristics of individual motors.\nEither a \"one-cage\" or \"two-cage\"\
+      \ model of the induction machine can be modelled. Magnetic saturation is not\
+      \ modelled.\nThis model treats a fraction of the constant power part of a load\
+      \ as a motor. During initialisation, the initial power drawn by the motor is\
+      \ set equal to <i>Pfrac</i> times the constant <i>P</i> part of the static load.\
+      \  The remainder of the load is left as a static load.\nThe reactive power demand\
+      \ of the motor is calculated during initialisation as a function of voltage\
+      \ at the load bus. This reactive power demand can be less than or greater than\
+      \ the constant <i>Q</i> component of the load.  If the motor's reactive demand\
+      \ is greater than the constant <i>Q</i> component of the load, the model inserts\
+      \ a shunt capacitor at the terminal of the motor to bring its reactive demand\
+      \ down to equal the constant <i>Q</i> reactive load.  \nIf an induction motor\
+      \ load model and a static load model are both present for a load, the motor\
+      \ <i>Pfrac</i> is assumed to be subtracted from the power flow constant <i>P</i>\
+      \ load before the static load model is applied.  The remainder of the load,\
+      \ if any, is then represented by the static load model."
+  CSCDynamics:
+    class_uri: cim:CSCDynamics
+    attributes:
+      CSConverter:
+        slot_uri: cim:CSCDynamics.CSConverter
+        range: CsConverter
+        multivalued: false
+        required: true
+        description: Current source converter to which current source converter dynamics
+          model applies.
+    is_a: HVDCDynamics
+    description: CSC function block whose behaviour is described by reference to a
+      standard model <font color="#0f0f0f">or by definition of a user-defined model.</font>
+  HVDCDynamics:
+    class_uri: cim:HVDCDynamics
+    is_a: DynamicsFunctionBlock
+    description: HVDC whose behaviour is described by reference to a standard model
+      <font color="#0f0f0f">or by definition of a user-defined model.</font>
+  VSCDynamics:
+    class_uri: cim:VSCDynamics
+    attributes:
+      VsConverter:
+        slot_uri: cim:VSCDynamics.VsConverter
+        range: VsConverter
+        multivalued: false
+        required: true
+        description: Voltage source converter to which voltage source converter dynamics
+          model applies.
+    is_a: HVDCDynamics
+    description: VSC function block whose behaviour is described by reference to a
+      standard model <font color="#0f0f0f">or by definition of a user-defined model.</font>
+  StaticVarCompensatorDynamics:
+    class_uri: cim:StaticVarCompensatorDynamics
+    attributes:
+      StaticVarCompensator:
+        slot_uri: cim:StaticVarCompensatorDynamics.StaticVarCompensator
+        range: StaticVarCompensator
+        multivalued: false
+        required: true
+        description: Static Var Compensator to which Static Var Compensator dynamics
+          model applies.
+    is_a: DynamicsFunctionBlock
+    description: Static var compensator whose behaviour is described by reference
+      to a standard model <font color="#0f0f0f">or by definition of a user-defined
+      model.</font>
+enums:
+  UnitMultiplier:
+    permissible_values:
+      y:
+        meaning: cim:UnitMultiplier.y
+      z:
+        meaning: cim:UnitMultiplier.z
+      a:
+        meaning: cim:UnitMultiplier.a
+      f:
+        meaning: cim:UnitMultiplier.f
+      p:
+        meaning: cim:UnitMultiplier.p
+      n:
+        meaning: cim:UnitMultiplier.n
+      micro:
+        meaning: cim:UnitMultiplier.micro
+      m:
+        meaning: cim:UnitMultiplier.m
+      c:
+        meaning: cim:UnitMultiplier.c
+      d:
+        meaning: cim:UnitMultiplier.d
+      none:
+        meaning: cim:UnitMultiplier.none
+      da:
+        meaning: cim:UnitMultiplier.da
+      h:
+        meaning: cim:UnitMultiplier.h
+      k:
+        meaning: cim:UnitMultiplier.k
+      M:
+        meaning: cim:UnitMultiplier.M
+      G:
+        meaning: cim:UnitMultiplier.G
+      T:
+        meaning: cim:UnitMultiplier.T
+      P:
+        meaning: cim:UnitMultiplier.P
+      E:
+        meaning: cim:UnitMultiplier.E
+      Z:
+        meaning: cim:UnitMultiplier.Z
+      Y:
+        meaning: cim:UnitMultiplier.Y
+    enum_uri: http://iec.ch/TC57/CIM100#UnitMultiplier
+  UnitSymbol:
+    permissible_values:
+      none:
+        meaning: cim:UnitSymbol.none
+      m:
+        meaning: cim:UnitSymbol.m
+      kg:
+        meaning: cim:UnitSymbol.kg
+      s:
+        meaning: cim:UnitSymbol.s
+      A:
+        meaning: cim:UnitSymbol.A
+      K:
+        meaning: cim:UnitSymbol.K
+      mol:
+        meaning: cim:UnitSymbol.mol
+      cd:
+        meaning: cim:UnitSymbol.cd
+      deg:
+        meaning: cim:UnitSymbol.deg
+      rad:
+        meaning: cim:UnitSymbol.rad
+      sr:
+        meaning: cim:UnitSymbol.sr
+      Gy:
+        meaning: cim:UnitSymbol.Gy
+      Bq:
+        meaning: cim:UnitSymbol.Bq
+      degC:
+        meaning: cim:UnitSymbol.degC
+      Sv:
+        meaning: cim:UnitSymbol.Sv
+      F:
+        meaning: cim:UnitSymbol.F
+      C:
+        meaning: cim:UnitSymbol.C
+      S:
+        meaning: cim:UnitSymbol.S
+      H:
+        meaning: cim:UnitSymbol.H
+      V:
+        meaning: cim:UnitSymbol.V
+      ohm:
+        meaning: cim:UnitSymbol.ohm
+      J:
+        meaning: cim:UnitSymbol.J
+      N:
+        meaning: cim:UnitSymbol.N
+      Hz:
+        meaning: cim:UnitSymbol.Hz
+      lx:
+        meaning: cim:UnitSymbol.lx
+      lm:
+        meaning: cim:UnitSymbol.lm
+      Wb:
+        meaning: cim:UnitSymbol.Wb
+      T:
+        meaning: cim:UnitSymbol.T
+      W:
+        meaning: cim:UnitSymbol.W
+      Pa:
+        meaning: cim:UnitSymbol.Pa
+      m2:
+        meaning: cim:UnitSymbol.m2
+      m3:
+        meaning: cim:UnitSymbol.m3
+      mPers:
+        meaning: cim:UnitSymbol.mPers
+      mPers2:
+        meaning: cim:UnitSymbol.mPers2
+      m3Pers:
+        meaning: cim:UnitSymbol.m3Pers
+      mPerm3:
+        meaning: cim:UnitSymbol.mPerm3
+      kgm:
+        meaning: cim:UnitSymbol.kgm
+      kgPerm3:
+        meaning: cim:UnitSymbol.kgPerm3
+      m2Pers:
+        meaning: cim:UnitSymbol.m2Pers
+      WPermK:
+        meaning: cim:UnitSymbol.WPermK
+      JPerK:
+        meaning: cim:UnitSymbol.JPerK
+      ppm:
+        meaning: cim:UnitSymbol.ppm
+      rotPers:
+        meaning: cim:UnitSymbol.rotPers
+      radPers:
+        meaning: cim:UnitSymbol.radPers
+      WPerm2:
+        meaning: cim:UnitSymbol.WPerm2
+      JPerm2:
+        meaning: cim:UnitSymbol.JPerm2
+      SPerm:
+        meaning: cim:UnitSymbol.SPerm
+      KPers:
+        meaning: cim:UnitSymbol.KPers
+      PaPers:
+        meaning: cim:UnitSymbol.PaPers
+      JPerkgK:
+        meaning: cim:UnitSymbol.JPerkgK
+      VA:
+        meaning: cim:UnitSymbol.VA
+      VAr:
+        meaning: cim:UnitSymbol.VAr
+      cosPhi:
+        meaning: cim:UnitSymbol.cosPhi
+      Vs:
+        meaning: cim:UnitSymbol.Vs
+      V2:
+        meaning: cim:UnitSymbol.V2
+      As:
+        meaning: cim:UnitSymbol.As
+      A2:
+        meaning: cim:UnitSymbol.A2
+      A2s:
+        meaning: cim:UnitSymbol.A2s
+      VAh:
+        meaning: cim:UnitSymbol.VAh
+      Wh:
+        meaning: cim:UnitSymbol.Wh
+      VArh:
+        meaning: cim:UnitSymbol.VArh
+      VPerHz:
+        meaning: cim:UnitSymbol.VPerHz
+      HzPers:
+        meaning: cim:UnitSymbol.HzPers
+      character:
+        meaning: cim:UnitSymbol.character
+      charPers:
+        meaning: cim:UnitSymbol.charPers
+      kgm2:
+        meaning: cim:UnitSymbol.kgm2
+      dB:
+        meaning: cim:UnitSymbol.dB
+      WPers:
+        meaning: cim:UnitSymbol.WPers
+      lPers:
+        meaning: cim:UnitSymbol.lPers
+      dBm:
+        meaning: cim:UnitSymbol.dBm
+      h:
+        meaning: cim:UnitSymbol.h
+      min:
+        meaning: cim:UnitSymbol.min
+      Q:
+        meaning: cim:UnitSymbol.Q
+      Qh:
+        meaning: cim:UnitSymbol.Qh
+      ohmm:
+        meaning: cim:UnitSymbol.ohmm
+      APerm:
+        meaning: cim:UnitSymbol.APerm
+      V2h:
+        meaning: cim:UnitSymbol.V2h
+      A2h:
+        meaning: cim:UnitSymbol.A2h
+      Ah:
+        meaning: cim:UnitSymbol.Ah
+      count:
+        meaning: cim:UnitSymbol.count
+      ft3:
+        meaning: cim:UnitSymbol.ft3
+      m3Perh:
+        meaning: cim:UnitSymbol.m3Perh
+      gal:
+        meaning: cim:UnitSymbol.gal
+      Btu:
+        meaning: cim:UnitSymbol.Btu
+      l:
+        meaning: cim:UnitSymbol.l
+      lPerh:
+        meaning: cim:UnitSymbol.lPerh
+      lPerl:
+        meaning: cim:UnitSymbol.lPerl
+      gPerg:
+        meaning: cim:UnitSymbol.gPerg
+      molPerm3:
+        meaning: cim:UnitSymbol.molPerm3
+      molPermol:
+        meaning: cim:UnitSymbol.molPermol
+      molPerkg:
+        meaning: cim:UnitSymbol.molPerkg
+      sPers:
+        meaning: cim:UnitSymbol.sPers
+      HzPerHz:
+        meaning: cim:UnitSymbol.HzPerHz
+      VPerV:
+        meaning: cim:UnitSymbol.VPerV
+      APerA:
+        meaning: cim:UnitSymbol.APerA
+      VPerVA:
+        meaning: cim:UnitSymbol.VPerVA
+      rev:
+        meaning: cim:UnitSymbol.rev
+      kat:
+        meaning: cim:UnitSymbol.kat
+      JPerkg:
+        meaning: cim:UnitSymbol.JPerkg
+      m3Uncompensated:
+        meaning: cim:UnitSymbol.m3Uncompensated
+      m3Compensated:
+        meaning: cim:UnitSymbol.m3Compensated
+      WPerW:
+        meaning: cim:UnitSymbol.WPerW
+      therm:
+        meaning: cim:UnitSymbol.therm
+      onePerm:
+        meaning: cim:UnitSymbol.onePerm
+      m3Perkg:
+        meaning: cim:UnitSymbol.m3Perkg
+      Pas:
+        meaning: cim:UnitSymbol.Pas
+      Nm:
+        meaning: cim:UnitSymbol.Nm
+      NPerm:
+        meaning: cim:UnitSymbol.NPerm
+      radPers2:
+        meaning: cim:UnitSymbol.radPers2
+      JPerm3:
+        meaning: cim:UnitSymbol.JPerm3
+      VPerm:
+        meaning: cim:UnitSymbol.VPerm
+      CPerm3:
+        meaning: cim:UnitSymbol.CPerm3
+      CPerm2:
+        meaning: cim:UnitSymbol.CPerm2
+      FPerm:
+        meaning: cim:UnitSymbol.FPerm
+      HPerm:
+        meaning: cim:UnitSymbol.HPerm
+      JPermol:
+        meaning: cim:UnitSymbol.JPermol
+      JPermolK:
+        meaning: cim:UnitSymbol.JPermolK
+      CPerkg:
+        meaning: cim:UnitSymbol.CPerkg
+      GyPers:
+        meaning: cim:UnitSymbol.GyPers
+      WPersr:
+        meaning: cim:UnitSymbol.WPersr
+      WPerm2sr:
+        meaning: cim:UnitSymbol.WPerm2sr
+      katPerm3:
+        meaning: cim:UnitSymbol.katPerm3
+      d:
+        meaning: cim:UnitSymbol.d
+      anglemin:
+        meaning: cim:UnitSymbol.anglemin
+      anglesec:
+        meaning: cim:UnitSymbol.anglesec
+      ha:
+        meaning: cim:UnitSymbol.ha
+      tonne:
+        meaning: cim:UnitSymbol.tonne
+      bar:
+        meaning: cim:UnitSymbol.bar
+      mmHg:
+        meaning: cim:UnitSymbol.mmHg
+      M:
+        meaning: cim:UnitSymbol.M
+      kn:
+        meaning: cim:UnitSymbol.kn
+      Mx:
+        meaning: cim:UnitSymbol.Mx
+      G:
+        meaning: cim:UnitSymbol.G
+      Oe:
+        meaning: cim:UnitSymbol.Oe
+      Vh:
+        meaning: cim:UnitSymbol.Vh
+      WPerA:
+        meaning: cim:UnitSymbol.WPerA
+      onePerHz:
+        meaning: cim:UnitSymbol.onePerHz
+      VPerVAr:
+        meaning: cim:UnitSymbol.VPerVAr
+      ohmPerm:
+        meaning: cim:UnitSymbol.ohmPerm
+      kgPerJ:
+        meaning: cim:UnitSymbol.kgPerJ
+      JPers:
+        meaning: cim:UnitSymbol.JPers
+    enum_uri: http://iec.ch/TC57/CIM100#UnitSymbol
+  DroopSignalFeedbackKind:
+    permissible_values:
+      electricalPower:
+        meaning: cim:DroopSignalFeedbackKind.electricalPower
+      none:
+        meaning: cim:DroopSignalFeedbackKind.none
+      fuelValveStroke:
+        meaning: cim:DroopSignalFeedbackKind.fuelValveStroke
+      governorOutput:
+        meaning: cim:DroopSignalFeedbackKind.governorOutput
+    enum_uri: http://iec.ch/TC57/CIM100#DroopSignalFeedbackKind
+  ExcIEEEST1AUELselectorKind:
+    permissible_values:
+      ignoreUELsignal:
+        meaning: cim:ExcIEEEST1AUELselectorKind.ignoreUELsignal
+      inputHVgateVoltageOutput:
+        meaning: cim:ExcIEEEST1AUELselectorKind.inputHVgateVoltageOutput
+      inputHVgateErrorSignal:
+        meaning: cim:ExcIEEEST1AUELselectorKind.inputHVgateErrorSignal
+      inputAddedToErrorSignal:
+        meaning: cim:ExcIEEEST1AUELselectorKind.inputAddedToErrorSignal
+    enum_uri: http://iec.ch/TC57/CIM100#ExcIEEEST1AUELselectorKind
+  ExcREXSFeedbackSignalKind:
+    permissible_values:
+      fieldVoltage:
+        meaning: cim:ExcREXSFeedbackSignalKind.fieldVoltage
+      fieldCurrent:
+        meaning: cim:ExcREXSFeedbackSignalKind.fieldCurrent
+      outputVoltage:
+        meaning: cim:ExcREXSFeedbackSignalKind.outputVoltage
+    enum_uri: http://iec.ch/TC57/CIM100#ExcREXSFeedbackSignalKind
+  ExcST6BOELselectorKind:
+    permissible_values:
+      noOELinput:
+        meaning: cim:ExcST6BOELselectorKind.noOELinput
+      beforeUEL:
+        meaning: cim:ExcST6BOELselectorKind.beforeUEL
+      afterUEL:
+        meaning: cim:ExcST6BOELselectorKind.afterUEL
+    enum_uri: http://iec.ch/TC57/CIM100#ExcST6BOELselectorKind
+  ExcST7BOELselectorKind:
+    permissible_values:
+      noOELinput:
+        meaning: cim:ExcST7BOELselectorKind.noOELinput
+      addVref:
+        meaning: cim:ExcST7BOELselectorKind.addVref
+      inputLVgate:
+        meaning: cim:ExcST7BOELselectorKind.inputLVgate
+      outputLVgate:
+        meaning: cim:ExcST7BOELselectorKind.outputLVgate
+    enum_uri: http://iec.ch/TC57/CIM100#ExcST7BOELselectorKind
+  ExcST7BUELselectorKind:
+    permissible_values:
+      noUELinput:
+        meaning: cim:ExcST7BUELselectorKind.noUELinput
+      addVref:
+        meaning: cim:ExcST7BUELselectorKind.addVref
+      inputHVgate:
+        meaning: cim:ExcST7BUELselectorKind.inputHVgate
+      outputHVgate:
+        meaning: cim:ExcST7BUELselectorKind.outputHVgate
+    enum_uri: http://iec.ch/TC57/CIM100#ExcST7BUELselectorKind
+  FrancisGovernorControlKind:
+    permissible_values:
+      mechanicHydrolicTachoAccelerator:
+        meaning: cim:FrancisGovernorControlKind.mechanicHydrolicTachoAccelerator
+      mechanicHydraulicTransientFeedback:
+        meaning: cim:FrancisGovernorControlKind.mechanicHydraulicTransientFeedback
+      electromechanicalElectrohydraulic:
+        meaning: cim:FrancisGovernorControlKind.electromechanicalElectrohydraulic
+    enum_uri: http://iec.ch/TC57/CIM100#FrancisGovernorControlKind
+  GenericNonLinearLoadModelKind:
+    permissible_values:
+      exponentialRecovery:
+        meaning: cim:GenericNonLinearLoadModelKind.exponentialRecovery
+      loadAdaptive:
+        meaning: cim:GenericNonLinearLoadModelKind.loadAdaptive
+    enum_uri: http://iec.ch/TC57/CIM100#GenericNonLinearLoadModelKind
+  GovHydro4ModelKind:
+    permissible_values:
+      simple:
+        meaning: cim:GovHydro4ModelKind.simple
+      francisPelton:
+        meaning: cim:GovHydro4ModelKind.francisPelton
+      kaplan:
+        meaning: cim:GovHydro4ModelKind.kaplan
+    enum_uri: http://iec.ch/TC57/CIM100#GovHydro4ModelKind
+  IfdBaseKind:
+    permissible_values:
+      ifag:
+        meaning: cim:IfdBaseKind.ifag
+      ifnl:
+        meaning: cim:IfdBaseKind.ifnl
+      iffl:
+        meaning: cim:IfdBaseKind.iffl
+    enum_uri: http://iec.ch/TC57/CIM100#IfdBaseKind
+  InputSignalKind:
+    permissible_values:
+      rotorSpeed:
+        meaning: cim:InputSignalKind.rotorSpeed
+      rotorAngularFrequencyDeviation:
+        meaning: cim:InputSignalKind.rotorAngularFrequencyDeviation
+      busFrequency:
+        meaning: cim:InputSignalKind.busFrequency
+      busFrequencyDeviation:
+        meaning: cim:InputSignalKind.busFrequencyDeviation
+      generatorElectricalPower:
+        meaning: cim:InputSignalKind.generatorElectricalPower
+      generatorAcceleratingPower:
+        meaning: cim:InputSignalKind.generatorAcceleratingPower
+      busVoltage:
+        meaning: cim:InputSignalKind.busVoltage
+      busVoltageDerivative:
+        meaning: cim:InputSignalKind.busVoltageDerivative
+      branchCurrent:
+        meaning: cim:InputSignalKind.branchCurrent
+      fieldCurrent:
+        meaning: cim:InputSignalKind.fieldCurrent
+      generatorMechanicalPower:
+        meaning: cim:InputSignalKind.generatorMechanicalPower
+    enum_uri: http://iec.ch/TC57/CIM100#InputSignalKind
+  RemoteSignalKind:
+    permissible_values:
+      remoteBusVoltageFrequency:
+        meaning: cim:RemoteSignalKind.remoteBusVoltageFrequency
+      remoteBusVoltageFrequencyDeviation:
+        meaning: cim:RemoteSignalKind.remoteBusVoltageFrequencyDeviation
+      remoteBusFrequency:
+        meaning: cim:RemoteSignalKind.remoteBusFrequency
+      remoteBusFrequencyDeviation:
+        meaning: cim:RemoteSignalKind.remoteBusFrequencyDeviation
+      remoteBusVoltageAmplitude:
+        meaning: cim:RemoteSignalKind.remoteBusVoltageAmplitude
+      remoteBusVoltage:
+        meaning: cim:RemoteSignalKind.remoteBusVoltage
+      remoteBranchCurrentAmplitude:
+        meaning: cim:RemoteSignalKind.remoteBranchCurrentAmplitude
+      remoteBusVoltageAmplitudeDerivative:
+        meaning: cim:RemoteSignalKind.remoteBusVoltageAmplitudeDerivative
+      remotePuBusVoltageDerivative:
+        meaning: cim:RemoteSignalKind.remotePuBusVoltageDerivative
+    enum_uri: http://iec.ch/TC57/CIM100#RemoteSignalKind
+  RotorKind:
+    permissible_values:
+      roundRotor:
+        meaning: cim:RotorKind.roundRotor
+      salientPole:
+        meaning: cim:RotorKind.salientPole
+    enum_uri: http://iec.ch/TC57/CIM100#RotorKind
+  StaticLoadModelKind:
+    permissible_values:
+      exponential:
+        meaning: cim:StaticLoadModelKind.exponential
+      zIP1:
+        meaning: cim:StaticLoadModelKind.zIP1
+      zIP2:
+        meaning: cim:StaticLoadModelKind.zIP2
+      constantZ:
+        meaning: cim:StaticLoadModelKind.constantZ
+    enum_uri: http://iec.ch/TC57/CIM100#StaticLoadModelKind
+  SynchronousMachineModelKind:
+    permissible_values:
+      subtransient:
+        meaning: cim:SynchronousMachineModelKind.subtransient
+      subtransientTypeF:
+        meaning: cim:SynchronousMachineModelKind.subtransientTypeF
+      subtransientTypeJ:
+        meaning: cim:SynchronousMachineModelKind.subtransientTypeJ
+      subtransientSimplified:
+        meaning: cim:SynchronousMachineModelKind.subtransientSimplified
+      subtransientSimplifiedDirectAxis:
+        meaning: cim:SynchronousMachineModelKind.subtransientSimplifiedDirectAxis
+    enum_uri: http://iec.ch/TC57/CIM100#SynchronousMachineModelKind
+  WindLookupTableFunctionKind:
+    permissible_values:
+      prr:
+        meaning: cim:WindLookupTableFunctionKind.prr
+      omegap:
+        meaning: cim:WindLookupTableFunctionKind.omegap
+      ipmax:
+        meaning: cim:WindLookupTableFunctionKind.ipmax
+      iqmax:
+        meaning: cim:WindLookupTableFunctionKind.iqmax
+      pwp:
+        meaning: cim:WindLookupTableFunctionKind.pwp
+      tcwdu:
+        meaning: cim:WindLookupTableFunctionKind.tcwdu
+      tduwt:
+        meaning: cim:WindLookupTableFunctionKind.tduwt
+      qmaxp:
+        meaning: cim:WindLookupTableFunctionKind.qmaxp
+      qminp:
+        meaning: cim:WindLookupTableFunctionKind.qminp
+      qmaxu:
+        meaning: cim:WindLookupTableFunctionKind.qmaxu
+      qminu:
+        meaning: cim:WindLookupTableFunctionKind.qminu
+      tuover:
+        meaning: cim:WindLookupTableFunctionKind.tuover
+      tuunder:
+        meaning: cim:WindLookupTableFunctionKind.tuunder
+      tfover:
+        meaning: cim:WindLookupTableFunctionKind.tfover
+      tfunder:
+        meaning: cim:WindLookupTableFunctionKind.tfunder
+      qwp:
+        meaning: cim:WindLookupTableFunctionKind.qwp
+    enum_uri: http://iec.ch/TC57/CIM100#WindLookupTableFunctionKind
+  WindPlantQcontrolModeKind:
+    permissible_values:
+      reactivePower:
+        meaning: cim:WindPlantQcontrolModeKind.reactivePower
+      powerFactor:
+        meaning: cim:WindPlantQcontrolModeKind.powerFactor
+      uqStatic:
+        meaning: cim:WindPlantQcontrolModeKind.uqStatic
+      voltageControl:
+        meaning: cim:WindPlantQcontrolModeKind.voltageControl
+    enum_uri: http://iec.ch/TC57/CIM100#WindPlantQcontrolModeKind
+  WindQcontrolModeKind:
+    permissible_values:
+      voltage:
+        meaning: cim:WindQcontrolModeKind.voltage
+      reactivePower:
+        meaning: cim:WindQcontrolModeKind.reactivePower
+      openLoopReactivePower:
+        meaning: cim:WindQcontrolModeKind.openLoopReactivePower
+      powerFactor:
+        meaning: cim:WindQcontrolModeKind.powerFactor
+      openLooppowerFactor:
+        meaning: cim:WindQcontrolModeKind.openLooppowerFactor
+    enum_uri: http://iec.ch/TC57/CIM100#WindQcontrolModeKind
+  WindUVRTQcontrolModeKind:
+    permissible_values:
+      mode0:
+        meaning: cim:WindUVRTQcontrolModeKind.mode0
+      mode1:
+        meaning: cim:WindUVRTQcontrolModeKind.mode1
+      mode2:
+        meaning: cim:WindUVRTQcontrolModeKind.mode2
+    enum_uri: http://iec.ch/TC57/CIM100#WindUVRTQcontrolModeKind

--- a/benchmark/resources/schemas/dummy.yml
+++ b/benchmark/resources/schemas/dummy.yml
@@ -1,0 +1,116 @@
+id: https://neverblink.eu/linkml/benchmark/library
+name: library
+title: Dummy Library Schema
+description: >-
+  A small, self-contained LinkML schema used by the code-generator benchmarks.
+default_prefix: lib
+imports:
+  - linkml:types
+prefixes:
+  lib: https://neverblink.eu/linkml/benchmark/library/
+  linkml: https://w3id.org/linkml/
+  schema: http://schema.org/
+
+classes:
+  Entity:
+    abstract: true
+    description: Base class for everything with an identifier.
+    slots:
+      - id
+      - name
+
+  Library:
+    tree_root: true
+    is_a: Entity
+    description: A collection of books and the people who use them.
+    slots:
+      - books
+      - members
+
+  Book:
+    is_a: Entity
+    description: A single catalogued book.
+    slots:
+      - isbn
+      - pageCount
+      - genre
+      - authors
+      - available
+
+  Person:
+    is_a: Entity
+    description: A human associated with the library.
+    slots:
+      - email
+      - age
+
+  Author:
+    is_a: Person
+    description: The writer of one or more books.
+    slots:
+      - biography
+
+  Member:
+    is_a: Person
+    description: A registered borrower.
+    slots:
+      - membershipId
+      - borrowed
+
+slots:
+  id:
+    identifier: true
+    range: string
+    required: true
+  name:
+    range: string
+    required: true
+  isbn:
+    range: string
+    required: true
+    pattern: "^[0-9-]{10,17}$"
+  pageCount:
+    range: integer
+    minimum_value: 1
+  genre:
+    range: Genre
+  authors:
+    range: Author
+    multivalued: true
+    inlined_as_list: true
+  available:
+    range: boolean
+  email:
+    range: string
+    pattern: "^\\S+@\\S+$"
+  age:
+    range: integer
+    minimum_value: 0
+    maximum_value: 150
+  biography:
+    range: string
+  membershipId:
+    range: string
+    required: true
+  borrowed:
+    range: Book
+    multivalued: true
+  books:
+    range: Book
+    multivalued: true
+    inlined_as_list: true
+  members:
+    range: Member
+    multivalued: true
+    inlined_as_list: true
+
+enums:
+  Genre:
+    description: High-level category of a book.
+    permissible_values:
+      FICTION:
+        description: Made-up stories.
+      NON_FICTION:
+        description: Factual works.
+      POETRY:
+      REFERENCE:

--- a/benchmark/src/eu/neverblink/linkml/benchmark/CommonParams.scala
+++ b/benchmark/src/eu/neverblink/linkml/benchmark/CommonParams.scala
@@ -14,7 +14,7 @@ import java.util.concurrent.TimeUnit
 ) // 5s usually enough for warmup and exiting from "turbo" mode reaching PL2 (Power Limit 2)
 @Measurement(iterations = 5, time = 1, timeUnit = TimeUnit.SECONDS)
 @Fork(
-  value = 0,
+  value = 1,
   jvmArgs = Array(
     "-server",
     "-Xnoclassgc",

--- a/benchmark/src/eu/neverblink/linkml/benchmark/CommonParams.scala
+++ b/benchmark/src/eu/neverblink/linkml/benchmark/CommonParams.scala
@@ -1,0 +1,50 @@
+package eu.neverblink.linkml.benchmark
+
+import org.openjdk.jmh.annotations.*
+
+import java.util.concurrent.TimeUnit
+
+@State(Scope.Benchmark)
+@BenchmarkMode(Array(Mode.Throughput))
+@OutputTimeUnit(TimeUnit.SECONDS)
+@Warmup(
+  iterations = 5,
+  time = 1,
+  timeUnit = TimeUnit.SECONDS,
+) // 5s usually enough for warmup and exiting from "turbo" mode reaching PL2 (Power Limit 2)
+@Measurement(iterations = 5, time = 1, timeUnit = TimeUnit.SECONDS)
+@Fork(
+  value = 0,
+  jvmArgs = Array(
+    "-server",
+    "-Xnoclassgc",
+    "-Xms4g", // Preallocate all heap regions & make them fixed-size where possible
+    "-Xmx4g",
+    "-Xss2m",
+    "-XX:NewSize=3g",
+    "-XX:MaxNewSize=3g",
+    "-XX:InitialCodeCacheSize=512m", // Preallocate all code regions
+    "-XX:ReservedCodeCacheSize=512m",
+    "-XX:NonNMethodCodeHeapSize=32m",
+    "-XX:NonProfiledCodeHeapSize=240m",
+    "-XX:ProfiledCodeHeapSize=240m",
+    "-XX:TLABSize=4m", // Use large fixed-size TLAB
+    "-XX:-ResizeTLAB",
+    "-XX:+UseParallelGC", // The fastest GC
+    "-XX:+UseCompactObjectHeaders", // Requires JDK 24+
+    "-XX:-UseAdaptiveSizePolicy", // Do not resize heap regions
+    "-XX:MaxInlineLevel=20", // Helps to speed-up Scala code
+    "-XX:InlineSmallCode=2500", // Use defaults from Open JDK 17+
+    "-XX:+AlwaysPreTouch", // Pretouch memory pages
+    // "-XX:+UseTransparentHugePages", Linux only???
+    "-XX:-UseDynamicNumberOfGCThreads", // Stabilize GC & JIT overhead
+    "-XX:-UseDynamicNumberOfCompilerThreads",
+    "-XX:+UseNUMA", // Relevant for multi-socket servers
+    "-XX:-UseAdaptiveNUMAChunkSizing",
+    "-XX:+PerfDisableSharedMem", // See https://github.com/Simonis/mmap-pause#readme
+    "-XX:-UsePerfData",
+    "-XX:+UnlockExperimentalVMOptions",
+    "-XX:+TrustFinalNonStaticFields", // It is safe for almost all Scala code
+  ),
+)
+abstract class CommonParams

--- a/benchmark/src/eu/neverblink/linkml/benchmark/GeneratorBench.scala
+++ b/benchmark/src/eu/neverblink/linkml/benchmark/GeneratorBench.scala
@@ -1,0 +1,60 @@
+package eu.neverblink.linkml.benchmark
+
+import eu.neverblink.linkml.generator.jsonschema.JsonSchemaGenerator
+import eu.neverblink.linkml.generator.rdf.RdfUtils
+import eu.neverblink.linkml.generator.shacl.ShaclGenerator
+import eu.neverblink.linkml.schemaview.SchemaView
+import org.openjdk.jmh.annotations.{Benchmark, Param, Setup}
+
+import scala.compiletime.uninitialized
+import scala.io.Source
+import scala.util.Using
+
+/** Benchmarks the two most common code-generator outputs (JSON Schema and SHACL) produced from a
+  * LinkML schema loaded from the classpath.
+  *
+  * For each generator there are two variants:
+  *   - `*FromYaml` parses the YAML source into a [[SchemaView]] on every invocation, measuring the
+  *     end-to-end cost of a CLI call.
+  *   - `*FromSchemaView` reuses a [[SchemaView]] parsed once in [[setup]].
+  */
+class GeneratorBench extends CommonParams {
+
+  @Param(Array("dummy.yml", "cgmes-core.yml", "cgmes-dynamics.yml"))
+  var schema: String = uninitialized
+
+  private var yaml: String = uninitialized
+  private var schemaView: SchemaView = uninitialized
+
+  @Setup
+  def setup(): Unit = {
+    yaml = Using.resource(getClass.getResourceAsStream(s"/schemas/$schema")) { in =>
+      Source.fromInputStream(in, "UTF-8").mkString
+    }
+    schemaView = SchemaView.loadSchemaViewFromString(yaml)
+  }
+
+  @Benchmark
+  def jsonSchemaFromYaml: String = {
+    given sv: SchemaView = SchemaView.loadSchemaViewFromString(yaml)
+    JsonSchemaGenerator().serialize()
+  }
+
+  @Benchmark
+  def jsonSchemaFromSchemaView: String = {
+    given sv: SchemaView = schemaView
+    JsonSchemaGenerator().serialize()
+  }
+
+  @Benchmark
+  def shaclFromYaml: String = {
+    given sv: SchemaView = SchemaView.loadSchemaViewFromString(yaml)
+    RdfUtils.toTurtle(ShaclGenerator().generate())
+  }
+
+  @Benchmark
+  def shaclFromSchemaView: String = {
+    given sv: SchemaView = schemaView
+    RdfUtils.toTurtle(ShaclGenerator().generate())
+  }
+}

--- a/build.mill
+++ b/build.mill
@@ -4,6 +4,7 @@
 //| - ch.epfl.scala:scalafix-interfaces:0.14.6
 //| - io.github.alexarchambault.mill::mill-native-image::0.2.5
 //| - com.lihaoyi::mill-contrib-scoverage:$MILL_VERSION
+//| - com.lihaoyi::mill-contrib-jmh:$MILL_VERSION
 //| - com.carlosedp::mill-aliases::1.1.0
 //| - org.scalameta::scalameta:4.13.4
 //| bspScriptIgnore: [".idea/**"]
@@ -13,6 +14,7 @@ package build
 
 import com.goyeau.mill.scalafix.ScalafixModule
 import mill.*
+import mill.contrib.jmh.JmhModule
 import mill.contrib.scoverage.*
 import mill.javalib.publish.*
 import mill.scalalib.scalafmt.ScalafmtModule
@@ -326,6 +328,28 @@ object cli extends Module {
       override def moduleDeps = super.moduleDeps :+ build.tests.jvm
     }
   }
+}
+
+/** JMH benchmarks for the code generators. JVM-only, not published. Run with:
+  * `./mill benchmark.runJmh`
+  */
+object benchmark extends ScalaModule, ScalafmtModule, ScalafixModule, JmhModule {
+  def scalaVersion = scala
+
+  // JMH forks a JVM using this runtime; the CommonParams JVM flags require JDK 24+
+  // (e.g. -XX:+UseCompactObjectHeaders).
+  override def jvmVersion = "temurin:25"
+
+  def jmhCoreVersion = "1.37"
+
+  def moduleDeps = Seq(
+    build.generator.jvm,
+  )
+
+  def scalacOptions = Seq(
+    "-release",
+    "17",
+  )
 }
 
 object tests extends Module {


### PR DESCRIPTION
```
Benchmark                                          (schema)   Mode  Cnt     Score     Error  Units
GeneratorBench.jsonSchemaFromSchemaView          dummy.yaml  thrpt    5  9438.205 ± 165.437  ops/s
GeneratorBench.jsonSchemaFromSchemaView      cgmes-core.yml  thrpt    5   101.333 ±   3.250  ops/s
GeneratorBench.jsonSchemaFromSchemaView  cgmes-dynamics.yml  thrpt    5    36.539 ±   2.954  ops/s
GeneratorBench.jsonSchemaFromYaml                dummy.yaml  thrpt    5   792.439 ±  45.411  ops/s
GeneratorBench.jsonSchemaFromYaml            cgmes-core.yml  thrpt    5    24.759 ±   1.131  ops/s
GeneratorBench.jsonSchemaFromYaml        cgmes-dynamics.yml  thrpt    5     7.612 ±   0.194  ops/s
GeneratorBench.shaclFromSchemaView               dummy.yaml  thrpt    5  4189.231 ±  95.009  ops/s
GeneratorBench.shaclFromSchemaView           cgmes-core.yml  thrpt    5     1.391 ±   0.050  ops/s
GeneratorBench.shaclFromSchemaView       cgmes-dynamics.yml  thrpt    5     3.522 ±   0.142  ops/s
GeneratorBench.shaclFromYaml                     dummy.yaml  thrpt    5   675.350 ±  21.643  ops/s
GeneratorBench.shaclFromYaml                 cgmes-core.yml  thrpt    5     1.253 ±   0.037  ops/s
GeneratorBench.shaclFromYaml             cgmes-dynamics.yml  thrpt    5     2.275 ±   0.056  ops/s
```