### PR TITLE
LNK-135 Use jsoniter-scala encoder for JSON Schema

### DIFF
--- a/build.mill
+++ b/build.mill
@@ -291,6 +291,7 @@ object generator extends Module {
     override def mvnDeps = super.mvnDeps() ++ Seq(
       mvn"com.softwaremill.sttp.apispec::apispec-model::0.11.10",
       mvn"com.softwaremill.sttp.apispec::jsonschema-circe::0.11.10",
+      mvn"com.github.plokhotnyuk.jsoniter-scala::jsoniter-scala-macros::2.39.1",
     )
   }
 }

--- a/cli/test/src/eu/neverblink/linkml/cli/VersionSpec.scala
+++ b/cli/test/src/eu/neverblink/linkml/cli/VersionSpec.scala
@@ -16,7 +16,9 @@ class VersionSpec extends AnyWordSpec, Matchers {
 
       "include the copyright year and a link to the license" in {
         val (out, _) = Version.runTestCommand(List(alias))
-        out should include(s"Copyright (C) ${java.time.Year.now().getValue} NeverBlink and contributors")
+        out should include(
+          s"Copyright (C) ${java.time.Year.now().getValue} NeverBlink and contributors",
+        )
         out should include("https://www.apache.org/licenses/LICENSE-2.0")
       }
     }

--- a/generator/src/eu/neverblink/linkml/generator/jsonschema/JsonSchemaGenerator.scala
+++ b/generator/src/eu/neverblink/linkml/generator/jsonschema/JsonSchemaGenerator.scala
@@ -1,9 +1,20 @@
 package eu.neverblink.linkml.generator.jsonschema
 
+import com.github.plokhotnyuk.jsoniter_scala.core.*
+import com.github.plokhotnyuk.jsoniter_scala.macros.{CodecMakerConfig, JsonCodecMaker}
 import eu.neverblink.linkml.metamodel.Anything
 import eu.neverblink.linkml.schemaview.*
-import sttp.apispec.{AnySchema, ExampleSingleValue, Pattern, Schema, SchemaFormat, SchemaType}
-import sttp.apispec.circe.encoderSchema
+import sttp.apispec.{
+  AnySchema,
+  ExampleMultipleValue,
+  ExampleSingleValue,
+  ExampleValue,
+  Pattern,
+  Schema,
+  SchemaFormat,
+  SchemaLike,
+  SchemaType,
+}
 
 import java.lang
 import scala.collection.immutable
