### PR TITLE
LNK-135 Update scala-yaml (perf fork) to 0.3.5

### DIFF
--- a/build.mill
+++ b/build.mill
@@ -134,7 +134,7 @@ object yaml extends Module {
 
   trait YamlModule extends CommonModule {
     def mvnDeps = Seq(
-      mvn"com.github.plokhotnyuk.scala-yaml::scala-yaml::0.3.4",
+      mvn"com.github.plokhotnyuk.scala-yaml::scala-yaml::0.3.5",
     )
   }
 }


### PR DESCRIPTION
Before:
```txt
Benchmark                                                       (schema)   Mode  Cnt          Score      Error   Units
GeneratorBench.jsonSchemaFromYaml                              dummy.yml  thrpt    5       4410.438 ±   43.131   ops/s
GeneratorBench.jsonSchemaFromYaml:gc.alloc.rate                dummy.yml  thrpt    5       4322.144 ±   41.912  MB/sec
GeneratorBench.jsonSchemaFromYaml:gc.alloc.rate.norm           dummy.yml  thrpt    5    1027737.210 ±    0.010    B/op
GeneratorBench.jsonSchemaFromYaml:gc.count                     dummy.yml  thrpt    5          9.000             counts
GeneratorBench.jsonSchemaFromYaml:gc.time                      dummy.yml  thrpt    5         16.000                 ms
GeneratorBench.jsonSchemaFromYaml                         cgmes-core.yml  thrpt    5        133.087 ±    1.084   ops/s
GeneratorBench.jsonSchemaFromYaml:gc.alloc.rate           cgmes-core.yml  thrpt    5       3665.994 ±   29.908  MB/sec
GeneratorBench.jsonSchemaFromYaml:gc.alloc.rate.norm      cgmes-core.yml  thrpt    5   28887432.562 ±    1.747    B/op
GeneratorBench.jsonSchemaFromYaml:gc.count                cgmes-core.yml  thrpt    5          8.000             counts
GeneratorBench.jsonSchemaFromYaml:gc.time                 cgmes-core.yml  thrpt    5         17.000                 ms
GeneratorBench.jsonSchemaFromYaml                     cgmes-dynamics.yml  thrpt    5         32.462 ±    2.045   ops/s
GeneratorBench.jsonSchemaFromYaml:gc.alloc.rate       cgmes-dynamics.yml  thrpt    5       3141.749 ±  197.542  MB/sec
GeneratorBench.jsonSchemaFromYaml:gc.alloc.rate.norm  cgmes-dynamics.yml  thrpt    5  101497086.909 ± 8063.063    B/op
GeneratorBench.jsonSchemaFromYaml:gc.count            cgmes-dynamics.yml  thrpt    5          7.000             counts
GeneratorBench.jsonSchemaFromYaml:gc.time             cgmes-dynamics.yml  thrpt    5         49.000                 ms
GeneratorBench.shaclFromYaml                                   dummy.yml  thrpt    5       4218.064 ±   12.397   ops/s
GeneratorBench.shaclFromYaml:gc.alloc.rate                     dummy.yml  thrpt    5       4154.041 ±   12.007  MB/sec
GeneratorBench.shaclFromYaml:gc.alloc.rate.norm                dummy.yml  thrpt    5    1032793.390 ±    0.120    B/op
GeneratorBench.shaclFromYaml:gc.count                          dummy.yml  thrpt    5          9.000             counts
GeneratorBench.shaclFromYaml:gc.time                           dummy.yml  thrpt    5         17.000                 ms
GeneratorBench.shaclFromYaml                              cgmes-core.yml  thrpt    5        100.773 ±    0.900   ops/s
GeneratorBench.shaclFromYaml:gc.alloc.rate                cgmes-core.yml  thrpt    5       2732.315 ±   24.291  MB/sec
GeneratorBench.shaclFromYaml:gc.alloc.rate.norm           cgmes-core.yml  thrpt    5   28434524.908 ±   16.033    B/op
GeneratorBench.shaclFromYaml:gc.count                     cgmes-core.yml  thrpt    5          6.000             counts
GeneratorBench.shaclFromYaml:gc.time                      cgmes-core.yml  thrpt    5         11.000                 ms
GeneratorBench.shaclFromYaml                          cgmes-dynamics.yml  thrpt    5         30.726 ±    0.230   ops/s
GeneratorBench.shaclFromYaml:gc.alloc.rate            cgmes-dynamics.yml  thrpt    5       2797.009 ±   20.786  MB/sec
GeneratorBench.shaclFromYaml:gc.alloc.rate.norm       cgmes-dynamics.yml  thrpt    5   95467884.439 ± 5487.600    B/op
GeneratorBench.shaclFromYaml:gc.count                 cgmes-dynamics.yml  thrpt    5          7.000             counts
GeneratorBench.shaclFromYaml:gc.time                  cgmes-dynamics.yml  thrpt    5         38.000                 ms
```

