### PR TITLE
LNK-134: optimize SchemaView

### DIFF
--- a/benchmark/src/eu/neverblink/linkml/benchmark/SchemaViewBench.scala
+++ b/benchmark/src/eu/neverblink/linkml/benchmark/SchemaViewBench.scala
@@ -1,0 +1,41 @@
+package eu.neverblink.linkml.benchmark
+
+import eu.neverblink.linkml.metamodel.SchemaDefinition
+import eu.neverblink.linkml.schemaview.SchemaView
+import org.openjdk.jmh.annotations.{Benchmark, Param, Setup}
+import org.openjdk.jmh.infra.Blackhole
+
+import scala.compiletime.uninitialized
+import scala.io.Source
+import scala.util.Using
+
+/** Benchmarks for SchemaView operations. These are not very meaningful on their own. Use them only
+  * for development (perf regression testing).
+  */
+class SchemaViewBench extends CommonParams {
+
+  @Param(Array( /*"dummy.yml", "cgmes-core.yml",*/ "cgmes-dynamics.yml"))
+  var schema: String = uninitialized
+
+  private var schemas: Seq[SchemaDefinition] = uninitialized
+
+  @Setup
+  def setup(): Unit = {
+    val yaml = Using.resource(getClass.getResourceAsStream(s"/schemas/$schema")) { in =>
+      Source.fromInputStream(in, "UTF-8").mkString
+    }
+    schemas = SchemaView.loadSchemaViewFromString(yaml).schemas
+  }
+
+  /** Construction: includes checking for fatal problems in the sv. */
+  @Benchmark
+  def construct: SchemaView =
+    new SchemaView(schemas)
+
+  /** Slot derivation: iterate every class and derive whether it has an identifier slot. */
+  @Benchmark
+  def identifierDerivation(bh: Blackhole): Unit = {
+    val sv = new SchemaView(schemas)
+    sv.classes.values.foreach(cls => bh.consume(cls.hasIdentifier))
+  }
+}

--- a/benchmark/src/eu/neverblink/linkml/benchmark/SchemaViewBench.scala
+++ b/benchmark/src/eu/neverblink/linkml/benchmark/SchemaViewBench.scala
@@ -14,7 +14,7 @@ import scala.util.Using
   */
 class SchemaViewBench extends CommonParams {
 
-  @Param(Array( /*"dummy.yml", "cgmes-core.yml",*/ "cgmes-dynamics.yml"))
+  @Param(Array("dummy.yml", "cgmes-core.yml", "cgmes-dynamics.yml"))
   var schema: String = uninitialized
 
   private var schemas: Seq[SchemaDefinition] = uninitialized

--- a/schemaview/src/eu/neverblink/linkml/schemaview/ElementView.scala
+++ b/schemaview/src/eu/neverblink/linkml/schemaview/ElementView.scala
@@ -56,6 +56,10 @@ sealed trait ElementView[E <: Element](using val sv: SchemaView) {
       }
 }
 
