### PR TITLE
LNK-135 More efficient `ClassView` initialization, `SchemaView` validation, and LinkML generation

### DIFF
--- a/generator/test/src/eu/neverblink/linkml/generator/graphql/GraphQlGeneratorSpec.scala
+++ b/generator/test/src/eu/neverblink/linkml/generator/graphql/GraphQlGeneratorSpec.scala
@@ -147,7 +147,7 @@ class GraphQlGeneratorSpec extends AnyWordSpec, Matchers {
         "enum SomeEnum",
         s"@linkml_uri(uri: \"${id}SomeEnum\")",
         "SOME_OPTION",
-        s"@linkml_uri(uri: \"http://www.w3.org/1999/02/22-rdf-syntax-ns#subject\")",
+        "@linkml_uri(uri: \"http://www.w3.org/1999/02/22-rdf-syntax-ns#subject\")",
         "SOME_OTHER_OPTION",
         s"@linkml_uri(uri: \"${id}SOME_OTHER_OPTION\")",
         "YET_ANOTHER_OPTION",

--- a/generator/test/src/eu/neverblink/linkml/generator/graphql/GraphQlGeneratorSpec.scala
+++ b/generator/test/src/eu/neverblink/linkml/generator/graphql/GraphQlGeneratorSpec.scala
@@ -163,12 +163,11 @@ class GraphQlGeneratorSpec extends AnyWordSpec, Matchers {
       val result = GraphQlGenerator().serialize()
       Seq(
         "some_slot: Any",
-        "scalar Any"
+        "scalar Any",
       ).foreach { snippet =>
         result should include(snippet)
       }
     }
-
 
     "generate descriptions" in {
       given SchemaView = ModelCatalogue.metadata.title.model
@@ -176,20 +175,20 @@ class GraphQlGeneratorSpec extends AnyWordSpec, Matchers {
       val result = GraphQlGenerator().serialize()
       Seq(
         "This is a class for testing purposes",
-        "This is a slot for testing purposes"
+        "This is a slot for testing purposes",
       ).foreach { snippet =>
         result should include(snippet)
       }
     }
-    
+
     "generate empty classes" in {
       given SchemaView = ModelCatalogue.emptyClass.model
-      
+
       val result = GraphQlGenerator().serialize()
       Seq(
         "SomeClass",
         "SomeOtherClass",
-        "_: String"
+        "_: String",
       ).foreach { snippet =>
         result should include(snippet)
       }

--- a/schemaview/src/eu/neverblink/linkml/schemaview/Closure.scala
+++ b/schemaview/src/eu/neverblink/linkml/schemaview/Closure.scala
@@ -23,7 +23,7 @@ object Closure {
       function: T => Iterable[T],
       reflexive: Boolean,
   ): Iterable[T] = {
-    val ret = mutable.ListBuffer.empty[T]
+    val ret = Vector.newBuilder[T]
     val visited = mutable.ArrayBuffer.empty[T]
     val todo = mutable.ArrayDeque.empty[T]
     start.foreach { s =>
@@ -34,8 +34,7 @@ object Closure {
       }
     }
     while (todo.nonEmpty) {
-      val current = todo.removeLast()
-      function(current).foreach { neighbor =>
+      function(todo.removeLast()).foreach { neighbor =>
         if (!visited.contains(neighbor)) {
           visited.addOne(neighbor)
           todo.addOne(neighbor)
@@ -43,6 +42,6 @@ object Closure {
         }
       }
     }
-    ret.toList
+    ret.result()
   }
 }

--- a/schemaview/src/eu/neverblink/linkml/schemaview/Closure.scala
+++ b/schemaview/src/eu/neverblink/linkml/schemaview/Closure.scala
@@ -23,21 +23,26 @@ object Closure {
       function: T => Iterable[T],
       reflexive: Boolean,
   ): Iterable[T] = {
-    val ret = if reflexive then mutable.ArrayBuffer.from(start) else mutable.ArrayBuffer.empty[T]
+    val ret = mutable.ListBuffer.empty[T]
     val visited = mutable.ArrayBuffer.empty[T]
-    val todo = mutable.ArrayDeque.from(start)
-
-    while todo.nonEmpty do {
+    val todo = mutable.ArrayDeque.empty[T]
+    start.foreach { s =>
+      if (!visited.contains(s)) {
+        visited.addOne(s)
+        todo.addOne(s)
+        if (reflexive) ret.addOne(s)
+      }
+    }
+    while (todo.nonEmpty) {
       val current = todo.removeLast()
-      visited.append(current)
-      for neighbor <- function(current) do {
-        if !visited.contains(neighbor) then {
-          todo.append(neighbor)
-          ret.append(neighbor)
+      function(current).foreach { neighbor =>
+        if (!visited.contains(neighbor)) {
+          visited.addOne(neighbor)
+          todo.addOne(neighbor)
+          ret.addOne(neighbor)
         }
       }
     }
-
-    ret.toSeq
+    ret.toList
   }
 }

--- a/schemaview/src/eu/neverblink/linkml/schemaview/ElementView.scala
+++ b/schemaview/src/eu/neverblink/linkml/schemaview/ElementView.scala
@@ -5,8 +5,6 @@ import eu.neverblink.linkml.metamodel.*
 import eu.neverblink.linkml.runtime.*
 import eu.neverblink.linkml.schemaview
 
-import scala.collection.mutable
-
 /** Element views provide a rich interface for working with schema elements. They require an
   * implicit [[SchemaView]] and are always linked to a defining schema, which is the schema in which
   * the element was originally defined. This allows you to both have the full context of all
@@ -79,12 +77,28 @@ final case class ClassView(cls: ClassDefinition, definingSchema: SchemaDefinitio
     */
   lazy val (derivedAttributes: Map[String, SlotView], identifier: Option[SlotView]) = {
     var idSv: SlotView = null
-    val das = applicableSlots.foldLeft(Map.empty[String, SlotView]) { (acc, v) =>
-      val sv = derivedSlot(v.ref, v.source)
-      if (sv.slot.identifier) {
-        idSv = sv
+    var das = Map.empty[String, SlotView]
+    ancestors(true).foreach { anc =>
+      val keys = anc.cls.attributes.keysIterator
+      while (keys.hasNext) {
+        val name = keys.next()
+        if (!das.contains(name)) {
+          val ref = new Reference[SlotDefinition](name)
+          val sv = derivedSlot(ref, anc)
+          if (sv.slot.identifier) idSv = sv
+          das = das.updated(ref.value, sv)
+        }
       }
-      acc.updated(v.ref.value, sv)
+      val slots = anc.cls.slots.iterator
+      while (slots.hasNext) {
+        val ref = slots.next()
+        val name = ref.value
+        if (!das.contains(name)) {
+          val sv = derivedSlot(ref, ref.asInstanceOf[Reference[SlotView]].resolve.get)
+          if (sv.slot.identifier) idSv = sv
+          das = das.updated(name, sv)
+        }
+      }
     }
     (das, Option(idSv))
   }
@@ -162,29 +176,6 @@ final case class ClassView(cls: ClassDefinition, definingSchema: SchemaDefinitio
 
   private def getDirectSlots(cls: ClassDefinition): Seq[Reference[SlotDefinition]] =
     cls.slots ++ cls.attributes.keys.map(Reference[SlotDefinition])
-
-  /** Get all slot references that are applicable to this class definition.
-    *
-    * Returns a sequence of pairs of (slot reference, source of the slot definition), where the
-    * source is either a ClassView (if the slot is defined as an attribute) or a SlotView (if the
-    * slot is defined as a top-level slot). The source is used for default prefix and range
-    * resolution according to the original schema file.
-    *
-    * @see
-    *   https://linkml.io/linkml-model/latest/docs/specification/04derived-schemas/#function-applicable-slots
-    */
-  def applicableSlots: Seq[(ref: Reference[SlotDefinition], source: ElementView[?])] =
-    // LinkedHashMap to preserve the order of slot definitions.
-    val buffer = mutable.LinkedHashMap[Reference[SlotDefinition], ElementView[?]]()
-    ancestors(true).foreach { anc =>
-      val candidates: Seq[(Reference[SlotDefinition], ElementView[?])] =
-        anc.cls.slots.map(ref => (ref, ref.asInstanceOf[Reference[SlotView]].resolve.get)) ++
-          anc.cls.attributes.keys.map(name => (Reference[SlotDefinition](name), anc))
-      for ((ref, source) <- candidates) do
-        // Older ancestors take precedence, so that we resolve to the original source of the slot.
-        buffer.update(ref, source)
-    }
-    buffer.toSeq
 
   /** Test whether the class or its ancestors have this slot defined as an attribute.
     *

--- a/schemaview/src/eu/neverblink/linkml/schemaview/ElementView.scala
+++ b/schemaview/src/eu/neverblink/linkml/schemaview/ElementView.scala
@@ -78,6 +78,12 @@ final case class ClassView(cls: ClassDefinition, definingSchema: SchemaDefinitio
   lazy val (derivedAttributes: Map[String, SlotView], identifier: Option[SlotView]) = {
     var idSv: SlotView = null
     var das = Map.empty[String, SlotView]
+    // Get all slots that are applicable to this class definition.
+    // Returns a sequence of pairs of slot name and the derived slot definition,
+    // where the source is either a ClassView (if the slot is defined as an attribute) or
+    // a SlotView (if the slot is defined as a top-level slot). The source is used
+    // for default prefix and range resolution according to the original schema file.
+    // See: https://linkml.io/linkml-model/latest/docs/specification/04derived-schemas/#function-applicable-slots
     ancestors(true).foreach { anc =>
       val keys = anc.cls.attributes.keysIterator
       while (keys.hasNext) {

--- a/schemaview/src/eu/neverblink/linkml/schemaview/SchemaValidator.scala
+++ b/schemaview/src/eu/neverblink/linkml/schemaview/SchemaValidator.scala
@@ -15,36 +15,26 @@ final class SchemaValidator(using sv: SchemaView) {
   // TODO: warn about shadowing
 
   /** Whether omitting `range` will result in a valid reference */
-  private lazy val isDefaultRangeAllowed: Boolean = sv.root.defaultRange match {
-    case Some(value) => true
-    case None =>
-      sv.types.get("string") match {
-        case Some(value) => true
-        case None => false
-      }
-  }
+  private lazy val isDefaultRangeAllowed: Boolean =
+    sv.root.defaultRange.isDefined || sv.types.contains("string")
 
   private given ValidatorContext = ValidatorContext(isDefaultRangeAllowed)
 
   /** Macro validator's result */
-  private lazy val macroResult = sv.schemas.map(schema =>
+  private lazy val macroResult = sv.schemas.foldLeft(ValidatorResult.ok) { (acc, schema) =>
     // TODO LNK-166: Store the element "fromSchema"
-    macroValidator.validate(schema.asInstanceOf).prependedPath("/"),
-  ).fold(ValidatorResult.ok)(_ + _)
-
-  /** Any invalid references present in the schema. Empty if all references are valid. */
-  lazy val unknownReferences: Seq[SchemaProblem.Fatal] = {
-    macroResult.unknownReferences.map(SchemaProblem.UnknownReferenceProblem(_))
+    acc + macroValidator.validate(schema.asInstanceOf).prependedPath("/")
   }
+  /** Any invalid references present in the schema. Empty if all references are valid. */
+  lazy val unknownReferences: Seq[SchemaProblem.Fatal] =
+    macroResult.unknownReferences.map(SchemaProblem.UnknownReferenceProblem(_))
 
   /** Any usages of an undefined `default_range`. Empty if no usages found. */
-  lazy val usedUndefinedDefaultRange: Seq[SchemaProblem.Fatal] = {
+  lazy val usedUndefinedDefaultRange: Seq[SchemaProblem.Fatal] =
     macroResult.invalidDefaultRanges.map(SchemaProblem.InvalidDefaultRangeProblem(_))
-  }
 
   lazy val schemaIdClash: Seq[SchemaProblem.Fatal] = {
     val schemas = sv.schemas.toIndexedSeq
-
     for
       (s1, s1index) <- schemas.zipWithIndex
       s2 <- schemas.slice(s1index + 1, schemas.size)
@@ -56,15 +46,13 @@ final class SchemaValidator(using sv: SchemaView) {
 
   /** Warning if defining a slot without a `range` will cause a fatal error, None otherwise
     */
-  private lazy val undefinedDefaultRange: Option[SchemaProblem.Warning] = {
+  private lazy val undefinedDefaultRange: Option[SchemaProblem.Warning] =
     if isDefaultRangeAllowed then None
     else Some(SchemaProblem.UndefinedDefaultRange)
-  }
 
   /** Any `range` slots pointing at invalid elements in the schema. */
-  lazy val invalidRangeTypes: Seq[SchemaProblem.Fatal] = {
+  lazy val invalidRangeTypes: Seq[SchemaProblem.Fatal] =
     macroResult.invalidRanges.map(SchemaProblem.InvalidRangeProblem(_))
-  }
 
   /** Error when a schema has multiple `tree_root` classes, None otherwise */
   private lazy val multipleTreeRoots: Option[SchemaProblem.Error] = {
@@ -239,18 +227,22 @@ final class SchemaValidator(using sv: SchemaView) {
   /** Ensure that any declared slot usages are refining some applicable slot (top level slot or
     * attribute)
     */
-  private lazy val invalidSlotUsage: Seq[SchemaProblem.Warning] = {
-    val perClass = for (cls <- sv.classes.values) yield {
-      val slotUsageNames = cls.cls.slotUsage.keys
-      val applicableSlotNames = cls.applicableSlots.map(_.ref.value)
-      val problemSlots = slotUsageNames
+  private lazy val invalidSlotUsage: Seq[SchemaProblem.Warning] =
+    sv.classes.values.foldLeft(Seq.newBuilder[SchemaProblem.Warning]) { (acc, cls) =>
+      val applicableSlotNames = java.util.HashSet[String]
+      cls.ancestors(true).foreach { anc =>
+        val keys = anc.cls.attributes.keysIterator
+        while (keys.hasNext) applicableSlotNames.add(keys.next())
+        val slots = anc.cls.slots.iterator
+        while (slots.hasNext) applicableSlotNames.add(slots.next().value)
+      }
+      val problemSlots = cls.cls.slotUsage.keys
         .filter(x => !applicableSlotNames.contains(x))
-      if problemSlots.nonEmpty then
-        Some(SchemaProblem.InvalidSlotUsage(cls.cls, problemSlots.toSeq))
-      else None
-    }
-    perClass.flatten.toSeq
-  }
+      if (problemSlots.nonEmpty) {
+        acc.addOne(SchemaProblem.InvalidSlotUsage(cls.cls, problemSlots.toSeq))
+      }
+      acc
+    }.result()
 
   private def slotImplicitPrefix(
       slotDefinition: SlotDefinition,

--- a/schemaview/src/eu/neverblink/linkml/schemaview/SchemaValidator.scala
+++ b/schemaview/src/eu/neverblink/linkml/schemaview/SchemaValidator.scala
@@ -230,13 +230,15 @@ final class SchemaValidator(using sv: SchemaView) {
     */
   private lazy val invalidSlotUsage: Seq[SchemaProblem.Warning] =
     sv.classes.values.foldLeft(Seq.newBuilder[SchemaProblem.Warning]) { (acc, cls) =>
-      val applicableSlotNames = java.util.HashSet[String]
+      // Collect all slot names that are applicable to this class definition.
+      val applicableSlotNames = new util.HashSet[String]
       cls.ancestors(true).foreach { anc =>
         val keys = anc.cls.attributes.keysIterator
         while (keys.hasNext) applicableSlotNames.add(keys.next())
         val slots = anc.cls.slots.iterator
         while (slots.hasNext) applicableSlotNames.add(slots.next().value)
       }
+      // Filter problematic slots for the warning per class
       val problemSlots = cls.cls.slotUsage.keys
         .filter(x => !applicableSlotNames.contains(x))
       if (problemSlots.nonEmpty) {

--- a/schemaview/src/eu/neverblink/linkml/schemaview/SchemaValidator.scala
+++ b/schemaview/src/eu/neverblink/linkml/schemaview/SchemaValidator.scala
@@ -25,6 +25,7 @@ final class SchemaValidator(using sv: SchemaView) {
     // TODO LNK-166: Store the element "fromSchema"
     acc + macroValidator.validate(schema.asInstanceOf).prependedPath("/")
   }
+
   /** Any invalid references present in the schema. Empty if all references are valid. */
   lazy val unknownReferences: Seq[SchemaProblem.Fatal] =
     macroResult.unknownReferences.map(SchemaProblem.UnknownReferenceProblem(_))


### PR DESCRIPTION
It speeds up LinkML generation for huge schemas greatly, please compare results of benchmarks below.

Before:
```txt
Benchmark                                                             (schema)   Mode  Cnt          Score       Error   Units
GeneratorBench.linkmlFromSchemaView                             cgmes-core.yml  thrpt    5        297.051 ±     1.019   ops/s
GeneratorBench.linkmlFromSchemaView:gc.alloc.rate               cgmes-core.yml  thrpt    5       3190.339 ±    11.292  MB/sec
GeneratorBench.linkmlFromSchemaView:gc.alloc.rate.norm          cgmes-core.yml  thrpt    5   11263359.937 ±    20.918    B/op
GeneratorBench.linkmlFromSchemaView:gc.count                    cgmes-core.yml  thrpt    5          7.000              counts
GeneratorBench.linkmlFromSchemaView:gc.time                     cgmes-core.yml  thrpt    5         13.000                  ms
GeneratorBench.linkmlFromSchemaView                         cgmes-dynamics.yml  thrpt    5        143.875 ±     3.032   ops/s
GeneratorBench.linkmlFromSchemaView:gc.alloc.rate           cgmes-dynamics.yml  thrpt    5       3431.196 ±    72.469  MB/sec
GeneratorBench.linkmlFromSchemaView:gc.alloc.rate.norm      cgmes-dynamics.yml  thrpt    5   25009961.532 ±   333.323    B/op
GeneratorBench.linkmlFromSchemaView:gc.count                cgmes-dynamics.yml  thrpt    5          8.000              counts
GeneratorBench.linkmlFromSchemaView:gc.time                 cgmes-dynamics.yml  thrpt    5         21.000                  ms
GeneratorBench.linkmlFromSchemaView                                TC57CIM.yml  thrpt    5          6.286 ±     0.131   ops/s
GeneratorBench.linkmlFromSchemaView:gc.alloc.rate                  TC57CIM.yml  thrpt    5        980.007 ±    20.317  MB/sec
GeneratorBench.linkmlFromSchemaView:gc.alloc.rate.norm             TC57CIM.yml  thrpt    5  163503979.200 ± 16846.330    B/op
GeneratorBench.linkmlFromSchemaView:gc.count                       TC57CIM.yml  thrpt    5          2.000              counts
GeneratorBench.linkmlFromSchemaView:gc.time                        TC57CIM.yml  thrpt    5          9.000                  ms
GeneratorBench.linkmlFromSchemas                                cgmes-core.yml  thrpt    5        194.734 ±     1.539   ops/s
GeneratorBench.linkmlFromSchemas:gc.alloc.rate                  cgmes-core.yml  thrpt    5       2881.006 ±    22.802  MB/sec
GeneratorBench.linkmlFromSchemas:gc.alloc.rate.norm             cgmes-core.yml  thrpt    5   15515651.344 ±   368.620    B/op
GeneratorBench.linkmlFromSchemas:gc.count                       cgmes-core.yml  thrpt    5          7.000              counts
GeneratorBench.linkmlFromSchemas:gc.time                        cgmes-core.yml  thrpt    5         16.000                  ms
GeneratorBench.linkmlFromSchemas                            cgmes-dynamics.yml  thrpt    5         95.332 ±     1.354   ops/s
GeneratorBench.linkmlFromSchemas:gc.alloc.rate              cgmes-dynamics.yml  thrpt    5       3139.834 ±    44.408  MB/sec
GeneratorBench.linkmlFromSchemas:gc.alloc.rate.norm         cgmes-dynamics.yml  thrpt    5   34540461.574 ±   366.185    B/op
GeneratorBench.linkmlFromSchemas:gc.count                   cgmes-dynamics.yml  thrpt    5          7.000              counts
GeneratorBench.linkmlFromSchemas:gc.time                    cgmes-dynamics.yml  thrpt    5         17.000                  ms
GeneratorBench.linkmlFromSchemas                                   TC57CIM.yml  thrpt    5          5.393 ±     0.252   ops/s
GeneratorBench.linkmlFromSchemas:gc.alloc.rate                     TC57CIM.yml  thrpt    5       1160.167 ±    54.304  MB/sec
GeneratorBench.linkmlFromSchemas:gc.alloc.rate.norm                TC57CIM.yml  thrpt    5  225604239.733 ± 14305.182    B/op
GeneratorBench.linkmlFromSchemas:gc.count                          TC57CIM.yml  thrpt    5          3.000              counts
GeneratorBench.linkmlFromSchemas:gc.time                           TC57CIM.yml  thrpt    5         13.000                  ms
GeneratorBench.linkmlFromYaml                                   cgmes-core.yml  thrpt    5        126.277 ±     1.154   ops/s
GeneratorBench.linkmlFromYaml:gc.alloc.rate                     cgmes-core.yml  thrpt    5       2685.224 ±    24.674  MB/sec
GeneratorBench.linkmlFromYaml:gc.alloc.rate.norm                cgmes-core.yml  thrpt    5   22300372.011 ±  1434.651    B/op
GeneratorBench.linkmlFromYaml:gc.count                          cgmes-core.yml  thrpt    5          6.000              counts
GeneratorBench.linkmlFromYaml:gc.time                           cgmes-core.yml  thrpt    5         14.000                  ms
GeneratorBench.linkmlFromYaml                               cgmes-dynamics.yml  thrpt    5         38.860 ±     0.807   ops/s
GeneratorBench.linkmlFromYaml:gc.alloc.rate                 cgmes-dynamics.yml  thrpt    5       2412.389 ±    50.111  MB/sec
GeneratorBench.linkmlFromYaml:gc.alloc.rate.norm            cgmes-dynamics.yml  thrpt    5   65102410.217 ±  7028.914    B/op
GeneratorBench.linkmlFromYaml:gc.count                      cgmes-dynamics.yml  thrpt    5          6.000              counts
GeneratorBench.linkmlFromYaml:gc.time                       cgmes-dynamics.yml  thrpt    5         14.000                  ms
GeneratorBench.linkmlFromYaml                                      TC57CIM.yml  thrpt    5          3.779 ±     0.257   ops/s
GeneratorBench.linkmlFromYaml:gc.alloc.rate                        TC57CIM.yml  thrpt    5       1215.196 ±    82.690  MB/sec
GeneratorBench.linkmlFromYaml:gc.alloc.rate.norm                   TC57CIM.yml  thrpt    5  337250655.600 ± 16131.965    B/op
GeneratorBench.linkmlFromYaml:gc.count                             TC57CIM.yml  thrpt    5          3.000              counts
GeneratorBench.linkmlFromYaml:gc.time                              TC57CIM.yml  thrpt    5         69.000                  ms
```

After
```txt
Benchmark                                                         (schema)   Mode  Cnt          Score       Error   Units
GeneratorBench.linkmlFromSchemaView                         cgmes-core.yml  thrpt    5        305.949 ±     3.983   ops/s
GeneratorBench.linkmlFromSchemaView:gc.alloc.rate           cgmes-core.yml  thrpt    5       3171.124 ±    41.361  MB/sec
GeneratorBench.linkmlFromSchemaView:gc.alloc.rate.norm      cgmes-core.yml  thrpt    5   10869874.049 ±     1.525    B/op
GeneratorBench.linkmlFromSchemaView:gc.count                cgmes-core.yml  thrpt    5          7.000              counts
GeneratorBench.linkmlFromSchemaView:gc.time                 cgmes-core.yml  thrpt    5         13.000                  ms
GeneratorBench.linkmlFromSchemaView                     cgmes-dynamics.yml  thrpt    5        140.572 ±     4.610   ops/s
GeneratorBench.linkmlFromSchemaView:gc.alloc.rate       cgmes-dynamics.yml  thrpt    5       3301.958 ±   108.277  MB/sec
GeneratorBench.linkmlFromSchemaView:gc.alloc.rate.norm  cgmes-dynamics.yml  thrpt    5   24633977.810 ±   251.468    B/op
GeneratorBench.linkmlFromSchemaView:gc.count            cgmes-dynamics.yml  thrpt    5          7.000              counts
GeneratorBench.linkmlFromSchemaView:gc.time             cgmes-dynamics.yml  thrpt    5         22.000                  ms
GeneratorBench.linkmlFromSchemaView                            TC57CIM.yml  thrpt    5          8.839 ±     0.147   ops/s
GeneratorBench.linkmlFromSchemaView:gc.alloc.rate              TC57CIM.yml  thrpt    5       1263.767 ±    20.998  MB/sec
GeneratorBench.linkmlFromSchemaView:gc.alloc.rate.norm         TC57CIM.yml  thrpt    5  149943339.200 ± 11036.886    B/op
GeneratorBench.linkmlFromSchemaView:gc.count                   TC57CIM.yml  thrpt    5          3.000              counts
GeneratorBench.linkmlFromSchemaView:gc.time                    TC57CIM.yml  thrpt    5         19.000                  ms
GeneratorBench.linkmlFromSchemas                            cgmes-core.yml  thrpt    5        216.776 ±     2.724   ops/s
GeneratorBench.linkmlFromSchemas:gc.alloc.rate              cgmes-core.yml  thrpt    5       3075.179 ±    38.474  MB/sec
GeneratorBench.linkmlFromSchemas:gc.alloc.rate.norm         cgmes-core.yml  thrpt    5   14877032.056 ±   795.340    B/op
GeneratorBench.linkmlFromSchemas:gc.count                   cgmes-core.yml  thrpt    5          6.000              counts
GeneratorBench.linkmlFromSchemas:gc.time                    cgmes-core.yml  thrpt    5         13.000                  ms
GeneratorBench.linkmlFromSchemas                        cgmes-dynamics.yml  thrpt    5         95.820 ±     1.691   ops/s
GeneratorBench.linkmlFromSchemas:gc.alloc.rate          cgmes-dynamics.yml  thrpt    5       3092.633 ±    54.669  MB/sec
GeneratorBench.linkmlFromSchemas:gc.alloc.rate.norm     cgmes-dynamics.yml  thrpt    5   33848127.481 ±   337.848    B/op
GeneratorBench.linkmlFromSchemas:gc.count               cgmes-dynamics.yml  thrpt    5          6.000              counts
GeneratorBench.linkmlFromSchemas:gc.time                cgmes-dynamics.yml  thrpt    5         13.000                  ms
GeneratorBench.linkmlFromSchemas                               TC57CIM.yml  thrpt    5          7.226 ±     0.140   ops/s
GeneratorBench.linkmlFromSchemas:gc.alloc.rate                 TC57CIM.yml  thrpt    5       1440.209 ±    27.968  MB/sec
GeneratorBench.linkmlFromSchemas:gc.alloc.rate.norm            TC57CIM.yml  thrpt    5  209024616.000 ± 17590.179    B/op
GeneratorBench.linkmlFromSchemas:gc.count                      TC57CIM.yml  thrpt    5          3.000              counts
GeneratorBench.linkmlFromSchemas:gc.time                       TC57CIM.yml  thrpt    5          9.000                  ms
GeneratorBench.linkmlFromYaml                               cgmes-core.yml  thrpt    5        131.801 ±     2.121   ops/s
GeneratorBench.linkmlFromYaml:gc.alloc.rate                 cgmes-core.yml  thrpt    5       2769.089 ±    44.588  MB/sec
GeneratorBench.linkmlFromYaml:gc.alloc.rate.norm            cgmes-core.yml  thrpt    5   22033325.485 ±  1712.243    B/op
GeneratorBench.linkmlFromYaml:gc.count                      cgmes-core.yml  thrpt    5          6.000              counts
GeneratorBench.linkmlFromYaml:gc.time                       cgmes-core.yml  thrpt    5         16.000                  ms
GeneratorBench.linkmlFromYaml                           cgmes-dynamics.yml  thrpt    5         39.317 ±     0.967   ops/s
GeneratorBench.linkmlFromYaml:gc.alloc.rate             cgmes-dynamics.yml  thrpt    5       2408.886 ±    59.146  MB/sec
GeneratorBench.linkmlFromYaml:gc.alloc.rate.norm        cgmes-dynamics.yml  thrpt    5   64252406.800 ±  7949.759    B/op
GeneratorBench.linkmlFromYaml:gc.count                  cgmes-dynamics.yml  thrpt    5          6.000              counts
GeneratorBench.linkmlFromYaml:gc.time                   cgmes-dynamics.yml  thrpt    5         17.000                  ms
GeneratorBench.linkmlFromYaml                                  TC57CIM.yml  thrpt    5          4.801 ±     0.172   ops/s
GeneratorBench.linkmlFromYaml:gc.alloc.rate                    TC57CIM.yml  thrpt    5       1467.811 ±    52.572  MB/sec
GeneratorBench.linkmlFromYaml:gc.alloc.rate.norm               TC57CIM.yml  thrpt    5  320605291.840 ±  4830.510    B/op
GeneratorBench.linkmlFromYaml:gc.count                         TC57CIM.yml  thrpt    5          3.000              counts
GeneratorBench.linkmlFromYaml:gc.time                          TC57CIM.yml  thrpt    5         21.000                  ms
```