### PR TITLE
LNK-135 More efficient accessing to SchemaView elements

### DIFF
--- a/generator/test/src-jvm/eu/neverblink/linkml/generator/rdfs/RdfsGeneratorSpec.scala
+++ b/generator/test/src-jvm/eu/neverblink/linkml/generator/rdfs/RdfsGeneratorSpec.scala
@@ -230,19 +230,19 @@ class RdfsGeneratorSpec extends AnyWordSpec, Matchers {
           |@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
           |@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
           |
-          |<https://neverblink.eu/linkml/rdfs/test/MotorVehicle> a rdfs:Class .
-          |
           |<https://neverblink.eu/linkml/rdfs/test/PassengerVehicle> a rdfs:Class;
           |  rdfs:subClassOf <https://neverblink.eu/linkml/rdfs/test/MotorVehicle> .
           |
-          |<https://neverblink.eu/linkml/rdfs/test/Van> a rdfs:Class;
-          |  rdfs:subClassOf <https://neverblink.eu/linkml/rdfs/test/MotorVehicle> .
+          |<https://neverblink.eu/linkml/rdfs/test/MotorVehicle> a rdfs:Class .
           |
           |<https://neverblink.eu/linkml/rdfs/test/Truck> a rdfs:Class;
           |  rdfs:subClassOf <https://neverblink.eu/linkml/rdfs/test/MotorVehicle> .
           |
           |<https://neverblink.eu/linkml/rdfs/test/MiniVan> a rdfs:Class;
           |  rdfs:subClassOf <https://neverblink.eu/linkml/rdfs/test/PassengerVehicle>, <https://neverblink.eu/linkml/rdfs/test/Van> .
+          |
+          |<https://neverblink.eu/linkml/rdfs/test/Van> a rdfs:Class;
+          |  rdfs:subClassOf <https://neverblink.eu/linkml/rdfs/test/MotorVehicle> .
           |""".stripMargin
     }
 

--- a/schemaview/src/eu/neverblink/linkml/schemaview/SchemaView.scala
+++ b/schemaview/src/eu/neverblink/linkml/schemaview/SchemaView.scala
@@ -52,19 +52,26 @@ final case class SchemaView(schemas: Seq[SchemaDefinition]) extends ReferenceRes
   /** All types defined in the loaded schemas, as views.
     */
   lazy val types: Map[String, TypeView] =
-    schemas.map(schema => schema.types.map((k, v) => (k, TypeView(v, schema)))).reduce(_ ++ _)
+    schemas.foldLeft(Map.newBuilder[String, TypeView]) { (acc, schema) =>
+      schema.types.foreach((k, v) => acc.addOne((k, TypeView(v, schema))))
+      acc
+    }.result()
 
   /** All slots defined in the loaded schemas, as views.
     */
   lazy val slotDefinitions: Map[String, SlotView] =
-    schemas.map(schema => schema.slotDefinitions.map((k, v) => (k, SlotView(v, schema)))).reduce(
-      _ ++ _,
-    )
+    schemas.foldLeft(Map.newBuilder[String, SlotView]) { (acc, schema) =>
+      schema.slotDefinitions.foreach((k, v) => acc.addOne((k, SlotView(v, schema))))
+      acc
+    }.result()
 
   /** All classes defined in the loaded schemas, as views.
     */
   lazy val classes: Map[String, ClassView] =
-    schemas.map(schema => schema.classes.map((k, v) => (k, ClassView(v, schema)))).reduce(_ ++ _)
+    schemas.foldLeft(Map.newBuilder[String, ClassView]) { (acc, schema) =>
+      schema.classes.foreach((k, v) => acc.addOne((k, ClassView(v, schema))))
+      acc
+    }.result()
 
   /** Get all classes reachable from a given class, following derived attributes and optionally
     * ancestors. The result is a map of class name to class view, including the starting class.

--- a/schemaview/test/src/eu/neverblink/linkml/schemaview/SchemaValidatorSpec.scala
+++ b/schemaview/test/src/eu/neverblink/linkml/schemaview/SchemaValidatorSpec.scala
@@ -381,8 +381,8 @@ class SchemaValidatorSpec extends AnyWordSpec, Matchers {
 
       Seq(
         """Schema validation failed:
-          |Invalid type of key / identifier slot in class 'some_class': 'UnitOfMeasure'. Expected a basic, scalar data type (e.g., string, integer, float, uri).
-          |Invalid type of key / identifier slot in class 'some_another_class': 'pv_formula_options'. Expected a basic, scalar data type (e.g., string, integer, float, uri).""".stripMargin,
+          |Invalid type of key / identifier slot in class 'some_another_class': 'pv_formula_options'. Expected a basic, scalar data type (e.g., string, integer, float, uri).
+          |Invalid type of key / identifier slot in class 'some_class': 'UnitOfMeasure'. Expected a basic, scalar data type (e.g., string, integer, float, uri).""".stripMargin,
       ) foreach { part =>
         msg should include(part)
       }