+private object ClassView:
+  // Used to avoid as many allocations as possible when deriving slots.
+  val emptySlotDef: SlotDefinitionImpl = SlotDefinitionImpl(name = "!!! invalid, internal !!!")
+
 final case class ClassView(cls: ClassDefinition, definingSchema: SchemaDefinition)(using
     sv: SchemaView,
 ) extends ElementView[ClassDefinition] {
@@ -184,8 +188,9 @@ final case class ClassView(cls: ClassDefinition, definingSchema: SchemaDefinitio
       slotRef: Reference[SlotDefinition],
       source: ElementView[?],
   ): SlotView = {
-    var currentSlot = SlotDefinitionImpl(name = slotRef.value)
-    currentSlot = sv.applySlotUsage(currentSlot, cls)
+    // Use empty slot base here to avoid an extra allocation
+    var currentSlot = ClassView.emptySlotDef
+    currentSlot = sv.applySlotUsage(currentSlot, slotRef.value, cls)
     sv.resolve(slotRef.asInstanceOf[Reference[SlotView]]) match {
       // Note this is a bit off-spec, but it's a pretty reasonable
       case Some(resolved: SlotView) if !isSlotFromAttributes(slotRef) =>
@@ -199,20 +204,18 @@ final case class ClassView(cls: ClassDefinition, definingSchema: SchemaDefinitio
         }
       case _ =>
     }
-    if currentSlot.inlinedAsList && !currentSlot.inlined then {
-      currentSlot = currentSlot.copy(inlined = true)
-    }
-    if (currentSlot.identifier || currentSlot.key) && !currentSlot.required then {
-      currentSlot = currentSlot.copy(required = true)
-    }
     val finalSlot = currentSlot.copy(
+      name = slotRef.value,
       slotUri = Some(
         SlotView.uri(
-          currentSlot,
+          currentSlot.slotUri,
+          slotRef.value,
           // For prefix resolution use the context of the original slot definition
           source,
         ),
       ),
+      inlined = currentSlot.inlinedAsList || currentSlot.inlined,
+      required = currentSlot.identifier || currentSlot.key || currentSlot.required,
     )
     // Apply the original schema as the defining schema, so that default prefix / default range
     // resolution still works as defined in the original schema file.
@@ -337,13 +340,13 @@ final case class SlotView(slot: SlotDefinition, definingSchema: SchemaDefinition
   /** Get the URI of this slot, using the default prefix of the implicit [[SchemaView]] if not
     * explicitly defined.
     */
-  def uriOrCurie: UriOrCurie = SlotView.uri(slot, this)
+  def uriOrCurie: UriOrCurie = SlotView.uri(slot.slotUri, slot.name, this)
 }
 
 private object SlotView:
   // Exposed for slot derivation in ClassView.
-  def uri(slot: SlotDefinition, context: ElementView[?]): UriOrCurie =
-    slot.slotUri.getOrElse(Uri(context.defaultPrefixUri + Case.deSpaceCase(slot.name)))
+  def uri(slotUri: Option[UriOrCurie], slotName: String, context: ElementView[?]): UriOrCurie =
+    slotUri.getOrElse(Uri(context.defaultPrefixUri + Case.deSpaceCase(slotName)))
 
 final case class EnumView(_enum: EnumDefinition, definingSchema: SchemaDefinition)(using
     sv: SchemaView,

--- a/schemaview/src/eu/neverblink/linkml/schemaview/MacroValidator.scala
+++ b/schemaview/src/eu/neverblink/linkml/schemaview/MacroValidator.scala
@@ -20,28 +20,49 @@ import scala.quoted.*
   *   Ranges that are invalid in the schema
   * @param invalidDefaultRanges
   *   Ranges whose inferred defaults wouldn't resolve
+  * @param isEmpty
+  *   Set to true only if you are creating a ValidatorResult == ValidatorResult.ok
   */
-case class ValidatorResult(
-    unknownReferences: Seq[UnknownReference] = Seq.empty,
-    invalidRanges: Seq[InvalidRange] = Seq.empty,
-    invalidDefaultRanges: Seq[InvalidDefaultRange] = Seq.empty,
+final case class ValidatorResult private (
+    unknownReferences: Seq[UnknownReference],
+    invalidRanges: Seq[InvalidRange],
+    invalidDefaultRanges: Seq[InvalidDefaultRange],
+    isEmpty: Boolean,
 ):
   /** Merge the [[ValidatorResult]]s */
-  def +(other: ValidatorResult): ValidatorResult = ValidatorResult(
-    unknownReferences ++ other.unknownReferences,
-    invalidRanges ++ other.invalidRanges,
-    invalidDefaultRanges ++ other.invalidDefaultRanges,
-  )
+  def +(other: ValidatorResult): ValidatorResult =
+    if other.isEmpty then this
+    else
+      ValidatorResult(
+        unknownReferences ++ other.unknownReferences,
+        invalidRanges ++ other.invalidRanges,
+        invalidDefaultRanges ++ other.invalidDefaultRanges,
+      )
 
   /** Add a [[prefix]] to each result's source path */
-  def prependedPath(prefix: String): ValidatorResult = ValidatorResult(
-    unknownReferences.map(_.prependedPath(prefix)),
-    invalidRanges.map(_.prependedPath(prefix)),
-    invalidDefaultRanges.map(_.prependedPath(prefix)),
-  )
+  def prependedPath(prefix: String): ValidatorResult =
+    if isEmpty then this
+    else
+      ValidatorResult(
+        unknownReferences.map(_.prependedPath(prefix)),
+        invalidRanges.map(_.prependedPath(prefix)),
+        invalidDefaultRanges.map(_.prependedPath(prefix)),
+      )
 
 object ValidatorResult {
-  val ok: ValidatorResult = ValidatorResult(Seq.empty, Seq.empty, Seq.empty)
+  val ok: ValidatorResult = ValidatorResult(Seq.empty, Seq.empty, Seq.empty, isEmpty = true)
+
+  def apply(
+      unknownReferences: Seq[UnknownReference] = Seq(),
+      invalidRanges: Seq[InvalidRange] = Seq(),
+      invalidDefaultRanges: Seq[InvalidDefaultRange] = Seq(),
+  ): ValidatorResult =
+    new ValidatorResult(
+      unknownReferences,
+      invalidRanges,
+      invalidDefaultRanges,
+      isEmpty = false,
+    )
 }
 
 /** A reference that could not be resolved in the [[SchemaView]]
@@ -51,7 +72,7 @@ object ValidatorResult {
   * @param referenceValue
   *   Value of the invalid reference
   */
-case class UnknownReference(path: String, referenceValue: String):
+final case class UnknownReference(path: String, referenceValue: String):
   /** Add a [[prefix]] to this class' path */
   def prependedPath(prefix: String): UnknownReference =
     copy(path = prefix + path)
@@ -65,7 +86,7 @@ case class UnknownReference(path: String, referenceValue: String):
   * @param actualType
   *   The definition type that this reference actually points to
   */
-case class InvalidRange(path: String, value: String, actualType: String):
+final case class InvalidRange(path: String, value: String, actualType: String):
   /** Add a [[prefix]] to this class' path */
   def prependedPath(prefix: String): InvalidRange =
     copy(path = prefix + path)
@@ -75,7 +96,7 @@ case class InvalidRange(path: String, value: String, actualType: String):
   * @param path
   *   JSON path to the reference
   */
-case class InvalidDefaultRange(path: String):
+final case class InvalidDefaultRange(path: String):
   /** Add a [[prefix]] to this class' path */
   def prependedPath(prefix: String): InvalidDefaultRange =
     copy(path = prefix + path)
@@ -253,7 +274,11 @@ private class ReferenceValidatorImpl(using Quotes) extends MacroUtils {
                 if fieldInfo.mappedName != "range" then vc
                 else '{ $vc.asRange },
               )
-              '{ $kvs.addOne($encodeVal.prependedPath(s"${$name}/")) }
+              '{
+                // Skip ok results to save on array expansion and folding
+                if $encodeVal ne ValidatorResult.ok then
+                  $kvs.addOne($encodeVal.prependedPath(s"${$name}/"))
+              }
           }).asTerm
         },
         '{}.asTerm,

