### PR TITLE
LNK-135 More efficient LinkML parsing

### DIFF
--- a/build.mill
+++ b/build.mill
@@ -134,7 +134,7 @@ object yaml extends Module {
 
   trait YamlModule extends CommonModule {
     def mvnDeps = Seq(
-      mvn"org.virtuslab::scala-yaml::0.3.2",
+      mvn"com.github.plokhotnyuk.scala-yaml::scala-yaml::0.3.3",
     )
   }
 }


### PR DESCRIPTION
Switching to the performance fork of scala-yaml

Before:
```txt
Benchmark                                                             (schema)   Mode  Cnt          Score      Error   Units
GeneratorBench.jsonSchemaFromYaml                                    dummy.yml  thrpt    5       1125.890 ±   36.628   ops/s
GeneratorBench.jsonSchemaFromYaml:gc.alloc.rate                      dummy.yml  thrpt    5       5717.571 ±  185.037  MB/sec
GeneratorBench.jsonSchemaFromYaml:gc.alloc.rate.norm                 dummy.yml  thrpt    5    5325838.879 ±  681.822    B/op
GeneratorBench.jsonSchemaFromYaml:gc.count                           dummy.yml  thrpt    5         13.000             counts
GeneratorBench.jsonSchemaFromYaml:gc.time                            dummy.yml  thrpt    5         13.000                 ms
GeneratorBench.jsonSchemaFromYaml                               cgmes-core.yml  thrpt    5         32.180 ±    0.288   ops/s
GeneratorBench.jsonSchemaFromYaml:gc.alloc.rate                 cgmes-core.yml  thrpt    5       4945.358 ±   43.960  MB/sec
GeneratorBench.jsonSchemaFromYaml:gc.alloc.rate.norm            cgmes-core.yml  thrpt    5  161167831.030 ± 8806.823    B/op
GeneratorBench.jsonSchemaFromYaml:gc.count                      cgmes-core.yml  thrpt    5         11.000             counts
GeneratorBench.jsonSchemaFromYaml:gc.time                       cgmes-core.yml  thrpt    5         12.000                 ms
GeneratorBench.jsonSchemaFromYaml                           cgmes-dynamics.yml  thrpt    5          7.888 ±    0.119   ops/s
GeneratorBench.jsonSchemaFromYaml:gc.alloc.rate             cgmes-dynamics.yml  thrpt    5       5032.267 ±   75.561  MB/sec
GeneratorBench.jsonSchemaFromYaml:gc.alloc.rate.norm        cgmes-dynamics.yml  thrpt    5  669106275.000 ± 3200.761    B/op
GeneratorBench.jsonSchemaFromYaml:gc.count                  cgmes-dynamics.yml  thrpt    5         11.000             counts
GeneratorBench.jsonSchemaFromYaml:gc.time                   cgmes-dynamics.yml  thrpt    5         29.000                 ms
GeneratorBench.shaclFromYaml                                         dummy.yml  thrpt    5       1095.535 ±   36.539   ops/s
GeneratorBench.shaclFromYaml:gc.alloc.rate                           dummy.yml  thrpt    5       5573.990 ±  185.121  MB/sec
GeneratorBench.shaclFromYaml:gc.alloc.rate.norm                      dummy.yml  thrpt    5    5335942.276 ±  727.082    B/op
GeneratorBench.shaclFromYaml:gc.count                                dummy.yml  thrpt    5         12.000             counts
GeneratorBench.shaclFromYaml:gc.time                                 dummy.yml  thrpt    5         13.000                 ms
GeneratorBench.shaclFromYaml                                    cgmes-core.yml  thrpt    5         29.002 ±    0.256   ops/s
GeneratorBench.shaclFromYaml:gc.alloc.rate                      cgmes-core.yml  thrpt    5       4435.408 ±   39.255  MB/sec
GeneratorBench.shaclFromYaml:gc.alloc.rate.norm                 cgmes-core.yml  thrpt    5  160389846.047 ± 5539.018    B/op
GeneratorBench.shaclFromYaml:gc.count                           cgmes-core.yml  thrpt    5          9.000             counts
GeneratorBench.shaclFromYaml:gc.time                            cgmes-core.yml  thrpt    5         10.000                 ms
GeneratorBench.shaclFromYaml                                cgmes-dynamics.yml  thrpt    5          8.972 ±    0.160   ops/s
GeneratorBench.shaclFromYaml:gc.alloc.rate                  cgmes-dynamics.yml  thrpt    5       4990.491 ±   88.926  MB/sec
GeneratorBench.shaclFromYaml:gc.alloc.rate.norm             cgmes-dynamics.yml  thrpt    5  583329928.320 ±  339.537    B/op
GeneratorBench.shaclFromYaml:gc.count                       cgmes-dynamics.yml  thrpt    5         12.000             counts
GeneratorBench.shaclFromYaml:gc.time                        cgmes-dynamics.yml  thrpt    5         30.000                 ms
```