### PR DESCRIPTION
Replacing usage of ListMap by HashMap

Before:
```txt
Benchmark                                                             (schema)   Mode  Cnt           Score        Error   Units
GeneratorBench.jsonSchemaFromSchemaView                              dummy.yml  thrpt    5       40860.383 ±    610.044   ops/s
GeneratorBench.jsonSchemaFromSchemaView:gc.alloc.rate                dummy.yml  thrpt    5        1488.346 ±     22.548  MB/sec
GeneratorBench.jsonSchemaFromSchemaView:gc.alloc.rate.norm           dummy.yml  thrpt    5       38200.130 ±      0.004    B/op
GeneratorBench.jsonSchemaFromSchemaView:gc.count                     dummy.yml  thrpt    5           3.000               counts
GeneratorBench.jsonSchemaFromSchemaView:gc.time                      dummy.yml  thrpt    5           4.000                   ms
GeneratorBench.jsonSchemaFromSchemaView                         cgmes-core.yml  thrpt    5         508.739 ±     15.944   ops/s
GeneratorBench.jsonSchemaFromSchemaView:gc.alloc.rate           cgmes-core.yml  thrpt    5        2555.034 ±     80.196  MB/sec
GeneratorBench.jsonSchemaFromSchemaView:gc.alloc.rate.norm      cgmes-core.yml  thrpt    5     5266906.460 ±      0.333    B/op
GeneratorBench.jsonSchemaFromSchemaView:gc.count                cgmes-core.yml  thrpt    5           6.000               counts
GeneratorBench.jsonSchemaFromSchemaView:gc.time                 cgmes-core.yml  thrpt    5           9.000                   ms
GeneratorBench.jsonSchemaFromSchemaView                     cgmes-dynamics.yml  thrpt    5         112.941 ±      2.943   ops/s
GeneratorBench.jsonSchemaFromSchemaView:gc.alloc.rate       cgmes-dynamics.yml  thrpt    5        1196.731 ±     31.148  MB/sec
GeneratorBench.jsonSchemaFromSchemaView:gc.alloc.rate.norm  cgmes-dynamics.yml  thrpt    5    11112246.793 ±      2.620    B/op
GeneratorBench.jsonSchemaFromSchemaView:gc.count            cgmes-dynamics.yml  thrpt    5           3.000               counts
GeneratorBench.jsonSchemaFromSchemaView:gc.time             cgmes-dynamics.yml  thrpt    5           6.000                   ms
GeneratorBench.jsonSchemaFromYaml                                    dummy.yml  thrpt    5        1239.839 ±     46.702   ops/s
GeneratorBench.jsonSchemaFromYaml:gc.alloc.rate                      dummy.yml  thrpt    5        6778.969 ±    254.344  MB/sec
GeneratorBench.jsonSchemaFromYaml:gc.alloc.rate.norm                 dummy.yml  thrpt    5     5733995.098 ±    574.906    B/op
GeneratorBench.jsonSchemaFromYaml:gc.count                           dummy.yml  thrpt    5          14.000               counts
GeneratorBench.jsonSchemaFromYaml:gc.time                            dummy.yml  thrpt    5           7.000                   ms
GeneratorBench.jsonSchemaFromYaml                               cgmes-core.yml  thrpt    5          37.391 ±      0.445   ops/s
GeneratorBench.jsonSchemaFromYaml:gc.alloc.rate                 cgmes-core.yml  thrpt    5        6288.937 ±     74.850  MB/sec
GeneratorBench.jsonSchemaFromYaml:gc.alloc.rate.norm            cgmes-core.yml  thrpt    5   176385398.989 ±  20275.547    B/op
GeneratorBench.jsonSchemaFromYaml:gc.count                      cgmes-core.yml  thrpt    5          13.000               counts
GeneratorBench.jsonSchemaFromYaml:gc.time                       cgmes-core.yml  thrpt    5          12.000                   ms
GeneratorBench.jsonSchemaFromYaml                           cgmes-dynamics.yml  thrpt    5           9.377 ±      0.092   ops/s
GeneratorBench.jsonSchemaFromYaml:gc.alloc.rate             cgmes-dynamics.yml  thrpt    5        6456.277 ±     62.928  MB/sec
GeneratorBench.jsonSchemaFromYaml:gc.alloc.rate.norm        cgmes-dynamics.yml  thrpt    5   722029550.240 ±   4865.720    B/op
GeneratorBench.jsonSchemaFromYaml:gc.count                  cgmes-dynamics.yml  thrpt    5          15.000               counts
GeneratorBench.jsonSchemaFromYaml:gc.time                   cgmes-dynamics.yml  thrpt    5          18.000                   ms
```