After:
```txt
Benchmark                                                       (schema)   Mode  Cnt          Score      Error   Units
GeneratorBench.jsonSchemaFromYaml                              dummy.yml  thrpt    5       4710.432 ±   60.323   ops/s
GeneratorBench.jsonSchemaFromYaml:gc.alloc.rate                dummy.yml  thrpt    5       4380.585 ±   55.722  MB/sec
GeneratorBench.jsonSchemaFromYaml:gc.alloc.rate.norm           dummy.yml  thrpt    5     975281.134 ±    0.014    B/op
GeneratorBench.jsonSchemaFromYaml:gc.count                     dummy.yml  thrpt    5         10.000             counts
GeneratorBench.jsonSchemaFromYaml:gc.time                      dummy.yml  thrpt    5         17.000                 ms
GeneratorBench.jsonSchemaFromYaml                         cgmes-core.yml  thrpt    5        139.123 ±    1.250   ops/s
GeneratorBench.jsonSchemaFromYaml:gc.alloc.rate           cgmes-core.yml  thrpt    5       3645.662 ±   32.715  MB/sec
GeneratorBench.jsonSchemaFromYaml:gc.alloc.rate.norm      cgmes-core.yml  thrpt    5   27480947.528 ±   97.429    B/op
GeneratorBench.jsonSchemaFromYaml:gc.count                cgmes-core.yml  thrpt    5          8.000             counts
GeneratorBench.jsonSchemaFromYaml:gc.time                 cgmes-core.yml  thrpt    5         15.000                 ms
GeneratorBench.jsonSchemaFromYaml                     cgmes-dynamics.yml  thrpt    5         33.214 ±    0.786   ops/s
GeneratorBench.jsonSchemaFromYaml:gc.alloc.rate       cgmes-dynamics.yml  thrpt    5       3368.172 ±   79.517  MB/sec
GeneratorBench.jsonSchemaFromYaml:gc.alloc.rate.norm  cgmes-dynamics.yml  thrpt    5  106348113.228 ± 7180.066    B/op
GeneratorBench.jsonSchemaFromYaml:gc.count            cgmes-dynamics.yml  thrpt    5          7.000             counts
GeneratorBench.jsonSchemaFromYaml:gc.time             cgmes-dynamics.yml  thrpt    5         11.000                 ms
GeneratorBench.shaclFromYaml                                   dummy.yml  thrpt    5       4306.610 ±   36.955   ops/s
GeneratorBench.shaclFromYaml:gc.alloc.rate                     dummy.yml  thrpt    5       4042.783 ±   34.793  MB/sec
GeneratorBench.shaclFromYaml:gc.alloc.rate.norm                dummy.yml  thrpt    5     984457.360 ±    0.125    B/op
GeneratorBench.shaclFromYaml:gc.count                          dummy.yml  thrpt    5          9.000             counts
GeneratorBench.shaclFromYaml:gc.time                           dummy.yml  thrpt    5         20.000                 ms
GeneratorBench.shaclFromYaml                              cgmes-core.yml  thrpt    5        103.865 ±    0.390   ops/s
GeneratorBench.shaclFromYaml:gc.alloc.rate                cgmes-core.yml  thrpt    5       2634.618 ±    9.725  MB/sec
GeneratorBench.shaclFromYaml:gc.alloc.rate.norm           cgmes-core.yml  thrpt    5   26601643.048 ±    9.690    B/op
GeneratorBench.shaclFromYaml:gc.count                     cgmes-core.yml  thrpt    5          6.000             counts
GeneratorBench.shaclFromYaml:gc.time                      cgmes-core.yml  thrpt    5         14.000                 ms
GeneratorBench.shaclFromYaml                          cgmes-dynamics.yml  thrpt    5         31.316 ±    0.782   ops/s
GeneratorBench.shaclFromYaml:gc.alloc.rate            cgmes-dynamics.yml  thrpt    5       2997.102 ±   75.002  MB/sec
GeneratorBench.shaclFromYaml:gc.alloc.rate.norm       cgmes-dynamics.yml  thrpt    5  100366588.800 ± 4446.553    B/op
GeneratorBench.shaclFromYaml:gc.count                 cgmes-dynamics.yml  thrpt    5          6.000             counts
GeneratorBench.shaclFromYaml:gc.time                  cgmes-dynamics.yml  thrpt    5         21.000                 ms
```