@@ -201,11 +212,17 @@ class JsonSchemaGenerator(using sv: SchemaView) {
     *   Whether the generated JSON Schema should allow `additionalProperties` for classes
     * @param treeRootOverride
     *   If defined, override the schema `tree_root` class with the one provided
+    * @param indentationStep
+    *   number of spaces in pretty print indentation of JSON Schema
     * @return
     *   Serialized JSON Schema
     */
-  final def serialize(open: Boolean = false, treeRootOverride: Option[String] = None): String =
-    encoderSchema(generate(open, treeRootOverride)).spaces2
+  final def serialize(
+      open: Boolean = false,
+      treeRootOverride: Option[String] = None,
+      indentationStep: Int = 2,
+  ): String =
+    writeToString(generate(open, treeRootOverride), WriterConfig.withIndentionStep(indentationStep))
 }
 
 object JsonSchemaGenerator {
@@ -243,4 +260,46 @@ object JsonSchemaGenerator {
   extension (schema: Schema)
     def arrayOf: Schema = Schema(SchemaType.Array).copy(items = Some(schema))
     def dictOf: Schema = Schema(SchemaType.Object).copy(additionalProperties = Some(schema))
+
+  private implicit lazy val codec: JsonValueCodec[Schema] = {
+    implicit val schemaLikeCodec: JsonValueCodec[SchemaLike] = new JsonValueCodec {
+      override def decodeValue(in: JsonReader, default: SchemaLike): SchemaLike = ???
+
+      override def encodeValue(x: SchemaLike, out: JsonWriter): Unit = x match {
+        case s: Schema => codec.encodeValue(s, out)
+        case AnySchema.Anything => out.writeVal(true)
+        case AnySchema.Nothing => out.writeVal(false)
+      }
+
+      override def nullValue: SchemaLike = ???
+    }
+    implicit val listOfSchemaTypeCodec: JsonValueCodec[List[SchemaType]] = new JsonValueCodec {
+      override def decodeValue(in: JsonReader, default: List[SchemaType]): List[SchemaType] = ???
+
+      override def encodeValue(xs: List[SchemaType], out: JsonWriter): Unit =
+        if (xs.size == 1) out.writeNonEscapedAsciiVal(xs.head.value)
+        else {
+          out.writeArrayStart()
+          xs.foreach(x => out.writeNonEscapedAsciiVal(x.value))
+          out.writeArrayEnd()
+        }
+
+      override def nullValue: List[SchemaType] = ???
+    }
+    implicit val exampleValueCodec: JsonValueCodec[ExampleValue] = new JsonValueCodec {
+      override def decodeValue(in: JsonReader, default: ExampleValue): ExampleValue = ???
+
+      override def encodeValue(x: ExampleValue, out: JsonWriter): Unit = x match {
+        case s: ExampleSingleValue => out.writeVal(s.value.toString)
+        case m: ExampleMultipleValue => m.values.foreach(a => out.writeVal(a.toString))
+      }
+
+      override def nullValue: ExampleValue = ???
+    }
+    JsonCodecMaker.make[Schema](
+      CodecMakerConfig.withDiscriminatorFieldName(None)
+        .withEncodingOnly(true)
+        .withInlineOneValueClasses(true),
+    )
+  }
 }

--- a/generator/test/src/eu/neverblink/linkml/generator/jsonschema/JsonSchemaGeneratorSpec.scala
+++ b/generator/test/src/eu/neverblink/linkml/generator/jsonschema/JsonSchemaGeneratorSpec.scala
@@ -4,6 +4,7 @@ import eu.neverblink.linkml.schemaview.SchemaView
 import eu.neverblink.linkml.tests.ModelCatalogue
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
+import sttp.apispec.circe.encoderSchema
 import sttp.apispec.{ExampleSingleValue, Pattern, Schema, SchemaType}
 
 class JsonSchemaGeneratorSpec extends AnyWordSpec, Matchers {
@@ -564,14 +565,20 @@ class JsonSchemaGeneratorSpec extends AnyWordSpec, Matchers {
     "generate the metamodel without errors" in {
       val sv = SchemaView.loadSchemaViewFromUri("https://w3id.org/linkml/meta")
       given SchemaView = sv
-      JsonSchemaGenerator().serialize() should not be ""
+      val generator = JsonSchemaGenerator()
+      val expected = encoderSchema(generator.generate(false, None)).noSpaces
+      val result = generator.serialize(indentationStep = 0)
+      result shouldBe expected
     }
 
     "generate all catalogue models without errors" when {
       for entry <- ModelCatalogue.all do
         s"model '${entry.model.root.name}'" in {
           assume(!skipModels.contains(entry.model.root.name))
-          JsonSchemaGenerator(using entry.model).serialize() should not be ""
+          val generator = JsonSchemaGenerator(using entry.model)
+          val expected = encoderSchema(generator.generate(false, None)).noSpaces
+          val result = generator.serialize(indentationStep = 0)
+          result shouldBe expected
         }
     }
   }


### PR DESCRIPTION
Results of JSON Schema generation benchmarks

Before:
```txt
Benchmark                                                             (schema)   Mode  Cnt           Score        Error   Units
GeneratorBench.jsonSchemaFromSchemaView                              dummy.yml  thrpt    5       12699.500 ±    136.522   ops/s
GeneratorBench.jsonSchemaFromSchemaView:gc.alloc.rate                dummy.yml  thrpt    5        4238.242 ±     45.275  MB/sec
GeneratorBench.jsonSchemaFromSchemaView:gc.alloc.rate.norm           dummy.yml  thrpt    5      349988.547 ±     26.583    B/op
GeneratorBench.jsonSchemaFromSchemaView:gc.count                     dummy.yml  thrpt    5           9.000               counts
GeneratorBench.jsonSchemaFromSchemaView:gc.time                      dummy.yml  thrpt    5           9.000                   ms
GeneratorBench.jsonSchemaFromSchemaView                         cgmes-core.yml  thrpt    5         138.392 ±      0.495   ops/s
GeneratorBench.jsonSchemaFromSchemaView:gc.alloc.rate           cgmes-core.yml  thrpt    5        3864.833 ±     13.749  MB/sec
GeneratorBench.jsonSchemaFromSchemaView:gc.alloc.rate.norm      cgmes-core.yml  thrpt    5    29287120.035 ±      1.548    B/op
GeneratorBench.jsonSchemaFromSchemaView:gc.count                cgmes-core.yml  thrpt    5           9.000               counts
GeneratorBench.jsonSchemaFromSchemaView:gc.time                 cgmes-core.yml  thrpt    5           6.000                   ms
GeneratorBench.jsonSchemaFromSchemaView                     cgmes-dynamics.yml  thrpt    5          53.864 ±      0.538   ops/s
GeneratorBench.jsonSchemaFromSchemaView:gc.alloc.rate       cgmes-dynamics.yml  thrpt    5        2866.686 ±     28.542  MB/sec
GeneratorBench.jsonSchemaFromSchemaView:gc.alloc.rate.norm  cgmes-dynamics.yml  thrpt    5    55812765.798 ±      8.397    B/op
GeneratorBench.jsonSchemaFromSchemaView:gc.count            cgmes-dynamics.yml  thrpt    5           6.000               counts
GeneratorBench.jsonSchemaFromSchemaView:gc.time             cgmes-dynamics.yml  thrpt    5           4.000                   ms
GeneratorBench.jsonSchemaFromYaml                                    dummy.yml  thrpt    5        1090.725 ±     35.290   ops/s
GeneratorBench.jsonSchemaFromYaml:gc.alloc.rate                      dummy.yml  thrpt    5        6295.620 ±    202.277  MB/sec
GeneratorBench.jsonSchemaFromYaml:gc.alloc.rate.norm                 dummy.yml  thrpt    5     6053197.431 ±   1274.599    B/op
GeneratorBench.jsonSchemaFromYaml:gc.count                           dummy.yml  thrpt    5          14.000               counts
GeneratorBench.jsonSchemaFromYaml:gc.time                            dummy.yml  thrpt    5           5.000                   ms
GeneratorBench.jsonSchemaFromYaml                               cgmes-core.yml  thrpt    5          30.951 ±      0.321   ops/s
GeneratorBench.jsonSchemaFromYaml:gc.alloc.rate                 cgmes-core.yml  thrpt    5        5923.037 ±     61.499  MB/sec
GeneratorBench.jsonSchemaFromYaml:gc.alloc.rate.norm            cgmes-core.yml  thrpt    5   200687657.961 ±  11227.370    B/op
GeneratorBench.jsonSchemaFromYaml:gc.count                      cgmes-core.yml  thrpt    5          13.000               counts
GeneratorBench.jsonSchemaFromYaml:gc.time                       cgmes-core.yml  thrpt    5           8.000                   ms
GeneratorBench.jsonSchemaFromYaml                           cgmes-dynamics.yml  thrpt    5           9.049 ±      0.115   ops/s
GeneratorBench.jsonSchemaFromYaml:gc.alloc.rate             cgmes-dynamics.yml  thrpt    5        5933.485 ±     75.265  MB/sec
GeneratorBench.jsonSchemaFromYaml:gc.alloc.rate.norm        cgmes-dynamics.yml  thrpt    5   687667896.160 ±   6631.471    B/op
GeneratorBench.jsonSchemaFromYaml:gc.count                  cgmes-dynamics.yml  thrpt    5          14.000               counts
GeneratorBench.jsonSchemaFromYaml:gc.time                   cgmes-dynamics.yml  thrpt    5          16.000                   ms
```

After:
```txt
Benchmark                                                             (schema)   Mode  Cnt           Score        Error   Units
GeneratorBench.jsonSchemaFromSchemaView                              dummy.yml  thrpt    5       40860.383 ±    610.044   ops/s
GeneratorBench.jsonSchemaFromSchemaView:gc.alloc.rate                dummy.yml  thrpt    5        1488.346 ±     22.548  MB/sec
GeneratorBench.jsonSchemaFromSchemaView:gc.alloc.rate.norm           dummy.yml  thrpt    5       38200.130 ±      0.004    B/op
GeneratorBench.jsonSchemaFromSchemaView:gc.count                     dummy.yml  thrpt    5           3.000               counts
GeneratorBench.jsonSchemaFromSchemaView:gc.time                      dummy.yml  thrpt    5           4.000                   ms
GeneratorBench.jsonSchemaFromSchemaView                         cgmes-core.yml  thrpt    5         508.739 ±     15.944   ops/s
GeneratorBench.jsonSchemaFromSchemaView:gc.alloc.rate           cgmes-core.yml  thrpt    5        2555.034 ±     80.196  MB/sec
GeneratorBench.jsonSchemaFromSchemaView:gc.alloc.rate.norm      cgmes-core.yml  thrpt    5     5266906.460 ±      0.333    B/op
GeneratorBench.jsonSchemaFromSchemaView:gc.count                cgmes-core.yml  thrpt    5           6.000               counts
GeneratorBench.jsonSchemaFromSchemaView:gc.time                 cgmes-core.yml  thrpt    5           9.000                   ms
GeneratorBench.jsonSchemaFromSchemaView                     cgmes-dynamics.yml  thrpt    5         112.941 ±      2.943   ops/s
GeneratorBench.jsonSchemaFromSchemaView:gc.alloc.rate       cgmes-dynamics.yml  thrpt    5        1196.731 ±     31.148  MB/sec
GeneratorBench.jsonSchemaFromSchemaView:gc.alloc.rate.norm  cgmes-dynamics.yml  thrpt    5    11112246.793 ±      2.620    B/op
GeneratorBench.jsonSchemaFromSchemaView:gc.count            cgmes-dynamics.yml  thrpt    5           3.000               counts
GeneratorBench.jsonSchemaFromSchemaView:gc.time             cgmes-dynamics.yml  thrpt    5           6.000                   ms
GeneratorBench.jsonSchemaFromYaml                                    dummy.yml  thrpt    5        1239.839 ±     46.702   ops/s
GeneratorBench.jsonSchemaFromYaml:gc.alloc.rate                      dummy.yml  thrpt    5        6778.969 ±    254.344  MB/sec
GeneratorBench.jsonSchemaFromYaml:gc.alloc.rate.norm                 dummy.yml  thrpt    5     5733995.098 ±    574.906    B/op
GeneratorBench.jsonSchemaFromYaml:gc.count                           dummy.yml  thrpt    5          14.000               counts
GeneratorBench.jsonSchemaFromYaml:gc.time                            dummy.yml  thrpt    5           7.000                   ms
GeneratorBench.jsonSchemaFromYaml                               cgmes-core.yml  thrpt    5          37.391 ±      0.445   ops/s
GeneratorBench.jsonSchemaFromYaml:gc.alloc.rate                 cgmes-core.yml  thrpt    5        6288.937 ±     74.850  MB/sec
GeneratorBench.jsonSchemaFromYaml:gc.alloc.rate.norm            cgmes-core.yml  thrpt    5   176385398.989 ±  20275.547    B/op
GeneratorBench.jsonSchemaFromYaml:gc.count                      cgmes-core.yml  thrpt    5          13.000               counts
GeneratorBench.jsonSchemaFromYaml:gc.time                       cgmes-core.yml  thrpt    5          12.000                   ms
GeneratorBench.jsonSchemaFromYaml                           cgmes-dynamics.yml  thrpt    5           9.377 ±      0.092   ops/s
GeneratorBench.jsonSchemaFromYaml:gc.alloc.rate             cgmes-dynamics.yml  thrpt    5        6456.277 ±     62.928  MB/sec
GeneratorBench.jsonSchemaFromYaml:gc.alloc.rate.norm        cgmes-dynamics.yml  thrpt    5   722029550.240 ±   4865.720    B/op
GeneratorBench.jsonSchemaFromYaml:gc.count                  cgmes-dynamics.yml  thrpt    5          15.000               counts
GeneratorBench.jsonSchemaFromYaml:gc.time                   cgmes-dynamics.yml  thrpt    5          18.000                   ms
```