### PR TITLE
Adjust Graal AOT settings for faster CLI

### DIFF
--- a/build.mill
+++ b/build.mill
@@ -317,7 +317,7 @@ object cli extends Module {
     def nativeImageGraalVmJvmId = "graalvm-oracle:25"
 
     def nativeImageOptions = Seq(
-      "-O3", // Optimized for smaller binary size and faster startup
+      "-O3", // Optimized for throughput
       "--no-fallback",
       "--initialize-at-build-time",
       "-H:+UnlockExperimentalVMOptions",

--- a/build.mill
+++ b/build.mill
@@ -54,8 +54,8 @@ def lint(ev: Evaluator, args: String*) = Task.Command(exclusive = true) {
   AliasesModule.run(ev, "lint")
 }
 
-/** Bundle the TypeScript playground UI (app.ts + CodeMirror) into ui/dist via
-  * esbuild. Installs npm deps on first run. Requires Node.js and npm on the PATH.
+/** Bundle the TypeScript playground UI (app.ts + CodeMirror) into ui/dist via esbuild. Installs npm
+  * deps on first run. Requires Node.js and npm on the PATH.
   */
 def buildUiBundle(): Unit = {
   val uiDir = mill.api.BuildCtx.workspaceRoot / "ui"
@@ -68,15 +68,15 @@ def uiBundle(args: String*) = Task.Command(exclusive = true) {
   buildUiBundle()
 }
 
-/** Regenerate ui/linkml.d.ts (the LinkML API types the UI is checked against)
-  * from the Scala facade. Run after changing LinkMlJsApi.scala.
+/** Regenerate ui/linkml.d.ts (the LinkML API types the UI is checked against) from the Scala
+  * facade. Run after changing LinkMlJsApi.scala.
   */
 def uiTypes(args: String*) = Task.Command(exclusive = true) {
   os.copy.over(generator.js.tsDefs().path, mill.api.BuildCtx.workspaceRoot / "ui" / "linkml.d.ts")
 }
 
-/** Type-check the UI against the LinkML types and confirm it bundles. Requires
-  * Node.js and npm on the PATH.
+/** Type-check the UI against the LinkML types and confirm it bundles. Requires Node.js and npm on
+  * the PATH.
   */
 def uiCheck(args: String*) = Task.Command(exclusive = true) {
   val uiDir = mill.api.BuildCtx.workspaceRoot / "ui"
@@ -317,11 +317,12 @@ object cli extends Module {
     def nativeImageGraalVmJvmId = "graalvm-oracle:25"
 
     def nativeImageOptions = Seq(
-      "-Os", // Optimized for smaller binary size and faster startup
+      "-O3", // Optimized for smaller binary size and faster startup
       "--no-fallback",
       "--initialize-at-build-time",
       "-H:+UnlockExperimentalVMOptions",
       "-H:+RemoveSaturatedTypeFlows",
+      "-H:+MLCallCountProfileInference",
       "-H:IncludeLocales=en",
       "-H:-GenLoopSafepoints",
       "-H:-ParseRuntimeOptions",


### PR DESCRIPTION
Sooo, I tried a few things:

| Settings | Binary size (B) | Gen. JSON Schema | Show help |
|---|--:|--:|--:|
| (original) | 16714048 | `968.2 ms ±  25.9 ms` | `2.5 ms ±   0.2 ms` |
| +MLCallCount | 18483520 | `719.8 ms ±  26.0 ms` | `2.5 ms ±   0.2 ms` |
| -O3 | 29624640 | `205.9 ms ±   9.1 ms` | `2.6 ms ±   0.3 ms` |
| -O3, +MLCallCount | 24381760 | `240.2 ms ±  12.3 ms` | `2.6 ms ±   0.2 ms` |

The benchmarks were done with hyperfine, 25 iterations at minimum. The "show help" case was to judge any difference in startup time – I could not find anything meaningful.

I propose to merge in `-O3, +MLCallCount` (that's the same combination as used in jelly-cli), as it increases binary size by *only* 50%, while making the thing like 4x faster. I don't think sacrificing another 5MB for a small improvement in times (-O3 variant) is worth it.

I also tried using G1 GC, it was slower. I tried SkipFlow as well, but it doesn't seem to do anything in this Graal version.