### PR TITLE
LNK-135 Update scala-yaml (perf fork) to 0.3.6

### DIFF
--- a/build.mill
+++ b/build.mill
@@ -134,7 +134,7 @@ object yaml extends Module {
 
   trait YamlModule extends CommonModule {
     def mvnDeps = Seq(
-      mvn"com.github.plokhotnyuk.scala-yaml::scala-yaml::0.3.5",
+      mvn"com.github.plokhotnyuk.scala-yaml::scala-yaml::0.3.6",
     )
   }
 }


### PR DESCRIPTION
Still improving scala-yaml parser...

Before:
```txt
Benchmark                                                       (schema)   Mode  Cnt          Score       Error   Units
GeneratorBench.jsonSchemaFromYaml                              dummy.yml  thrpt    5       4598.242 ±    44.417   ops/s
GeneratorBench.jsonSchemaFromYaml:gc.alloc.rate                dummy.yml  thrpt    5       4262.190 ±    40.961  MB/sec
GeneratorBench.jsonSchemaFromYaml:gc.alloc.rate.norm           dummy.yml  thrpt    5     972081.159 ±     0.015    B/op
GeneratorBench.jsonSchemaFromYaml:gc.count                     dummy.yml  thrpt    5          9.000              counts
GeneratorBench.jsonSchemaFromYaml:gc.time                      dummy.yml  thrpt    5         17.000                  ms
GeneratorBench.jsonSchemaFromYaml                         cgmes-core.yml  thrpt    5        136.011 ±     1.173   ops/s
GeneratorBench.jsonSchemaFromYaml:gc.alloc.rate           cgmes-core.yml  thrpt    5       3564.043 ±    30.614  MB/sec
GeneratorBench.jsonSchemaFromYaml:gc.alloc.rate.norm      cgmes-core.yml  thrpt    5   27480361.577 ±    52.750    B/op
GeneratorBench.jsonSchemaFromYaml:gc.count                cgmes-core.yml  thrpt    5          7.000              counts
GeneratorBench.jsonSchemaFromYaml:gc.time                 cgmes-core.yml  thrpt    5         13.000                  ms
GeneratorBench.jsonSchemaFromYaml                     cgmes-dynamics.yml  thrpt    5         33.170 ±     0.703   ops/s
GeneratorBench.jsonSchemaFromYaml:gc.alloc.rate       cgmes-dynamics.yml  thrpt    5       3200.459 ±    67.535  MB/sec
GeneratorBench.jsonSchemaFromYaml:gc.alloc.rate.norm  cgmes-dynamics.yml  thrpt    5  101186577.318 ± 12681.960    B/op
GeneratorBench.jsonSchemaFromYaml:gc.count            cgmes-dynamics.yml  thrpt    5          7.000              counts
GeneratorBench.jsonSchemaFromYaml:gc.time             cgmes-dynamics.yml  thrpt    5         31.000                  ms
GeneratorBench.shaclFromYaml                                   dummy.yml  thrpt    5       4357.180 ±    25.318   ops/s
GeneratorBench.shaclFromYaml:gc.alloc.rate                     dummy.yml  thrpt    5       4092.640 ±    23.735  MB/sec
GeneratorBench.shaclFromYaml:gc.alloc.rate.norm                dummy.yml  thrpt    5     985033.332 ±     0.151    B/op
GeneratorBench.shaclFromYaml:gc.count                          dummy.yml  thrpt    5          8.000              counts
GeneratorBench.shaclFromYaml:gc.time                           dummy.yml  thrpt    5         17.000                  ms
GeneratorBench.shaclFromYaml                              cgmes-core.yml  thrpt    5        105.523 ±     0.486   ops/s
GeneratorBench.shaclFromYaml:gc.alloc.rate                cgmes-core.yml  thrpt    5       2681.194 ±    12.300  MB/sec
GeneratorBench.shaclFromYaml:gc.alloc.rate.norm           cgmes-core.yml  thrpt    5   26646961.645 ±    13.052    B/op
GeneratorBench.shaclFromYaml:gc.count                     cgmes-core.yml  thrpt    5          6.000              counts
GeneratorBench.shaclFromYaml:gc.time                      cgmes-core.yml  thrpt    5         13.000                  ms
GeneratorBench.shaclFromYaml                          cgmes-dynamics.yml  thrpt    5         30.820 ±     0.651   ops/s
GeneratorBench.shaclFromYaml:gc.alloc.rate            cgmes-dynamics.yml  thrpt    5       2808.906 ±    59.284  MB/sec
GeneratorBench.shaclFromYaml:gc.alloc.rate.norm       cgmes-dynamics.yml  thrpt    5   95579684.444 ±  6141.547    B/op
GeneratorBench.shaclFromYaml:gc.count                 cgmes-dynamics.yml  thrpt    5          7.000              counts
GeneratorBench.shaclFromYaml:gc.time                  cgmes-dynamics.yml  thrpt    5         41.000                  ms
```

