### PR TITLE
LNK-135 More efficient JSON Schema generation

### DIFF
--- a/generator/src/eu/neverblink/linkml/generator/jsonschema/JsonSchemaGenerator.scala
+++ b/generator/src/eu/neverblink/linkml/generator/jsonschema/JsonSchemaGenerator.scala
@@ -80,7 +80,7 @@ class JsonSchemaGenerator(using sv: SchemaView) {
               ).dictOf // TODO LNK-34: or null
           }
         } else {
-          val referenceSchema = Schema(SchemaType.String)
+          val referenceSchema = stringSchema
             .copy($comment =
               Some(s"Reference to an instance of the '${range.inner.name}' LinkML class"),
             )
@@ -151,7 +151,7 @@ class JsonSchemaGenerator(using sv: SchemaView) {
       val requiredSlots = slots.values.collect {
         case s if s.slot.required => s.slot.name
       }
-      className(cls) -> Schema(SchemaType.Object).copy(
+      className(cls) -> objectSchema.copy(
         required = requiredSlots.toList,
         properties = properties.to(immutable.ListMap),
         additionalProperties = Some(if (open) AnySchema.Anything else AnySchema.Nothing),
@@ -161,7 +161,7 @@ class JsonSchemaGenerator(using sv: SchemaView) {
     }
     val defsEnums = for ev <- sv.enums.values yield {
       val enum_ = ev._enum
-      enum_.name -> Schema(SchemaType.Object).copy(
+      enum_.name -> objectSchema.copy(
         `type` = Some(List(SchemaType.String)),
         `enum` = Some(enum_.permissibleValues.keys.map(ExampleSingleValue(_)).toList),
         title = enum_.title,
@@ -189,7 +189,7 @@ class JsonSchemaGenerator(using sv: SchemaView) {
           case InlineType.optional =>
             Schema.oneOf(List(classSchema, Schema.Null), discriminator = None) // object or null
           case InlineType.list =>
-            Schema(SchemaType.Array).copy(items = Some(classSchema)) // array of objects
+            arraySchema.copy(items = Some(classSchema)) // array of objects
           case _ =>
             throw NotImplementedError(
               s"Tree root inline type '$inlineType' is not implemented for JSON Schema.",
@@ -231,26 +231,26 @@ object JsonSchemaGenerator {
     * Provides formats for date-times and URI/CURIE.
     */
   def typeToRuntime(tv: TypeView): Schema = tv.runtimeType match {
-    case StringType => Schema(SchemaType.String)
-    case IntegerType => Schema(SchemaType.Integer)
-    case FloatType => Schema(SchemaType.Number)
-    case DoubleType => Schema(SchemaType.Number)
-    case BooleanType => Schema(SchemaType.Boolean)
-    case DecimalType => Schema(SchemaType.Number)
+    case StringType => stringSchema
+    case IntegerType => integerSchema
+    case FloatType => numberSchema
+    case DoubleType => numberSchema
+    case BooleanType => booleanSchema
+    case DecimalType => numberSchema
     case AnyType => Schema.Empty
-    case DateType => Schema(SchemaType.String).copy(format = Some(SchemaFormat.Date))
-    case DateTimeType => Schema(SchemaType.String).copy(format = Some(SchemaFormat.DateTime))
-    case TimeType => Schema(SchemaType.String).copy(format = Some("time"))
+    case DateType => stringSchema.copy(format = Some(SchemaFormat.Date))
+    case DateTimeType => stringSchema.copy(format = Some(SchemaFormat.DateTime))
+    case TimeType => stringSchema.copy(format = Some("time"))
     case UriOrCurieType =>
       Schema.Empty.copy(anyOf =
         List(
-          Schema(SchemaType.String).copy(format = Some("uri")),
-          Schema(SchemaType.String).copy(format = Some("curie")),
+          stringSchema.copy(format = Some("uri")),
+          stringSchema.copy(format = Some("curie")),
         ),
       )
-    case UriType => Schema(SchemaType.String).copy(format = Some("uri"))
-    case CurieType => Schema(SchemaType.String).copy(format = Some("curie"))
-    case NcNameType => Schema(SchemaType.String).copy(format = Some("ncname"))
+    case UriType => stringSchema.copy(format = Some("uri"))
+    case CurieType => stringSchema.copy(format = Some("curie"))
+    case NcNameType => stringSchema.copy(format = Some("ncname"))
     case UnknownType => Schema.Empty
   }
 
@@ -258,8 +258,8 @@ object JsonSchemaGenerator {
   type MappedSlotName = String
 
   extension (schema: Schema)
-    def arrayOf: Schema = Schema(SchemaType.Array).copy(items = Some(schema))
-    def dictOf: Schema = Schema(SchemaType.Object).copy(additionalProperties = Some(schema))
+    def arrayOf: Schema = arraySchema.copy(items = Some(schema))
+    def dictOf: Schema = objectSchema.copy(additionalProperties = Some(schema))
 
   private implicit lazy val codec: JsonValueCodec[Schema] = {
     implicit val schemaLikeCodec: JsonValueCodec[SchemaLike] = new JsonValueCodec {
@@ -302,4 +302,11 @@ object JsonSchemaGenerator {
         .withInlineOneValueClasses(true),
     )
   }
+
+  private val arraySchema: Schema = Schema(SchemaType.Array)
+  private val booleanSchema: Schema = Schema(SchemaType.Boolean)
+  private val integerSchema: Schema = Schema(SchemaType.Integer)
+  private val numberSchema: Schema = Schema(SchemaType.Number)
+  private val objectSchema: Schema = Schema(SchemaType.Object)
+  private val stringSchema: Schema = Schema(SchemaType.String)
 }

--- a/runtime/src/eu/neverblink/linkml/runtime/UriOrCurie.scala
+++ b/runtime/src/eu/neverblink/linkml/runtime/UriOrCurie.scala
@@ -71,16 +71,14 @@ class BasicPrefixResolver(schemaId: String) extends PrefixResolver {
     uriToPrefix.put(normalizedUri, prefix)
   }
 
-  override def resolvePrefix(prefix: String): Option[String] =
-    if prefixToUri.containsKey(prefix) then Option(prefixToUri.get(prefix))
-    else None
+  override def resolvePrefix(prefix: String): Option[String] = Option(prefixToUri.get(prefix))
 
   override def expand(curie: String): String = {
-    val parts = curie.split(':')
-    if (parts.length == 2) {
-      val prefix = parts(0)
+    val index = curie.indexOf(':')
+    if (index >= 0) {
+      val prefix = curie.substring(0, index)
       val baseUri = prefixToUri.get(prefix)
-      if (baseUri != null) baseUri + parts(1)
+      if (baseUri ne null) baseUri + curie.substring(index + 1)
       else sys.error(s"Unknown prefix '$prefix' for CURIE '$curie' in schema '$schemaId'")
     } else curie // relative reference
   }
@@ -116,12 +114,15 @@ class BasicPrefixResolver(schemaId: String) extends PrefixResolver {
     s"$prefix:$curie"
   }
 
-  private def getLastPathSegment(uri: java.net.URI): String =
-    Option(uri.getPath) match {
-      case Some(path) if path.nonEmpty && path != "/" =>
-        path.stripSuffix("/").split("/").lastOption.getOrElse("")
-      case _ => ""
-    }
+  private def getLastPathSegment(uri: java.net.URI): String = {
+    var path = uri.getPath
+    if (path ne null) {
+      path = path.stripSuffix("/")
+      val index = path.lastIndexOf('/')
+      if (index >= 0) path.substring(index + 1)
+      else ""
+    } else ""
+  }
 }
 
 /** Regular-expression-based URI and CURIE validation functions

--- a/schemaview/src/eu/neverblink/linkml/schemaview/ElementView.scala
+++ b/schemaview/src/eu/neverblink/linkml/schemaview/ElementView.scala
@@ -64,10 +64,19 @@ final case class ClassView(cls: ClassDefinition, definingSchema: SchemaDefinitio
   def uriOrCurie: UriOrCurie =
     cls.classUri.getOrElse(Uri(defaultPrefixUri + Case.PascalCase(cls.name)))
 
-  /** Derived attributes for this class.
+  /** Derived attributes for this class and the identifier slot of a class, if it has one.
     */
-  lazy val derivedAttributes: Map[String, SlotView] =
-    applicableSlots.map(v => v.ref.value -> derivedSlot(v.ref, v.source)).toMap
+  lazy val (derivedAttributes: Map[String, SlotView], identifier: Option[SlotView]) = {
+    var idSv: SlotView = null
+    val das = applicableSlots.foldLeft(Map.empty[String, SlotView]) { (acc, v) =>
+      val sv = derivedSlot(v.ref, v.source)
+      if (sv.slot.identifier) {
+        idSv = sv
+      }
+      acc.updated(v.ref.value, sv)
+    }
+    (das, Option(idSv))
+  }
 
   /** Get and dereference the direct parents (mixins + inheritance) of this class
     *
@@ -82,15 +91,15 @@ final case class ClassView(cls: ClassDefinition, definingSchema: SchemaDefinitio
     */
   def subjectType: Option[SubjectType] = identifier.flatMap(slotView => {
     slotView.derivedRangeView.resolve.collect { case tv: TypeView =>
-      tv.subjectType
-    }.map {
-      // Fallback if the type does not define the prefix but the slot does
-      case SubjectType.base =>
-        slotView.implicitPrefixReference match {
-          case Some(prefix) => SubjectType.implicitPrefix(prefix)
-          case None => SubjectType.base
-        }
-      case subject => subject
+      tv.subjectType match {
+        // Fallback if the type does not define the prefix but the slot does
+        case SubjectType.base =>
+          slotView.implicitPrefixReference match {
+            case Some(prefix) => SubjectType.implicitPrefix(prefix)
+            case _ => SubjectType.base
+          }
+        case subject => subject
+      }
     }
   })
 
@@ -116,12 +125,6 @@ final case class ClassView(cls: ClassDefinition, definingSchema: SchemaDefinitio
 
   private def getDirectSlots(cls: ClassDefinition): Seq[Reference[SlotDefinition]] =
     cls.slots ++ cls.attributes.keys.map(Reference[SlotDefinition])
-
-  /** Get the identifier slot of a class, if it has one.
-    */
-  def identifier: Option[SlotView] = {
-    derivedAttributes.values.find(_.slot.identifier)
-  }
 
   /** Get all slot references that are applicable to this class definition.
     *
@@ -221,7 +224,7 @@ final case class ClassView(cls: ClassDefinition, definingSchema: SchemaDefinitio
     * @return
     *   true if the class has an identifier
     */
-  def hasIdentifier: Boolean = identifier.isDefined
+  lazy val hasIdentifier: Boolean = identifier.isDefined
 
   /** Check the tree_root_as extension for this class and return the corresponding InlineType. If
     * the extension is not present, return InlineType.optional as the default.
@@ -307,13 +310,15 @@ final case class SlotView(slot: SlotDefinition, definingSchema: SchemaDefinition
     *   true if the slot is inlined
     */
   def derivedInlined: Boolean =
-    slot.inlined || sv.resolve(
-      slot.range.getOrElse(definingSchema.defaultRangeResolved).asInstanceOf[Reference[
-        ElementView[?],
-      ]],
-    )
-      .collect({ case cls: ClassView => !cls.hasIdentifier })
-      .getOrElse(false)
+    slot.inlined || (sv.resolve(
+      (slot.range match {
+        case Some(range) => range
+        case _ => definingSchema.defaultRangeResolved
+      }).asInstanceOf[Reference[ElementView[?]]],
+    ) match {
+      case Some(cls: ClassView) => !cls.hasIdentifier
+      case _ => false
+    })
 
   /** Get the range of this slot, with missing values filled with `default_range` from the implicit
     * [[SchemaView]]. Does NOT take inheritance into account: Make sure you use this method after

--- a/schemaview/src/eu/neverblink/linkml/schemaview/SchemaView.scala
+++ b/schemaview/src/eu/neverblink/linkml/schemaview/SchemaView.scala
@@ -32,7 +32,6 @@ final case class SchemaView(schemas: Seq[SchemaDefinition]) extends ReferenceRes
       case _: TypeDefinition => types.get(ref.value).map(_._type)
       case _: ClassDefinition => classes.get(ref.value).map(_.cls)
       case _: EnumDefinition => enums.get(ref.value).map(_._enum)
-
       case _: SubsetDefinition => subsets.get(ref.value).map(_.subset)
       // `range` slot's `range` is underspecified as per the metamodel notes,
       // I think it should be ClassDef | TypeDef | EnumDef
@@ -72,6 +71,25 @@ final case class SchemaView(schemas: Seq[SchemaDefinition]) extends ReferenceRes
       schema.classes.foreach((k, v) => acc.addOne((k, ClassView(v, schema))))
       acc
     }.result()
+
+  /** All enums defined in the loaded schemas, as views.
+    */
+  lazy val enums: Map[String, EnumView] =
+    schemas.foldLeft(Map.newBuilder[String, EnumView]) { (acc, schema) =>
+      schema.enums.map((k, v) => acc.addOne((k, EnumView(v, schema))))
+      acc
+    }.result()
+
+  /** All subsets defined in the loaded schemas, as views.
+    */
+  lazy val subsets: Map[String, SubsetView] =
+    schemas.foldLeft(Map.newBuilder[String, SubsetView]) { (acc, schema) =>
+      schema.subsets.map((k, v) => acc.addOne((k, SubsetView(v, schema))))
+      acc
+    }.result()
+
+  lazy val elements: Map[String, ElementView[?]] =
+    subsets ++ slotDefinitions ++ enums ++ types ++ classes
 
   /** Get all classes reachable from a given class, following derived attributes and optionally
     * ancestors. The result is a map of class name to class view, including the starting class.
@@ -163,24 +181,9 @@ final case class SchemaView(schemas: Seq[SchemaDefinition]) extends ReferenceRes
       },
     ).toSet
 
-  /** All enums defined in the loaded schemas, as views.
-    */
-  lazy val enums: Map[String, EnumView] =
-    schemas.map(schema => schema.enums.map((k, v) => (k, EnumView(v, schema)))).reduce(_ ++ _)
-
-  /** All subsets defined in the loaded schemas, as views.
-    */
-  lazy val subsets: Map[String, SubsetView] =
-    schemas.map(schema => schema.subsets.map((k, v) => (k, SubsetView(v, schema)))).reduce(_ ++ _)
-
   /** Get a schema element by its ID
     */
-  def getElement(name: String): Option[ElementView[?]] =
-    classes.get(name)
-      .orElse(types.get(name))
-      .orElse(enums.get(name))
-      .orElse(slotDefinitions.get(name))
-      .orElse(subsets.get(name))
+  def getElement(name: String): Option[ElementView[?]] = elements.get(name)
 
   /** Get the class defined as `tree_root: true` from the schema, if any is present
     */
@@ -261,8 +264,7 @@ final case class SchemaView(schemas: Seq[SchemaDefinition]) extends ReferenceRes
     * @return
     *   Unit if the schema is valid, an exception with formatted problems otherwise
     */
-  def validate(maxProblems: Int = 5): Try[Unit] =
-    validator.validate(maxProblems)
+  def validate(maxProblems: Int = 5): Try[Unit] = validator.validate(maxProblems)
 
   /** Produce validation report with all detected problems
     *


### PR DESCRIPTION
Replaced remaining usage of ListMap by HashMap + reduced redundant allocations

Before:
```txt
Benchmark                                                             (schema)   Mode  Cnt           Score        Error   Units
GeneratorBench.jsonSchemaFromSchemaView                              dummy.yml  thrpt    5       41995.044 ±    144.659   ops/s
GeneratorBench.jsonSchemaFromSchemaView:gc.alloc.rate                dummy.yml  thrpt    5        1506.312 ±      5.134  MB/sec
GeneratorBench.jsonSchemaFromSchemaView:gc.alloc.rate.norm           dummy.yml  thrpt    5       37616.126 ±      0.003    B/op
GeneratorBench.jsonSchemaFromSchemaView:gc.count                     dummy.yml  thrpt    5           3.000               counts
GeneratorBench.jsonSchemaFromSchemaView:gc.time                      dummy.yml  thrpt    5           4.000                   ms
GeneratorBench.jsonSchemaFromSchemaView                         cgmes-core.yml  thrpt    5        1037.038 ±     31.497   ops/s
GeneratorBench.jsonSchemaFromSchemaView:gc.alloc.rate           cgmes-core.yml  thrpt    5        5195.054 ±    157.593  MB/sec
GeneratorBench.jsonSchemaFromSchemaView:gc.alloc.rate.norm      cgmes-core.yml  thrpt    5     5253508.490 ±    224.512    B/op
GeneratorBench.jsonSchemaFromSchemaView:gc.count                cgmes-core.yml  thrpt    5          11.000               counts
GeneratorBench.jsonSchemaFromSchemaView:gc.time                 cgmes-core.yml  thrpt    5          11.000                   ms
GeneratorBench.jsonSchemaFromSchemaView                     cgmes-dynamics.yml  thrpt    5         427.566 ±      1.165   ops/s
GeneratorBench.jsonSchemaFromSchemaView:gc.alloc.rate       cgmes-dynamics.yml  thrpt    5        4521.477 ±     12.113  MB/sec
GeneratorBench.jsonSchemaFromSchemaView:gc.alloc.rate.norm  cgmes-dynamics.yml  thrpt    5    11089996.440 ±      0.225    B/op
GeneratorBench.jsonSchemaFromSchemaView:gc.count            cgmes-dynamics.yml  thrpt    5          10.000               counts
GeneratorBench.jsonSchemaFromSchemaView:gc.time             cgmes-dynamics.yml  thrpt    5          11.000                   ms
GeneratorBench.jsonSchemaFromYaml                                    dummy.yml  thrpt    5        1226.386 ±     43.788   ops/s
GeneratorBench.jsonSchemaFromYaml:gc.alloc.rate                      dummy.yml  thrpt    5        6717.575 ±    239.066  MB/sec
GeneratorBench.jsonSchemaFromYaml:gc.alloc.rate.norm                 dummy.yml  thrpt    5     5744422.428 ±    500.228    B/op
GeneratorBench.jsonSchemaFromYaml:gc.count                           dummy.yml  thrpt    5          14.000               counts
GeneratorBench.jsonSchemaFromYaml:gc.time                            dummy.yml  thrpt    5          10.000                   ms
GeneratorBench.jsonSchemaFromYaml                               cgmes-core.yml  thrpt    5          40.142 ±      0.757   ops/s
GeneratorBench.jsonSchemaFromYaml:gc.alloc.rate                 cgmes-core.yml  thrpt    5        6753.172 ±    126.994  MB/sec
GeneratorBench.jsonSchemaFromYaml:gc.alloc.rate.norm            cgmes-core.yml  thrpt    5   176424620.244 ±  21238.700    B/op
GeneratorBench.jsonSchemaFromYaml:gc.count                      cgmes-core.yml  thrpt    5          15.000               counts
GeneratorBench.jsonSchemaFromYaml:gc.time                       cgmes-core.yml  thrpt    5          11.000                   ms
GeneratorBench.jsonSchemaFromYaml                           cgmes-dynamics.yml  thrpt    5          11.866 ±      0.126   ops/s
GeneratorBench.jsonSchemaFromYaml:gc.alloc.rate             cgmes-dynamics.yml  thrpt    5        7261.238 ±     76.856  MB/sec
GeneratorBench.jsonSchemaFromYaml:gc.alloc.rate.norm        cgmes-dynamics.yml  thrpt    5   641717334.533 ±   2676.893    B/op
GeneratorBench.jsonSchemaFromYaml:gc.count                  cgmes-dynamics.yml  thrpt    5          16.000               counts
GeneratorBench.jsonSchemaFromYaml:gc.time                   cgmes-dynamics.yml  thrpt    5          19.000                   ms
```

After:
```txt
Benchmark                                                             (schema)   Mode  Cnt           Score        Error   Units
GeneratorBench.jsonSchemaFromSchemaView                              dummy.yml  thrpt    5       44086.945 ±    420.606   ops/s
GeneratorBench.jsonSchemaFromSchemaView:gc.alloc.rate                dummy.yml  thrpt    5        1199.527 ±     11.819  MB/sec
GeneratorBench.jsonSchemaFromSchemaView:gc.alloc.rate.norm           dummy.yml  thrpt    5       28536.120 ±      0.004    B/op
GeneratorBench.jsonSchemaFromSchemaView:gc.count                     dummy.yml  thrpt    5           3.000               counts
GeneratorBench.jsonSchemaFromSchemaView:gc.time                      dummy.yml  thrpt    5           6.000                   ms
GeneratorBench.jsonSchemaFromSchemaView                         cgmes-core.yml  thrpt    5        1171.180 ±     10.313   ops/s
GeneratorBench.jsonSchemaFromSchemaView:gc.alloc.rate           cgmes-core.yml  thrpt    5        4864.466 ±     42.756  MB/sec
GeneratorBench.jsonSchemaFromSchemaView:gc.alloc.rate.norm      cgmes-core.yml  thrpt    5     4355742.317 ±     15.293    B/op
GeneratorBench.jsonSchemaFromSchemaView:gc.count                cgmes-core.yml  thrpt    5          11.000               counts
GeneratorBench.jsonSchemaFromSchemaView:gc.time                 cgmes-core.yml  thrpt    5          12.000                   ms
GeneratorBench.jsonSchemaFromSchemaView                     cgmes-dynamics.yml  thrpt    5         527.912 ±     30.375   ops/s
GeneratorBench.jsonSchemaFromSchemaView:gc.alloc.rate       cgmes-dynamics.yml  thrpt    5        4688.823 ±    269.673  MB/sec
GeneratorBench.jsonSchemaFromSchemaView:gc.alloc.rate.norm  cgmes-dynamics.yml  thrpt    5     9314330.075 ±      0.694    B/op
GeneratorBench.jsonSchemaFromSchemaView:gc.count            cgmes-dynamics.yml  thrpt    5          11.000               counts
GeneratorBench.jsonSchemaFromSchemaView:gc.time             cgmes-dynamics.yml  thrpt    5           9.000                   ms
GeneratorBench.jsonSchemaFromYaml                                    dummy.yml  thrpt    5        1241.656 ±     35.622   ops/s
GeneratorBench.jsonSchemaFromYaml:gc.alloc.rate                      dummy.yml  thrpt    5        6782.983 ±    193.926  MB/sec
GeneratorBench.jsonSchemaFromYaml:gc.alloc.rate.norm                 dummy.yml  thrpt    5     5728935.955 ±    416.830    B/op
GeneratorBench.jsonSchemaFromYaml:gc.count                           dummy.yml  thrpt    5          14.000               counts
GeneratorBench.jsonSchemaFromYaml:gc.time                            dummy.yml  thrpt    5           9.000                   ms
GeneratorBench.jsonSchemaFromYaml                               cgmes-core.yml  thrpt    5          41.143 ±      0.849   ops/s
GeneratorBench.jsonSchemaFromYaml:gc.alloc.rate                 cgmes-core.yml  thrpt    5        6892.101 ±    141.336  MB/sec
GeneratorBench.jsonSchemaFromYaml:gc.alloc.rate.norm            cgmes-core.yml  thrpt    5   175675808.956 ±  27691.275    B/op
GeneratorBench.jsonSchemaFromYaml:gc.count                      cgmes-core.yml  thrpt    5          15.000               counts
GeneratorBench.jsonSchemaFromYaml:gc.time                       cgmes-core.yml  thrpt    5          12.000                   ms
GeneratorBench.jsonSchemaFromYaml                           cgmes-dynamics.yml  thrpt    5          10.417 ±      0.178   ops/s
GeneratorBench.jsonSchemaFromYaml:gc.alloc.rate             cgmes-dynamics.yml  thrpt    5        7152.182 ±    121.906  MB/sec
GeneratorBench.jsonSchemaFromYaml:gc.alloc.rate.norm        cgmes-dynamics.yml  thrpt    5   719998020.218 ±   4470.036    B/op
GeneratorBench.jsonSchemaFromYaml:gc.count                  cgmes-dynamics.yml  thrpt    5          17.000               counts
GeneratorBench.jsonSchemaFromYaml:gc.time                   cgmes-dynamics.yml  thrpt    5          25.000                   ms
```