### PR TITLE
Add YAML parsing benchmarks for zio-blocks

### DIFF
--- a/benchmark/src/eu/neverblink/linkml/benchmark/YamlParsingBench.scala
+++ b/benchmark/src/eu/neverblink/linkml/benchmark/YamlParsingBench.scala
@@ -1,8 +1,8 @@
 package eu.neverblink.linkml.benchmark
 
 import org.virtuslab.yaml.*
+import zio.blocks.schema.yaml.*
 import org.openjdk.jmh.annotations.{Benchmark, Param, Setup}
-import org.openjdk.jmh.infra.Blackhole
 
 import scala.compiletime.uninitialized
 import scala.io.Source
@@ -20,5 +20,8 @@ class YamlParsingBench extends CommonParams {
   }
 
   @Benchmark
-  def fromStringToNode(bh: Blackhole): Node = parseYaml(yaml).getOrElse(null)
+  def scalaYaml: Node = parseYaml(yaml).getOrElse(null)
+
+  @Benchmark
+  def zioBlocks: Yaml = YamlReader.read(yaml)
 }

--- a/build.mill
+++ b/build.mill
@@ -373,6 +373,7 @@ object benchmark extends ScalaModule, ScalafmtModule, ScalafixModule, JmhModule 
   // RDF4J Rio N-Triples (cli only brings rio-turtle) and Jena ARQ/RIOT,
   // for the N-Triples streaming-serializer benchmark.
   override def mvnDeps = super.mvnDeps() ++ Seq(
+    mvn"dev.zio::zio-blocks-schema-yaml::0.0.41",
     mvn"org.eclipse.rdf4j:rdf4j-rio-ntriples:$rdf4j",
     mvn"org.apache.jena:jena-arq:5.6.0",
   )


### PR DESCRIPTION
Results from JDK 25 on my MacBook:

```txt
Benchmark                                                (schema)   Mode  Cnt         Score      Error   Units
YamlParsingBench.scalaYaml                         cgmes-core.yml  thrpt    5       663.345 ±   54.155   ops/s
YamlParsingBench.scalaYaml:gc.alloc.rate           cgmes-core.yml  thrpt    5      3653.873 ±  297.645  MB/sec
YamlParsingBench.scalaYaml:gc.alloc.rate.norm      cgmes-core.yml  thrpt    5   5776781.053 ±  236.586    B/op
YamlParsingBench.scalaYaml:gc.count                cgmes-core.yml  thrpt    5         8.000             counts
YamlParsingBench.scalaYaml:gc.time                 cgmes-core.yml  thrpt    5        14.000                 ms
YamlParsingBench.scalaYaml                     cgmes-dynamics.yml  thrpt    5       150.515 ±    3.817   ops/s
YamlParsingBench.scalaYaml:gc.alloc.rate       cgmes-dynamics.yml  thrpt    5      3709.462 ±   93.688  MB/sec
YamlParsingBench.scalaYaml:gc.alloc.rate.norm  cgmes-dynamics.yml  thrpt    5  25846113.004 ±   88.942    B/op
YamlParsingBench.scalaYaml:gc.count            cgmes-dynamics.yml  thrpt    5         8.000             counts
YamlParsingBench.scalaYaml:gc.time             cgmes-dynamics.yml  thrpt    5        40.000                 ms
YamlParsingBench.scalaYaml                            TC57CIM.yml  thrpt    5        33.797 ±    1.830   ops/s
YamlParsingBench.scalaYaml:gc.alloc.rate              TC57CIM.yml  thrpt    5      2965.189 ±  160.486  MB/sec
YamlParsingBench.scalaYaml:gc.alloc.rate.norm         TC57CIM.yml  thrpt    5  92008255.753 ±   22.181    B/op
YamlParsingBench.scalaYaml:gc.count                   TC57CIM.yml  thrpt    5         6.000             counts
YamlParsingBench.scalaYaml:gc.time                    TC57CIM.yml  thrpt    5       121.000                 ms
YamlParsingBench.zioBlocks                         cgmes-core.yml  thrpt    5      8657.560 ±  149.349   ops/s
YamlParsingBench.zioBlocks:gc.alloc.rate           cgmes-core.yml  thrpt    5      4171.398 ±   71.696  MB/sec
YamlParsingBench.zioBlocks:gc.alloc.rate.norm      cgmes-core.yml  thrpt    5    505288.616 ±    0.013    B/op
YamlParsingBench.zioBlocks:gc.count                cgmes-core.yml  thrpt    5         9.000             counts
YamlParsingBench.zioBlocks:gc.time                 cgmes-core.yml  thrpt    5         5.000                 ms
YamlParsingBench.zioBlocks                     cgmes-dynamics.yml  thrpt    5      2087.488 ±   10.244   ops/s
YamlParsingBench.zioBlocks:gc.alloc.rate       cgmes-dynamics.yml  thrpt    5      4359.572 ±   21.385  MB/sec
YamlParsingBench.zioBlocks:gc.alloc.rate.norm  cgmes-dynamics.yml  thrpt    5   2190162.558 ±    0.014    B/op
YamlParsingBench.zioBlocks:gc.count            cgmes-dynamics.yml  thrpt    5         9.000             counts
YamlParsingBench.zioBlocks:gc.time             cgmes-dynamics.yml  thrpt    5         6.000                 ms
YamlParsingBench.zioBlocks                            TC57CIM.yml  thrpt    5       492.683 ±  310.137   ops/s
YamlParsingBench.zioBlocks:gc.alloc.rate              TC57CIM.yml  thrpt    5      3585.600 ± 2257.076  MB/sec
YamlParsingBench.zioBlocks:gc.alloc.rate.norm         TC57CIM.yml  thrpt    5   7632147.059 ±    7.594    B/op
YamlParsingBench.zioBlocks:gc.count                   TC57CIM.yml  thrpt    5         7.000             counts
YamlParsingBench.zioBlocks:gc.time                    TC57CIM.yml  thrpt    5         5.000                 ms
```