### PR TITLE
LNK-134: Only do URI validation in SchemaValidator

### DIFF
--- a/runtime/src/eu/neverblink/linkml/runtime/UriOrCurie.scala
+++ b/runtime/src/eu/neverblink/linkml/runtime/UriOrCurie.scala
@@ -5,11 +5,13 @@ import scala.util.matching.Regex
 sealed trait UriOrCurie {
   def original: String
 
-  def +(s: String): UriOrCurie = UriOrCurie(original + s)
-
   def uri(implicit resolver: PrefixResolver): String
 
   def curie(implicit resolver: PrefixResolver): String
+
+  /** Validate the value of this UriOrCurie. Returns true if valid, false if invalid.
+    */
+  def isValid: Boolean
 }
 
 object UriOrCurie {
@@ -18,20 +20,20 @@ object UriOrCurie {
     else new Curie(s)
 }
 
-case class Uri(original: String) extends UriOrCurie {
-  require(UriCurieValidator.validateUri(original).isDefined, s"Illegal uri value: $original")
-
+final case class Uri(original: String) extends UriOrCurie {
   def uri(implicit resolver: PrefixResolver): String = original
 
   def curie(implicit resolver: PrefixResolver): String = resolver.compact(original)
+
+  def isValid: Boolean = UriCurieValidator.validateUri(original).isDefined
 }
 
-case class Curie(original: String) extends UriOrCurie {
-  require(UriCurieValidator.validateCurie(original).isDefined, s"Illegal curie value: $original")
-
+final case class Curie(original: String) extends UriOrCurie {
   def uri(implicit resolver: PrefixResolver): String = resolver.expand(original)
 
   def curie(implicit resolver: PrefixResolver): String = original
+
+  def isValid: Boolean = UriCurieValidator.validateCurie(original).isDefined
 }
 
 type NcName = String
@@ -57,7 +59,7 @@ trait PrefixResolver {
   def resolvePrefix(prefix: String): Option[String]
 }
 
-class BasicPrefixResolver(schemaId: String) extends PrefixResolver {
+final class BasicPrefixResolver(schemaId: String) extends PrefixResolver {
   private val prefixToUri = new java.util.HashMap[String, String]
   private val uriToPrefix = new java.util.HashMap[String, String]
 

--- a/runtime/test/src/eu/neverblink/linkml/runtime/UriOrCurieSpec.scala
+++ b/runtime/test/src/eu/neverblink/linkml/runtime/UriOrCurieSpec.scala
@@ -16,9 +16,32 @@ class UriOrCurieSpec extends AnyWordSpec, Matchers {
     "return valid Curie" in {
       UriOrCurie("skos:exactMatch") shouldBe Curie("skos:exactMatch")
     }
-    "throw exception for invalid input" in {
-      assert(intercept[Throwable](UriOrCurie("<>")).getMessage.contains("Illegal curie value"))
-      assert(intercept[Throwable](UriOrCurie("http://<>")).getMessage.contains("Illegal uri value"))
+    "dispatch to Uri or Curie based on the string shape" in {
+      UriOrCurie("http://example.org/thing") shouldBe a[Uri]
+      UriOrCurie("urn:isbn:0451450523") shouldBe a[Uri]
+      UriOrCurie("skos:exactMatch") shouldBe a[Curie]
+      UriOrCurie("just-a-local-name") shouldBe a[Curie]
+    }
+    "not validate on construction" in {
+      // Construction never inspects the value; only validate() does.
+      noException should be thrownBy UriOrCurie("<>")
+      noException should be thrownBy UriOrCurie("http://<>")
+    }
+  }
+  "Uri.isValid" should {
+    "be true for a valid value" in {
+      Uri("http://example.org/thing").isValid shouldBe true
+    }
+    "be false for an invalid value" in {
+      Uri("http://<>").isValid shouldBe false
+    }
+  }
+  "Curie.isValid" should {
+    "be true for a valid value" in {
+      Curie("skos:exactMatch").isValid shouldBe true
+    }
+    "be false for an invalid value" in {
+      Curie("<>").isValid shouldBe false
     }
   }
   "BasicPrefixResolver" should {

--- a/schemaview/src/eu/neverblink/linkml/schemaview/ElementView.scala
+++ b/schemaview/src/eu/neverblink/linkml/schemaview/ElementView.scala
@@ -19,6 +19,10 @@ import scala.collection.mutable
   */
 sealed trait ElementView[E <: Element](using val sv: SchemaView) {
 
+  /** Element type name, e.g. "class", "slot", "type", "enum", "subset", used for error messages.
+    */
+  def elementType: String
+
   /** Schema definition that defined this Element. This schema should be used for prefixes and
     * default ranges.
     */
@@ -63,6 +67,8 @@ private object ClassView:
 final case class ClassView(cls: ClassDefinition, definingSchema: SchemaDefinition)(using
     sv: SchemaView,
 ) extends ElementView[ClassDefinition] {
+  def elementType: String = "class"
+
   def inner: ClassDefinition = cls
 
   def uriOrCurie: UriOrCurie =
@@ -278,6 +284,8 @@ final case class ClassView(cls: ClassDefinition, definingSchema: SchemaDefinitio
 final case class SlotView(slot: SlotDefinition, definingSchema: SchemaDefinition)(using
     sv: SchemaView,
 ) extends ElementView[SlotDefinition] {
+  def elementType: String = "slot"
+
   def inner: SlotDefinition = slot
 
   /** Resolved URI string for the implicit_prefix metaslot for this slot, if defined
@@ -351,6 +359,8 @@ private object SlotView:
 final case class EnumView(_enum: EnumDefinition, definingSchema: SchemaDefinition)(using
     sv: SchemaView,
 ) extends ElementView[EnumDefinition] {
+  def elementType: String = "enum"
+
   def inner: EnumDefinition = _enum
 
   def uriOrCurie: UriOrCurie =
@@ -370,6 +380,8 @@ final case class EnumView(_enum: EnumDefinition, definingSchema: SchemaDefinitio
 final case class TypeView(_type: TypeDefinition, definingSchema: SchemaDefinition)(using
     sv: SchemaView,
 ) extends ElementView[TypeDefinition] {
+  def elementType: String = "type"
+
   def inner: TypeDefinition = _type
 
   /** Return the RDF subject type that corresponds to this type. This is used to create subjects in
@@ -450,6 +462,8 @@ final case class TypeView(_type: TypeDefinition, definingSchema: SchemaDefinitio
 final case class SubsetView(subset: SubsetDefinition, definingSchema: SchemaDefinition)(using
     sv: SchemaView,
 ) extends ElementView[SubsetDefinition] {
+  def elementType: String = "subset"
+
   def inner: SubsetDefinition = subset
 
   def uriOrCurie: UriOrCurie =

--- a/schemaview/src/eu/neverblink/linkml/schemaview/SchemaProblem.scala
+++ b/schemaview/src/eu/neverblink/linkml/schemaview/SchemaProblem.scala
@@ -1,6 +1,6 @@
 package eu.neverblink.linkml.schemaview
 
-import eu.neverblink.linkml.metamodel.{ClassDefinition, SlotDefinition}
+import eu.neverblink.linkml.metamodel.{ClassDefinition, Element, SlotDefinition}
 import eu.neverblink.linkml.runtime.NcName
 
 import scala.util.Failure
@@ -160,4 +160,13 @@ object SchemaProblem {
   final case class UndefinedPrefix(prefix: NcName, position: String) extends Error:
     lazy val description: String = s"Undefined prefix $prefix at $position"
     lazy val verbose: String = description
+
+  final case class InvalidUriOrCurie(inElement: ElementView[? <: Element]) extends Error:
+    lazy val description: String =
+      s"Invalid URI or CURIE '${inElement.uriOrCurie.original}' in ${inElement.elementType} " +
+        s"'${inElement.inner.name}' imported from schema '${inElement.definingSchema.id}'."
+    lazy val verbose: String =
+      s"$description. " +
+        "A valid URI must be a valid IRI, and a valid CURIE must be of the form 'prefix:localname' " +
+        "where 'prefix' is defined in the schema and 'localname' is a valid NCName."
 }

--- a/schemaview/src/eu/neverblink/linkml/schemaview/SchemaValidator.scala
+++ b/schemaview/src/eu/neverblink/linkml/schemaview/SchemaValidator.scala
@@ -289,6 +289,13 @@ final class SchemaValidator(using sv: SchemaView) {
       )
   }
 
+  private lazy val invalidUris: Seq[SchemaProblem.Error] = {
+    sv.elements.values.flatMap { elem =>
+      if elem.uriOrCurie.isValid then None
+      else Some(SchemaProblem.InvalidUriOrCurie(elem))
+    }.toSeq
+  }
+
   /** Any fatal problems that block further processing / validation, if any. */
   lazy val fatalProblems: Seq[SchemaProblem.Fatal] =
     unknownReferences ++
@@ -300,7 +307,8 @@ final class SchemaValidator(using sv: SchemaView) {
     identifierAndKey ++
       multipleTreeRoots ++
       nonUniqueNames ++
-      unknownPrefixes
+      unknownPrefixes ++
+      invalidUris
 
   /** Any warnings found in the schema, if any. */
   private lazy val warnings: Seq[SchemaProblem.Warning] =

--- a/schemaview/src/eu/neverblink/linkml/schemaview/SchemaView.scala
+++ b/schemaview/src/eu/neverblink/linkml/schemaview/SchemaView.scala
@@ -88,7 +88,7 @@ final case class SchemaView(schemas: Seq[SchemaDefinition]) extends ReferenceRes
       acc
     }.result()
 
-  lazy val elements: Map[String, ElementView[?]] =
+  lazy val elements: Map[String, ElementView[? <: Element]] =
     subsets ++ slotDefinitions ++ enums ++ types ++ classes
 
   /** Cached prefix resolvers for each schema in the view.

--- a/schemaview/test/src/eu/neverblink/linkml/schemaview/SchemaValidatorSpec.scala
+++ b/schemaview/test/src/eu/neverblink/linkml/schemaview/SchemaValidatorSpec.scala
@@ -466,6 +466,72 @@ class SchemaValidatorSpec extends AnyWordSpec, Matchers {
       }
     }
 
+    "fail on invalid URIs or CURIEs, covering every element type" in {
+      val schemaYaml =
+        s"""$schemaShared
+           |types:
+           |  string:
+           |    uri: "http://<>"
+           |classes:
+           |  SomeClass:
+           |    class_uri: "not a curie!"
+           |    slots:
+           |    - some_slot
+           |slots:
+           |  some_slot:
+           |    slot_uri: "http://<>"
+           |    range: string
+           |enums:
+           |  SomeEnum:
+           |    enum_uri: "http://<>"
+           |    permissible_values:
+           |      v1:
+           |subsets:
+           |  "Bad<Subset>":
+           |""".stripMargin
+      val sv = load(schemaYaml)
+
+      val msg = SchemaValidator(using sv).validate(maxProblems = 20).failed.get.getMessage
+
+      Seq(
+        "Invalid URI or CURIE 'not a curie!' in class 'SomeClass'",
+        "Invalid URI or CURIE 'http://<>' in slot 'some_slot'",
+        "Invalid URI or CURIE 'http://<>' in enum 'SomeEnum'",
+        "Invalid URI or CURIE 'http://<>' in type 'string'",
+        "Invalid URI or CURIE 'https://neverblink.eu/linkml/referenceValidator/test/Bad<Subset>' " +
+          "in subset 'Bad<Subset>'",
+      ) foreach { part =>
+        msg should include(part)
+      }
+    }
+
+    "accept valid URIs and CURIEs for every element type" in {
+      val schemaYaml =
+        s"""$schemaShared
+           |types:
+           |  string:
+           |    uri: xsd:string
+           |classes:
+           |  SomeClass:
+           |    class_uri: "https://neverblink.eu/example/SomeClass"
+           |    slots:
+           |    - some_slot
+           |slots:
+           |  some_slot:
+           |    slot_uri: ex:someSlot
+           |    range: string
+           |enums:
+           |  SomeEnum:
+           |    permissible_values:
+           |      v1:
+           |subsets:
+           |  SomeSubset:
+           |""".stripMargin
+      val sv = load(schemaYaml)
+
+      SchemaValidator(using sv).validate() shouldBe a[Success[?]]
+    }
+
     "validate the metamodel" in {
       val sv = SchemaView.loadSchemaViewFromUri("https://w3id.org/linkml/meta")
       SchemaValidator(using sv).validate() shouldBe a[Success[?]]


### PR DESCRIPTION
Before:

```
Benchmark                                     (schema)   Mode  Cnt      Score     Error  Units
GeneratorBench.shaclFromSchemaView           dummy.yml  thrpt    5  12106.459 ± 439.248  ops/s
GeneratorBench.shaclFromSchemaView      cgmes-core.yml  thrpt    5    239.887 ±   6.851  ops/s
GeneratorBench.shaclFromSchemaView  cgmes-dynamics.yml  thrpt    5    182.979 ±   1.572  ops/s
GeneratorBench.shaclFromSchemas              dummy.yml  thrpt    5   3584.549 ± 180.346  ops/s
GeneratorBench.shaclFromSchemas         cgmes-core.yml  thrpt    5    167.340 ±   3.473  ops/s
GeneratorBench.shaclFromSchemas     cgmes-dynamics.yml  thrpt    5     96.596 ±   2.228  ops/s
GeneratorBench.shaclFromYaml                 dummy.yml  thrpt    5    903.208 ±  52.337  ops/s
GeneratorBench.shaclFromYaml            cgmes-core.yml  thrpt    5     33.653 ±   3.374  ops/s
GeneratorBench.shaclFromYaml        cgmes-dynamics.yml  thrpt    5      9.833 ±   1.038  ops/s
```

After:

```
Benchmark                                     (schema)   Mode  Cnt      Score     Error  Units
GeneratorBench.shaclFromSchemaView           dummy.yml  thrpt    5  38852.537 ± 428.404  ops/s
GeneratorBench.shaclFromSchemaView      cgmes-core.yml  thrpt    5    240.910 ±   4.353  ops/s
GeneratorBench.shaclFromSchemaView  cgmes-dynamics.yml  thrpt    5    183.552 ±   4.927  ops/s
GeneratorBench.shaclFromSchemas              dummy.yml  thrpt    5  13600.036 ± 292.209  ops/s
GeneratorBench.shaclFromSchemas         cgmes-core.yml  thrpt    5    165.680 ±   3.170  ops/s
GeneratorBench.shaclFromSchemas     cgmes-dynamics.yml  thrpt    5     98.358 ±   1.653  ops/s
GeneratorBench.shaclFromYaml                 dummy.yml  thrpt    5   1237.284 ±  55.811  ops/s
GeneratorBench.shaclFromYaml            cgmes-core.yml  thrpt    5     38.685 ±   2.309  ops/s
GeneratorBench.shaclFromYaml        cgmes-dynamics.yml  thrpt    5     10.635 ±   0.262  ops/s
```