### PR TITLE
Add YAML parsing benchmarks

### DIFF
--- a/benchmark/src/eu/neverblink/linkml/benchmark/YamlParsingBench.scala
+++ b/benchmark/src/eu/neverblink/linkml/benchmark/YamlParsingBench.scala
@@ -1,0 +1,24 @@
+package eu.neverblink.linkml.benchmark
+
+import org.virtuslab.yaml.*
+import org.openjdk.jmh.annotations.{Benchmark, Param, Setup}
+import org.openjdk.jmh.infra.Blackhole
+
+import scala.compiletime.uninitialized
+import scala.io.Source
+import scala.util.Using
+
+class YamlParsingBench extends CommonParams {
+  @Param(Array("cgmes-core.yml", "cgmes-dynamics.yml", "TC57CIM.yml"))
+  var schema: String = uninitialized
+
+  private var yaml: String = uninitialized
+
+  @Setup
+  def setup(): Unit = yaml = Using.resource(getClass.getResourceAsStream(s"/schemas/$schema")) { in =>
+    Source.fromInputStream(in, "UTF-8").mkString
+  }
+
+  @Benchmark
+  def fromStringToNode(bh: Blackhole): Node = parseYaml(yaml).getOrElse(null)
+}


### PR DESCRIPTION
org.virtuslab::scala-yaml::0.3.2
```
Benchmark                                                       (schema)   Mode  Cnt           Score          Error   Units
YamlParsingBench.fromStringToNode                         cgmes-core.yml  thrpt   15          72.361 ±        1.860   ops/s
YamlParsingBench.fromStringToNode:gc.alloc.rate           cgmes-core.yml  thrpt   15        8908.800 ±      227.009  MB/sec
YamlParsingBench.fromStringToNode:gc.alloc.rate.norm      cgmes-core.yml  thrpt   15   129113063.245 ±    28509.685    B/op
YamlParsingBench.fromStringToNode:gc.count                cgmes-core.yml  thrpt   15          58.000                 counts
YamlParsingBench.fromStringToNode:gc.time                 cgmes-core.yml  thrpt   15          34.000                     ms
YamlParsingBench.fromStringToNode                     cgmes-dynamics.yml  thrpt   15          14.930 ±        0.868   ops/s
YamlParsingBench.fromStringToNode:gc.alloc.rate       cgmes-dynamics.yml  thrpt   15        8737.397 ±      107.043  MB/sec
YamlParsingBench.fromStringToNode:gc.alloc.rate.norm  cgmes-dynamics.yml  thrpt   15   615661923.372 ± 40989267.773    B/op
YamlParsingBench.fromStringToNode:gc.count            cgmes-dynamics.yml  thrpt   15          60.000                 counts
YamlParsingBench.fromStringToNode:gc.time             cgmes-dynamics.yml  thrpt   15          99.000                     ms
YamlParsingBench.fromStringToNode                            TC57CIM.yml  thrpt   15           4.536 ±        0.105   ops/s
YamlParsingBench.fromStringToNode:gc.alloc.rate              TC57CIM.yml  thrpt   15        8684.199 ±      200.665  MB/sec
YamlParsingBench.fromStringToNode:gc.alloc.rate.norm         TC57CIM.yml  thrpt   15  2007960186.880 ±      198.114    B/op
YamlParsingBench.fromStringToNode:gc.count                   TC57CIM.yml  thrpt   15          63.000                 counts
YamlParsingBench.fromStringToNode:gc.time                    TC57CIM.yml  thrpt   15         189.000                     ms
```

org.virtuslab::scala-yaml::0.3.3 (after https://github.com/VirtusLab/scala-yaml/pull/488)
```
Benchmark                                                       (schema)   Mode  Cnt         Score       Error   Units
YamlParsingBench.fromStringToNode                         cgmes-core.yml  thrpt   15       676.537 ±     3.467   ops/s
YamlParsingBench.fromStringToNode:gc.alloc.rate           cgmes-core.yml  thrpt   15      3697.193 ±    34.221  MB/sec
YamlParsingBench.fromStringToNode:gc.alloc.rate.norm      cgmes-core.yml  thrpt   15   5731042.414 ± 35802.682    B/op
YamlParsingBench.fromStringToNode:gc.count                cgmes-core.yml  thrpt   15        25.000              counts
YamlParsingBench.fromStringToNode:gc.time                 cgmes-core.yml  thrpt   15        38.000                  ms
YamlParsingBench.fromStringToNode                     cgmes-dynamics.yml  thrpt   15       153.342 ±     0.802   ops/s
YamlParsingBench.fromStringToNode:gc.alloc.rate       cgmes-dynamics.yml  thrpt   15      3779.196 ±    19.792  MB/sec
YamlParsingBench.fromStringToNode:gc.alloc.rate.norm  cgmes-dynamics.yml  thrpt   15  25846109.228 ±    27.751    B/op
YamlParsingBench.fromStringToNode:gc.count            cgmes-dynamics.yml  thrpt   15        27.000              counts
YamlParsingBench.fromStringToNode:gc.time             cgmes-dynamics.yml  thrpt   15       133.000                  ms
YamlParsingBench.fromStringToNode                            TC57CIM.yml  thrpt   15        34.472 ±     0.420   ops/s
YamlParsingBench.fromStringToNode:gc.alloc.rate              TC57CIM.yml  thrpt   15      3024.374 ±    36.910  MB/sec
YamlParsingBench.fromStringToNode:gc.alloc.rate.norm         TC57CIM.yml  thrpt   15  92008251.061 ±    12.367    B/op
YamlParsingBench.fromStringToNode:gc.count                   TC57CIM.yml  thrpt   15        21.000              counts
YamlParsingBench.fromStringToNode:gc.time                    TC57CIM.yml  thrpt   15       366.000                  ms
```