--- a/schemaview/src/eu/neverblink/linkml/schemaview/SchemaView.scala
+++ b/schemaview/src/eu/neverblink/linkml/schemaview/SchemaView.scala
@@ -219,14 +219,16 @@ final case class SchemaView(schemas: Seq[SchemaDefinition]) extends ReferenceRes
     */
   private[schemaview] def applySlotUsage(
       slot: SlotDefinitionImpl,
+      slotName: String,
       cls: ClassDefinition,
   ): SlotDefinitionImpl = {
     var currentSlot = slot
-    for s <- cls.slotUsage.values ++ cls.attributes.values do {
-      if currentSlot.name == s.name then currentSlot = currentSlot.combineWith(s, combineRange)
-    }
-    for c <- cls.mixins.flatMap(resolve) ++ cls.isA.flatMap(resolve) do
-      currentSlot = applySlotUsage(currentSlot, c)
+    def combine(s: SlotDefinitionImpl): Unit =
+      currentSlot = currentSlot.combineWith(s, combineRange)
+    cls.slotUsage.get(slotName).foreach(combine)
+    cls.attributes.get(slotName).foreach(combine)
+    for c <- cls.mixins.flatMap(resolve) do currentSlot = applySlotUsage(currentSlot, slotName, c)
+    for c <- cls.isA.flatMap(resolve) do currentSlot = applySlotUsage(currentSlot, slotName, c)
     currentSlot
   }
 


### PR DESCRIPTION
Done:

- Speed up macro validator by essentially skipping over "OK" results.
- Speed up slot derivation by reducing the number of times we allocate new instances of SchemaDefinitionImpl, and by unrolling some code in applySlotUsage to avoid list allocations, concatenations, and so on.

Currently the main bottleneck in class/slot derivation is the allocation of `SlotDefinitionImpl` objects, which are absolutely MASSIVE and bash the L1 cache very, very hard. The only ideas that I have to further improve this is to either implement some sort of a "sparse" slot definition object and/or use slot definition builders instead of copies (Scala collection builder style, with a mutable object being promoted to immutable without copies – we do sth like this in Jelly-JVM's protobuf).

But these would be pretty involved, I think this is good enough for now.

Before:

```
Benchmark                                       (schema)   Mode  Cnt      Score      Error  Units
SchemaViewBench.construct                      dummy.yml  thrpt    5  24932.329 ± 1269.149  ops/s
SchemaViewBench.construct                 cgmes-core.yml  thrpt    5    798.468 ±   45.983  ops/s
SchemaViewBench.construct             cgmes-dynamics.yml  thrpt    5    174.050 ±   15.442  ops/s
SchemaViewBench.identifierDerivation           dummy.yml  thrpt    5   4074.410 ±   39.486  ops/s
SchemaViewBench.identifierDerivation      cgmes-core.yml  thrpt    5    260.299 ±    4.758  ops/s
SchemaViewBench.identifierDerivation  cgmes-dynamics.yml  thrpt    5     81.416 ±    1.426  ops/s
```


After:

```
Benchmark                                       (schema)   Mode  Cnt      Score     Error  Units
SchemaViewBench.construct                      dummy.yml  thrpt    5  76259.826 ± 761.442  ops/s
SchemaViewBench.construct                 cgmes-core.yml  thrpt    5   3017.934 ±  39.944  ops/s
SchemaViewBench.construct             cgmes-dynamics.yml  thrpt    5    752.015 ±  15.405  ops/s
SchemaViewBench.identifierDerivation           dummy.yml  thrpt    5   4570.339 ± 153.129  ops/s
SchemaViewBench.identifierDerivation      cgmes-core.yml  thrpt    5    566.320 ±  15.924  ops/s
SchemaViewBench.identifierDerivation  cgmes-dynamics.yml  thrpt    5    216.596 ±   2.369  ops/s
```

