### PR TITLE
LNK-130: Prefix resolver performance fix

### DIFF
--- a/benchmark/src/eu/neverblink/linkml/benchmark/WarmBench.scala
+++ b/benchmark/src/eu/neverblink/linkml/benchmark/WarmBench.scala
@@ -38,7 +38,7 @@ class WarmBench extends CommonParams {
   val repoRoot: Path =
     Option(System.getenv("MILL_WORKSPACE_ROOT")).map(os.Path.apply).getOrElse(os.pwd)
 
-  val modelsDir: Path = repoRoot / ".." / "linkml-benchmark-schemas"
+  val modelsDir: Path = repoRoot / ".." / "linkml-benchmark-schemas" / "benchmark_data"
 
   assume(
     os.exists(modelsDir),

--- a/schemaview/src/eu/neverblink/linkml/schemaview/ElementView.scala
+++ b/schemaview/src/eu/neverblink/linkml/schemaview/ElementView.scala
@@ -37,7 +37,7 @@ sealed trait ElementView[E <: Element](using val sv: SchemaView) {
   final def name: String = inner.name
 
   /** The defining schema's prefix resolver */
-  given definingPrefixResolver: PrefixResolver = sv.prefixResolvers(definingSchema)
+  given definingPrefixResolver: PrefixResolver = sv.getPrefixResolver(definingSchema)
 
   /** Get the URI of this element, using the default prefix of the implicit [[SchemaView]] if not
     * explicitly defined.

--- a/schemaview/src/eu/neverblink/linkml/schemaview/SchemaProblem.scala
+++ b/schemaview/src/eu/neverblink/linkml/schemaview/SchemaProblem.scala
@@ -1,6 +1,6 @@
 package eu.neverblink.linkml.schemaview
 
-import eu.neverblink.linkml.metamodel.{ClassDefinition, Element, SlotDefinition}
+import eu.neverblink.linkml.metamodel.{ClassDefinition, Element, SchemaDefinition, SlotDefinition}
 import eu.neverblink.linkml.runtime.NcName
 
 import scala.util.Failure
@@ -156,6 +156,11 @@ object SchemaProblem {
       "schema 'default_range' is undefined, and the fallback 'string' type is not available. " +
       "Define the 'range' of the slot, add a 'default_range' to the schema, " +
       "import 'linkml:types', or define a 'string' type to fix."
+
+  final case class SchemaIdClash(schema1: SchemaDefinition, schema2: SchemaDefinition)
+      extends Fatal:
+    lazy val description: String = "Non-unique schema IDs detected"
+    lazy val verbose: String = description
 
   final case class UndefinedPrefix(prefix: NcName, position: String) extends Error:
     lazy val description: String = s"Undefined prefix $prefix at $position"

--- a/schemaview/src/eu/neverblink/linkml/schemaview/SchemaValidator.scala
+++ b/schemaview/src/eu/neverblink/linkml/schemaview/SchemaValidator.scala
@@ -39,6 +39,18 @@ final class SchemaValidator(using sv: SchemaView) {
     macroResult.invalidDefaultRanges.map(SchemaProblem.InvalidDefaultRangeProblem(_))
   }
 
+  lazy val schemaIdClash: Seq[SchemaProblem.Fatal] = {
+    val schemas = sv.schemas.toIndexedSeq
+
+    for
+      (s1, s1index) <- schemas.zipWithIndex
+      s2 <- schemas.slice(s1index + 1, schemas.size)
+      if s1.id == s2.id
+        // TODO LNK-154 Robust file system importing
+        && s1 != s2
+    yield SchemaProblem.SchemaIdClash(s1, s2)
+  }
+
   /** Warning if defining a slot without a `range` will cause a fatal error, None otherwise
     */
   private lazy val undefinedDefaultRange: Option[SchemaProblem.Warning] = {
@@ -300,7 +312,8 @@ final class SchemaValidator(using sv: SchemaView) {
   lazy val fatalProblems: Seq[SchemaProblem.Fatal] =
     unknownReferences ++
       invalidRangeTypes ++
-      usedUndefinedDefaultRange
+      usedUndefinedDefaultRange ++
+      schemaIdClash
 
   /** Any errors found in the schema, if any. */
   private lazy val errors: Seq[SchemaProblem.Error] =

--- a/schemaview/src/eu/neverblink/linkml/schemaview/SchemaView.scala
+++ b/schemaview/src/eu/neverblink/linkml/schemaview/SchemaView.scala
@@ -96,8 +96,12 @@ final case class SchemaView(schemas: Seq[SchemaDefinition]) extends ReferenceRes
     *
     * These should be used in ElementView instead of creating a new prefix resolver every time.
     */
-  lazy val prefixResolvers: Map[SchemaDefinition, BasicPrefixResolver] =
-    schemas.map(schema => schema -> createPrefixResolver(schema)).toMap
+  private lazy val prefixResolvers: Map[Uri, BasicPrefixResolver] =
+    schemas.map(schema => schema.id -> createPrefixResolver(schema)).toMap
+
+  def getPrefixResolver(schema: SchemaDefinition): BasicPrefixResolver = {
+    prefixResolvers(schema.id)
+  }
 
   /** Get all elements reachable from a given starting set, following slots, ranges, inheritance and
     * other reference slots. This will run the query without schema derivation.
@@ -316,6 +320,7 @@ object SchemaView {
       importer: Importer,
       visited: mutable.Set[String],
   ): Seq[SchemaDefinition] = {
+    // TODO LNK-154 Robust file system importing
     var normalizedUri = uri.stripSuffix(PlatformSpecificUtils.separator)
     if (!normalizedUri.endsWith(".yaml") && !normalizedUri.endsWith(".yml"))
       normalizedUri += ".yaml"
@@ -382,7 +387,7 @@ object SchemaView {
   /** Create a [[BasicPrefixResolver]] based on the given schema. Loads metamodel emit_prefixes,
     * resolves "semweb_context" curi map and loads user defined prefixes.
     */
-  def createPrefixResolver(forSchema: SchemaDefinition): BasicPrefixResolver = {
+  private def createPrefixResolver(forSchema: SchemaDefinition): BasicPrefixResolver = {
     val prefixResolver = new BasicPrefixResolver(forSchema.id.original)
     Prefixes.map.foreach { (prefix, uri) => prefixResolver.add(prefix, uri) }
     if (forSchema.defaultCuriMaps.contains("semweb_context")) {


### PR DESCRIPTION
With multiple SchemaDefinitions in a SchemaView, getting a prefix resolver from Map[SchemaDefinition, PrefixResolver] was running structural equality checks on the entire schema definition, which is why it was very slow for some benchmark schemas. I changed it to compare on ID only, which should be unique - but we do check it in the validator, as well as with a fallback for some importer issues.

Before:
```
Benchmark             (model)   Mode  Cnt  Score   Error  Units
WarmBench.jsonSchema      cdm  thrpt   50  1.539 ± 0.012  ops/s
WarmBench.shacl           cdm  thrpt   50  0.593 ± 0.015  ops/s
```

After:
```
Benchmark             (model)   Mode  Cnt   Score   Error  Units
WarmBench.jsonSchema      cdm  thrpt   50  69.386 ± 1.715  ops/s
WarmBench.shacl           cdm  thrpt   50  50.378 ± 0.310  ops/s
```