After
```txt
Benchmark                                                             (schema)   Mode  Cnt           Score        Error   Units
GeneratorBench.jsonSchemaFromSchemaView                              dummy.yml  thrpt    5       41995.044 ±    144.659   ops/s
GeneratorBench.jsonSchemaFromSchemaView:gc.alloc.rate                dummy.yml  thrpt    5        1506.312 ±      5.134  MB/sec
GeneratorBench.jsonSchemaFromSchemaView:gc.alloc.rate.norm           dummy.yml  thrpt    5       37616.126 ±      0.003    B/op
GeneratorBench.jsonSchemaFromSchemaView:gc.count                     dummy.yml  thrpt    5           3.000               counts
GeneratorBench.jsonSchemaFromSchemaView:gc.time                      dummy.yml  thrpt    5           4.000                   ms
GeneratorBench.jsonSchemaFromSchemaView                         cgmes-core.yml  thrpt    5        1037.038 ±     31.497   ops/s
GeneratorBench.jsonSchemaFromSchemaView:gc.alloc.rate           cgmes-core.yml  thrpt    5        5195.054 ±    157.593  MB/sec
GeneratorBench.jsonSchemaFromSchemaView:gc.alloc.rate.norm      cgmes-core.yml  thrpt    5     5253508.490 ±    224.512    B/op
GeneratorBench.jsonSchemaFromSchemaView:gc.count                cgmes-core.yml  thrpt    5          11.000               counts
GeneratorBench.jsonSchemaFromSchemaView:gc.time                 cgmes-core.yml  thrpt    5          11.000                   ms
GeneratorBench.jsonSchemaFromSchemaView                     cgmes-dynamics.yml  thrpt    5         427.566 ±      1.165   ops/s
GeneratorBench.jsonSchemaFromSchemaView:gc.alloc.rate       cgmes-dynamics.yml  thrpt    5        4521.477 ±     12.113  MB/sec
GeneratorBench.jsonSchemaFromSchemaView:gc.alloc.rate.norm  cgmes-dynamics.yml  thrpt    5    11089996.440 ±      0.225    B/op
GeneratorBench.jsonSchemaFromSchemaView:gc.count            cgmes-dynamics.yml  thrpt    5          10.000               counts
GeneratorBench.jsonSchemaFromSchemaView:gc.time             cgmes-dynamics.yml  thrpt    5          11.000                   ms
GeneratorBench.jsonSchemaFromYaml                                    dummy.yml  thrpt    5        1226.386 ±     43.788   ops/s
GeneratorBench.jsonSchemaFromYaml:gc.alloc.rate                      dummy.yml  thrpt    5        6717.575 ±    239.066  MB/sec
GeneratorBench.jsonSchemaFromYaml:gc.alloc.rate.norm                 dummy.yml  thrpt    5     5744422.428 ±    500.228    B/op
GeneratorBench.jsonSchemaFromYaml:gc.count                           dummy.yml  thrpt    5          14.000               counts
GeneratorBench.jsonSchemaFromYaml:gc.time                            dummy.yml  thrpt    5          10.000                   ms
GeneratorBench.jsonSchemaFromYaml                               cgmes-core.yml  thrpt    5          40.142 ±      0.757   ops/s
GeneratorBench.jsonSchemaFromYaml:gc.alloc.rate                 cgmes-core.yml  thrpt    5        6753.172 ±    126.994  MB/sec
GeneratorBench.jsonSchemaFromYaml:gc.alloc.rate.norm            cgmes-core.yml  thrpt    5   176424620.244 ±  21238.700    B/op
GeneratorBench.jsonSchemaFromYaml:gc.count                      cgmes-core.yml  thrpt    5          15.000               counts
GeneratorBench.jsonSchemaFromYaml:gc.time                       cgmes-core.yml  thrpt    5          11.000                   ms
GeneratorBench.jsonSchemaFromYaml                           cgmes-dynamics.yml  thrpt    5          11.866 ±      0.126   ops/s
GeneratorBench.jsonSchemaFromYaml:gc.alloc.rate             cgmes-dynamics.yml  thrpt    5        7261.238 ±     76.856  MB/sec
GeneratorBench.jsonSchemaFromYaml:gc.alloc.rate.norm        cgmes-dynamics.yml  thrpt    5   641717334.533 ±   2676.893    B/op
GeneratorBench.jsonSchemaFromYaml:gc.count                  cgmes-dynamics.yml  thrpt    5          16.000               counts
GeneratorBench.jsonSchemaFromYaml:gc.time                   cgmes-dynamics.yml  thrpt    5          19.000                   ms
```