After:
```txt
Benchmark                                                       (schema)   Mode  Cnt         Score       Error   Units
GeneratorBench.jsonSchemaFromYaml                              dummy.yml  thrpt    5      6309.883 ±    60.382   ops/s
GeneratorBench.jsonSchemaFromYaml:gc.alloc.rate                dummy.yml  thrpt    5      2957.423 ±    28.405  MB/sec
GeneratorBench.jsonSchemaFromYaml:gc.alloc.rate.norm           dummy.yml  thrpt    5    491520.845 ±     0.011    B/op
GeneratorBench.jsonSchemaFromYaml:gc.count                     dummy.yml  thrpt    5         7.000              counts
GeneratorBench.jsonSchemaFromYaml:gc.time                      dummy.yml  thrpt    5        15.000                  ms
GeneratorBench.jsonSchemaFromYaml                         cgmes-core.yml  thrpt    5       194.433 ±     2.158   ops/s
GeneratorBench.jsonSchemaFromYaml:gc.alloc.rate           cgmes-core.yml  thrpt    5      2864.284 ±    31.540  MB/sec
GeneratorBench.jsonSchemaFromYaml:gc.alloc.rate.norm      cgmes-core.yml  thrpt    5  15449488.545 ±   623.469    B/op
GeneratorBench.jsonSchemaFromYaml:gc.count                cgmes-core.yml  thrpt    5         6.000              counts
GeneratorBench.jsonSchemaFromYaml:gc.time                 cgmes-core.yml  thrpt    5        11.000                  ms
GeneratorBench.jsonSchemaFromYaml                     cgmes-dynamics.yml  thrpt    5        51.476 ±     2.021   ops/s
GeneratorBench.jsonSchemaFromYaml:gc.alloc.rate       cgmes-dynamics.yml  thrpt    5      2404.044 ±    93.966  MB/sec
GeneratorBench.jsonSchemaFromYaml:gc.alloc.rate.norm  cgmes-dynamics.yml  thrpt    5  48977064.009 ± 14568.267    B/op
GeneratorBench.jsonSchemaFromYaml:gc.count            cgmes-dynamics.yml  thrpt    5         6.000              counts
GeneratorBench.jsonSchemaFromYaml:gc.time             cgmes-dynamics.yml  thrpt    5        20.000                  ms
GeneratorBench.shaclFromYaml                                   dummy.yml  thrpt    5      5606.829 ±    33.407   ops/s
GeneratorBench.shaclFromYaml:gc.alloc.rate                     dummy.yml  thrpt    5      2695.985 ±    16.171  MB/sec
GeneratorBench.shaclFromYaml:gc.alloc.rate.norm                dummy.yml  thrpt    5    504265.013 ±     0.098    B/op
GeneratorBench.shaclFromYaml:gc.count                          dummy.yml  thrpt    5         6.000              counts
GeneratorBench.shaclFromYaml:gc.time                           dummy.yml  thrpt    5        14.000                  ms
GeneratorBench.shaclFromYaml                              cgmes-core.yml  thrpt    5       134.260 ±     1.017   ops/s
GeneratorBench.shaclFromYaml:gc.alloc.rate                cgmes-core.yml  thrpt    5      1861.929 ±    14.128  MB/sec
GeneratorBench.shaclFromYaml:gc.alloc.rate.norm           cgmes-core.yml  thrpt    5  14543574.376 ±    51.778    B/op
GeneratorBench.shaclFromYaml:gc.count                     cgmes-core.yml  thrpt    5         4.000              counts
GeneratorBench.shaclFromYaml:gc.time                      cgmes-core.yml  thrpt    5         9.000                  ms
GeneratorBench.shaclFromYaml                          cgmes-dynamics.yml  thrpt    5        46.218 ±     1.050   ops/s
GeneratorBench.shaclFromYaml:gc.alloc.rate            cgmes-dynamics.yml  thrpt    5      1902.449 ±    42.647  MB/sec
GeneratorBench.shaclFromYaml:gc.alloc.rate.norm       cgmes-dynamics.yml  thrpt    5  43167802.087 ± 15864.495    B/op
GeneratorBench.shaclFromYaml:gc.count                 cgmes-dynamics.yml  thrpt    5         5.000              counts
GeneratorBench.shaclFromYaml:gc.time                  cgmes-dynamics.yml  thrpt    5        19.000                  ms
```