After:
```txt
Benchmark                                                             (schema)   Mode  Cnt          Score      Error   Units
GeneratorBench.jsonSchemaFromYaml                                    dummy.yml  thrpt    5       2973.023 ±   17.185   ops/s
GeneratorBench.jsonSchemaFromYaml:gc.alloc.rate                      dummy.yml  thrpt    5       2896.314 ±   16.571  MB/sec
GeneratorBench.jsonSchemaFromYaml:gc.alloc.rate.norm                 dummy.yml  thrpt    5    1021689.789 ±    0.042    B/op
GeneratorBench.jsonSchemaFromYaml:gc.count                           dummy.yml  thrpt    5          6.000             counts
GeneratorBench.jsonSchemaFromYaml:gc.time                            dummy.yml  thrpt    5         16.000                 ms
GeneratorBench.jsonSchemaFromYaml                               cgmes-core.yml  thrpt    5         89.277 ±    0.901   ops/s
GeneratorBench.jsonSchemaFromYaml:gc.alloc.rate                 cgmes-core.yml  thrpt    5       2462.105 ±   24.956  MB/sec
GeneratorBench.jsonSchemaFromYaml:gc.alloc.rate.norm            cgmes-core.yml  thrpt    5   28922282.027 ±  531.603    B/op
GeneratorBench.jsonSchemaFromYaml:gc.count                      cgmes-core.yml  thrpt    5          6.000             counts
GeneratorBench.jsonSchemaFromYaml:gc.time                       cgmes-core.yml  thrpt    5         16.000                 ms
GeneratorBench.jsonSchemaFromYaml                           cgmes-dynamics.yml  thrpt    5         23.001 ±    0.334   ops/s
GeneratorBench.jsonSchemaFromYaml:gc.alloc.rate             cgmes-dynamics.yml  thrpt    5       2331.625 ±   33.772  MB/sec
GeneratorBench.jsonSchemaFromYaml:gc.alloc.rate.norm        cgmes-dynamics.yml  thrpt    5  106311406.501 ± 5281.935    B/op
GeneratorBench.jsonSchemaFromYaml:gc.count                  cgmes-dynamics.yml  thrpt    5          6.000             counts
GeneratorBench.jsonSchemaFromYaml:gc.time                   cgmes-dynamics.yml  thrpt    5         13.000                 ms
GeneratorBench.shaclFromYaml                                         dummy.yml  thrpt    5       2774.129 ±   11.665   ops/s
GeneratorBench.shaclFromYaml:gc.alloc.rate                           dummy.yml  thrpt    5       2731.886 ±   11.467  MB/sec
GeneratorBench.shaclFromYaml:gc.alloc.rate.norm                      dummy.yml  thrpt    5    1032778.049 ±    0.192    B/op
GeneratorBench.shaclFromYaml:gc.count                                dummy.yml  thrpt    5          6.000             counts
GeneratorBench.shaclFromYaml:gc.time                                 dummy.yml  thrpt    5         15.000                 ms
GeneratorBench.shaclFromYaml                                    cgmes-core.yml  thrpt    5         67.892 ±    2.130   ops/s
GeneratorBench.shaclFromYaml:gc.alloc.rate                      cgmes-core.yml  thrpt    5       1836.703 ±   57.378  MB/sec
GeneratorBench.shaclFromYaml:gc.alloc.rate.norm                 cgmes-core.yml  thrpt    5   28372062.179 ± 5023.764    B/op
GeneratorBench.shaclFromYaml:gc.count                           cgmes-core.yml  thrpt    5          4.000             counts
GeneratorBench.shaclFromYaml:gc.time                            cgmes-core.yml  thrpt    5         10.000                 ms
GeneratorBench.shaclFromYaml                                cgmes-dynamics.yml  thrpt    5         21.445 ±    0.192   ops/s
GeneratorBench.shaclFromYaml:gc.alloc.rate                  cgmes-dynamics.yml  thrpt    5       2051.329 ±   18.277  MB/sec
GeneratorBench.shaclFromYaml:gc.alloc.rate.norm             cgmes-dynamics.yml  thrpt    5  100320251.636 ± 5631.967    B/op
GeneratorBench.shaclFromYaml:gc.count                       cgmes-dynamics.yml  thrpt    5          4.000             counts
GeneratorBench.shaclFromYaml:gc.time                        cgmes-dynamics.yml  thrpt    5          9.000                 ms

```