### PR TITLE
LNK-149 More efficient calculation of closure for sets and reachability queries

### DIFF
--- a/generator/test/src-jvm/eu/neverblink/linkml/generator/graphql/GraphQlGeneratorSyntaxSpec.scala
+++ b/generator/test/src-jvm/eu/neverblink/linkml/generator/graphql/GraphQlGeneratorSyntaxSpec.scala
@@ -13,7 +13,7 @@ class GraphQlGeneratorSyntaxSpec extends AnyWordSpec, Matchers, ModelCatalogueSp
   )
 
   // dummy query object to make the generated types a valid graphql schema
-  val dummyQuery =
+  val dummyQuery: String =
     """type Query {
       |  test: String
       |}

--- a/schemaview/src/eu/neverblink/linkml/schemaview/Closure.scala
+++ b/schemaview/src/eu/neverblink/linkml/schemaview/Closure.scala
@@ -46,9 +46,7 @@ object Closure {
 
   /** Computes the irreflexive transitive closure starting from a single node.
     *
-    * In an irreflexive closure, the `start` node is NOT automatically included in the result. It
-    * will only be present in the output if it is reachable via a cycle (i.e., another node points
-    * back to it).
+    * In an irreflexive closure, the `start` node will not be included in the result.
     *
     * @tparam T
     *   The type of the nodes in the graph.
@@ -103,6 +101,8 @@ object Closure {
     * `HashSet` to track visited nodes. For all other builder types, it falls back to an O(N)
     * `ArrayBuffer` for visited checks to strictly preserve insertion order/duplicates based on the
     * builder's semantics.
+    *
+    * In an irreflexive closure, the `start` node will not be included in the result.
     *
     * @tparam T
     *   The type of the nodes in the graph.

--- a/schemaview/src/eu/neverblink/linkml/schemaview/Closure.scala
+++ b/schemaview/src/eu/neverblink/linkml/schemaview/Closure.scala
@@ -2,46 +2,171 @@ package eu.neverblink.linkml.schemaview
 
 import scala.collection.mutable
 
+/** Utility object for computing the transitive closure of a directed graph or hierarchical data
+  * structure.
+  *
+  * A transitive closure traverses all reachable nodes starting from a given node (or set of nodes)
+  * using a provided edge-generator function. This implementation is safe for cyclic graphs, as it
+  * internally tracks visited nodes to prevent infinite loops.
+  *
+  * The traversal is performed using a Depth-First Search (DFS) strategy.
+  */
 object Closure {
+
+  /** Computes the reflexive transitive closure starting from a single node.
+    *
+    * In a reflexive closure, the `start` node is always included in the result, regardless of
+    * whether it has any incoming edges.
+    *
+    * @tparam T
+    *   The type of the nodes in the graph.
+    * @param start
+    *   The initial node to start the traversal from.
+    * @param function
+    *   A generator function that takes a node and returns an `Iterable` of its immediate neighbors.
+    * @return
+    *   An `Iterable` containing the `start` node and all nodes reachable from it.
+    */
   def reflexive[T](start: T, function: T => Iterable[T]): Iterable[T] =
     get(Seq(start), function, reflexive = true)
 
+  /** Computes the reflexive transitive closure starting from multiple nodes.
+    *
+    * @tparam T
+    *   The type of the nodes in the graph.
+    * @param start
+    *   A collection of initial nodes to start the traversal from.
+    * @param function
+    *   A generator function that takes a node and returns an `Iterable` of its immediate neighbors.
+    * @return
+    *   An `Iterable` containing all `start` nodes and all nodes reachable from them.
+    */
   def reflexive[T](start: Iterable[T], function: T => Iterable[T]): Iterable[T] =
     get(start, function, reflexive = true)
 
+  /** Computes the irreflexive transitive closure starting from a single node.
+    *
+    * In an irreflexive closure, the `start` node is NOT automatically included in the result. It
+    * will only be present in the output if it is reachable via a cycle (i.e., another node points
+    * back to it).
+    *
+    * @tparam T
+    *   The type of the nodes in the graph.
+    * @param start
+    *   The initial node to start the traversal from.
+    * @param function
+    *   A generator function that takes a node and returns an `Iterable` of its immediate neighbors.
+    * @return
+    *   An `Iterable` containing all nodes reachable from the `start` node (excluding `start`
+    *   itself, unless cyclical).
+    */
   def irreflexive[T](start: T, function: T => Iterable[T]): Iterable[T] =
     get(Seq(start), function, reflexive = false)
 
+  /** Computes the irreflexive transitive closure starting from multiple nodes.
+    *
+    * @tparam T
+    *   The type of the nodes in the graph.
+    * @param start
+    *   A collection of initial nodes to start the traversal from.
+    * @param function
+    *   A generator function that takes a node and returns an `Iterable` of its immediate neighbors.
+    * @return
+    *   An `Iterable` containing all nodes reachable from the `start` nodes.
+    */
   def irreflexive[T](start: Iterable[T], function: T => Iterable[T]): Iterable[T] =
     get(start, function, reflexive = false)
 
+  /** Computes the transitive closure starting from a single node, with a configurable reflexivity
+    * flag.
+    *
+    * @tparam T
+    *   The type of the nodes in the graph.
+    * @param start
+    *   The initial node to start the traversal from.
+    * @param function
+    *   A generator function that takes a node and returns an `Iterable` of its immediate neighbors.
+    * @param reflexive
+    *   If `true`, includes the `start` node in the result. If `false`, excludes it (unless
+    *   reachable via cycle).
+    * @return
+    *   An `Iterable` containing the computed closure.
+    */
   def get[T](start: T, function: T => Iterable[T], reflexive: Boolean): Iterable[T] =
     get(Seq(start), function, reflexive)
 
-  def get[T](
+  /** The core engine for computing the transitive closure, supporting custom output collection
+    * types.
+    *
+    * This method performs a Depth-First Search (DFS) using an `ArrayDeque` as a stack. It includes
+    * a performance optimization: if the provided `resultBuilder` is for a `Set`, it uses an O(1)
+    * `HashSet` to track visited nodes. For all other builder types, it falls back to an O(N)
+    * `ArrayBuffer` for visited checks to strictly preserve insertion order/duplicates based on the
+    * builder's semantics.
+    *
+    * @tparam T
+    *   The type of the nodes in the graph.
+    * @tparam C
+    *   The higher-kinded type of the resulting collection (e.g., `Vector`, `Set`, `List`).
+    * @param start
+    *   A collection of initial nodes to start the traversal from.
+    * @param function
+    *   A generator function that takes a node and returns an `Iterable` of its immediate neighbors.
+    * @param reflexive
+    *   If `true`, the `start` nodes are added to the result builder immediately.
+    * @param resultBuilder
+    *   A mutable builder used to construct the final output collection. Defaults to a `Vector`
+    *   builder.
+    * @return
+    *   The computed closure, packaged in the collection type `C[T]`.
+    */
+  def get[T, C[_]](
       start: Iterable[T],
       function: T => Iterable[T],
       reflexive: Boolean,
-  ): Iterable[T] = {
-    val ret = Vector.newBuilder[T]
-    val visited = mutable.ArrayBuffer.empty[T]
-    val todo = mutable.ArrayDeque.empty[T]
-    start.foreach { s =>
-      if (!visited.contains(s)) {
-        visited.addOne(s)
-        todo.addOne(s)
-        if (reflexive) ret.addOne(s)
-      }
-    }
-    while (todo.nonEmpty) {
-      function(todo.removeLast()).foreach { neighbor =>
-        if (!visited.contains(neighbor)) {
-          visited.addOne(neighbor)
-          todo.addOne(neighbor)
-          ret.addOne(neighbor)
+      resultBuilder: mutable.Builder[T, C[T]] = Vector.newBuilder[T],
+  ): C[T] = {
+    // Stack for Depth-First Search traversal
+    val todo = new mutable.ArrayDeque[T]
+    resultBuilder match {
+      case b if b.getClass.getSimpleName.contains("SetBuilder") =>
+        // Optimization: If the target collection is Set-based, we can use a fast HashSet for visited checks.
+        val visited = new mutable.HashSet[T]
+        start.foreach { s =>
+          if (visited.add(s)) {
+            todo.addOne(s)
+            if (reflexive) resultBuilder.addOne(s)
+          }
         }
-      }
+        while (todo.nonEmpty) {
+          function(todo.removeLast()).foreach { neighbor =>
+            if (visited.add(neighbor)) {
+              todo.addOne(neighbor)
+              resultBuilder.addOne(neighbor)
+            }
+          }
+        }
+      case _ =>
+        // Fallback: For sequence-based collections where order matters, use an ArrayBuffer.
+        // Note: `visited.contains` is O(N), which may impact performance on very large graphs.
+        val visited = new mutable.ArrayBuffer[T]
+        start.foreach { s =>
+          if (!visited.contains(s)) {
+            visited.addOne(s)
+            todo.addOne(s)
+            if (reflexive) resultBuilder.addOne(s)
+          }
+        }
+        while (todo.nonEmpty) {
+          function(todo.removeLast()).foreach { neighbor =>
+            if (!visited.contains(neighbor)) {
+              visited.addOne(neighbor)
+              todo.addOne(neighbor)
+              resultBuilder.addOne(neighbor)
+            }
+          }
+        }
     }
-    ret.result()
+    resultBuilder.result()
   }
 }

--- a/schemaview/src/eu/neverblink/linkml/schemaview/Closure.scala
+++ b/schemaview/src/eu/neverblink/linkml/schemaview/Closure.scala
@@ -98,8 +98,7 @@ object Closure {
     *
     * This method performs a Depth-First Search (DFS) using an `ArrayDeque` as a stack. It includes
     * a performance optimization: if the provided `useHashCode` is `true`, it uses an O(1) `HashSet`
-    * to track visited nodes. Otherwise, it falls back to an O(N) `ArrayBuffer` for visited checks
-    * to strictly preserve insertion order/duplicates based on the builder's semantics.
+    * to track visited nodes. Otherwise, it falls back to an O(N) `ArrayBuffer` for visited checks.
     *
     * In an irreflexive closure, the `start` node will not be included in the result.
     *

--- a/schemaview/src/eu/neverblink/linkml/schemaview/Closure.scala
+++ b/schemaview/src/eu/neverblink/linkml/schemaview/Closure.scala
@@ -97,10 +97,9 @@ object Closure {
     * types.
     *
     * This method performs a Depth-First Search (DFS) using an `ArrayDeque` as a stack. It includes
-    * a performance optimization: if the provided `resultBuilder` is for a `Set`, it uses an O(1)
-    * `HashSet` to track visited nodes. For all other builder types, it falls back to an O(N)
-    * `ArrayBuffer` for visited checks to strictly preserve insertion order/duplicates based on the
-    * builder's semantics.
+    * a performance optimization: if the provided `useHashCode` is `true`, it uses an O(1) `HashSet`
+    * to track visited nodes. Otherwise, it falls back to an O(N) `ArrayBuffer` for visited checks
+    * to strictly preserve insertion order/duplicates based on the builder's semantics.
     *
     * In an irreflexive closure, the `start` node will not be included in the result.
     *
@@ -117,6 +116,8 @@ object Closure {
     * @param resultBuilder
     *   A mutable builder used to construct the final output collection. Defaults to a `Vector`
     *   builder.
+    * @param useHashCode
+    *   A flag that allows using `hashCode` calls of `T` values for the performance optimization.
     * @return
     *   The computed closure, packaged in the collection type `C[T]`.
     */
@@ -125,47 +126,47 @@ object Closure {
       function: T => Iterable[T],
       reflexive: Boolean,
       resultBuilder: mutable.Builder[T, C[T]] = Vector.newBuilder[T],
+      useHashCode: Boolean = false,
   ): C[T] = {
     // Stack for Depth-First Search traversal
     val todo = new mutable.ArrayDeque[T]
-    resultBuilder match {
-      case b if b.getClass.getSimpleName.contains("SetBuilder") =>
-        // Optimization: If the target collection is Set-based, we can use a fast HashSet for visited checks.
-        val visited = new mutable.HashSet[T]
-        start.foreach { s =>
-          if (visited.add(s)) {
-            todo.addOne(s)
-            if (reflexive) resultBuilder.addOne(s)
+    if (useHashCode) {
+      // Optimization: If the target collection is Set-based, we can use a fast HashSet for visited checks.
+      val visited = new mutable.HashSet[T]
+      start.foreach { s =>
+        if (visited.add(s)) {
+          todo.addOne(s)
+          if (reflexive) resultBuilder.addOne(s)
+        }
+      }
+      while (todo.nonEmpty) {
+        function(todo.removeLast()).foreach { neighbor =>
+          if (visited.add(neighbor)) {
+            todo.addOne(neighbor)
+            resultBuilder.addOne(neighbor)
           }
         }
-        while (todo.nonEmpty) {
-          function(todo.removeLast()).foreach { neighbor =>
-            if (visited.add(neighbor)) {
-              todo.addOne(neighbor)
-              resultBuilder.addOne(neighbor)
-            }
+      }
+    } else {
+      // Fallback: For sequence-based collections where order matters, use an ArrayBuffer.
+      // Note: `visited.contains` is O(N), which may impact performance on very large graphs.
+      val visited = new mutable.ArrayBuffer[T]
+      start.foreach { s =>
+        if (!visited.contains(s)) {
+          visited.addOne(s)
+          todo.addOne(s)
+          if (reflexive) resultBuilder.addOne(s)
+        }
+      }
+      while (todo.nonEmpty) {
+        function(todo.removeLast()).foreach { neighbor =>
+          if (!visited.contains(neighbor)) {
+            visited.addOne(neighbor)
+            todo.addOne(neighbor)
+            resultBuilder.addOne(neighbor)
           }
         }
-      case _ =>
-        // Fallback: For sequence-based collections where order matters, use an ArrayBuffer.
-        // Note: `visited.contains` is O(N), which may impact performance on very large graphs.
-        val visited = new mutable.ArrayBuffer[T]
-        start.foreach { s =>
-          if (!visited.contains(s)) {
-            visited.addOne(s)
-            todo.addOne(s)
-            if (reflexive) resultBuilder.addOne(s)
-          }
-        }
-        while (todo.nonEmpty) {
-          function(todo.removeLast()).foreach { neighbor =>
-            if (!visited.contains(neighbor)) {
-              visited.addOne(neighbor)
-              todo.addOne(neighbor)
-              resultBuilder.addOne(neighbor)
-            }
-          }
-        }
+      }
     }
     resultBuilder.result()
   }

--- a/schemaview/src/eu/neverblink/linkml/schemaview/Closure.scala
+++ b/schemaview/src/eu/neverblink/linkml/schemaview/Closure.scala
@@ -131,7 +131,7 @@ object Closure {
     // Stack for Depth-First Search traversal
     val todo = new mutable.ArrayDeque[T]
     if (useHashCode) {
-      // Optimization: If the target collection is Set-based, we can use a fast HashSet for visited checks.
+      // Optimization: We can use a fast HashSet for visited checks.
       val visited = new mutable.HashSet[T]
       start.foreach { s =>
         if (visited.add(s)) {
@@ -148,7 +148,7 @@ object Closure {
         }
       }
     } else {
-      // Fallback: For sequence-based collections where order matters, use an ArrayBuffer.
+      // Fallback: Use an ArrayBuffer.
       // Note: `visited.contains` is O(N), which may impact performance on very large graphs.
       val visited = new mutable.ArrayBuffer[T]
       start.foreach { s =>

--- a/schemaview/src/eu/neverblink/linkml/schemaview/SchemaReachabilityQuery.scala
+++ b/schemaview/src/eu/neverblink/linkml/schemaview/SchemaReachabilityQuery.scala
@@ -102,20 +102,20 @@ final class DerivedReachabilityQuery(
         val type_ = sv.types(name)._type
         type_.typeof.foreach { t =>
           t.resolve match {
-            case Some(r) => result.addOne((typeDef, r.name))
+            case Some(td) => result.addOne((typeDef, td.name))
             case _ =>
           }
         }
         type_.unionOf.foreach { t =>
           t.resolve match {
-            case Some(r) => result.addOne((typeDef, r.name))
+            case Some(td) => result.addOne((typeDef, td.name))
             case _ =>
           }
         }
       case ElementTypeTag.enumDef =>
-        sv.enums(name)._enum.inherits.foreach { t =>
-          t.resolve match {
-            case Some(r) => result.addOne((enumDef, r.name))
+        sv.enums(name)._enum.inherits.foreach { e =>
+          e.resolve match {
+            case Some(ed) => result.addOne((enumDef, ed.name))
             case _ =>
           }
         }
@@ -192,9 +192,9 @@ final class UnderivedReachabilityQuery(
         }
         collectSlotRefs(slotView, result)
       case ElementTypeTag.enumDef =>
-        sv.enums(name)._enum.inherits.foreach { t =>
-          t.resolve match {
-            case Some(r) => result.addOne((enumDef, r.name))
+        sv.enums(name)._enum.inherits.foreach { e =>
+          e.resolve match {
+            case Some(ed) => result.addOne((enumDef, ed.name))
             case _ =>
           }
         }

--- a/schemaview/src/eu/neverblink/linkml/schemaview/SchemaReachabilityQuery.scala
+++ b/schemaview/src/eu/neverblink/linkml/schemaview/SchemaReachabilityQuery.scala
@@ -150,7 +150,7 @@ final class UnderivedReachabilityQuery(
       case ElementTypeTag.classDef =>
         val classView = sv.classes(name)
         classView.ancestors(reflexive = false).foreach { anc =>
-          result.addOne(classDef -> anc.cls.name)
+          result.addOne((classDef, anc.cls.name))
         }
         classView.cls.slots.foreach(slot => result.addOne(slotDef -> slot.value))
         // The *ranges* of class-defined slots (attributes, slot_usage)

--- a/schemaview/src/eu/neverblink/linkml/schemaview/SchemaReachabilityQuery.scala
+++ b/schemaview/src/eu/neverblink/linkml/schemaview/SchemaReachabilityQuery.scala
@@ -96,7 +96,7 @@ final class DerivedReachabilityQuery(
         val classView = sv.classes(name)
         classView.derivedAttributes.values.foreach {
           // if the classes are going to be derived, then we can simply skip to the ranges of derived attributes
-          case s if !inlinedOnly || s.derivedInlined => collectSlotRefs(s, result)
+          case sv if !inlinedOnly || sv.derivedInlined => collectSlotRefs(sv, result)
           case _ =>
         }
         if (includeClassAncestors) {
@@ -104,21 +104,21 @@ final class DerivedReachabilityQuery(
         }
       case ElementTypeTag.typeDef =>
         val type_ = sv.types(name)._type
-        type_.typeof.foreach { t =>
-          t.resolve match {
+        type_.typeof.foreach { tr =>
+          tr.resolve match {
             case Some(td) => result.addOne((typeDef, td.name))
             case _ =>
           }
         }
-        type_.unionOf.foreach { t =>
-          t.resolve match {
+        type_.unionOf.foreach { tr =>
+          tr.resolve match {
             case Some(td) => result.addOne((typeDef, td.name))
             case _ =>
           }
         }
       case ElementTypeTag.enumDef =>
-        sv.enums(name)._enum.inherits.foreach { e =>
-          e.resolve match {
+        sv.enums(name)._enum.inherits.foreach { er =>
+          er.resolve match {
             case Some(ed) => result.addOne((enumDef, ed.name))
             case _ =>
           }
@@ -160,7 +160,7 @@ final class UnderivedReachabilityQuery(
           result.addOne((classDef, anc.cls.name))
         }
         val cls = classView.cls
-        cls.slots.foreach(slot => result.addOne((slotDef, slot.value)))
+        cls.slots.foreach(sr => result.addOne((slotDef, sr.value)))
         // The *ranges* of class-defined slots (attributes, slot_usage)
         val definingSchema = classView.definingSchema
         cls.attributes.values.foreach { sd =>
@@ -171,36 +171,36 @@ final class UnderivedReachabilityQuery(
         }
       case ElementTypeTag.typeDef =>
         val type_ = sv.types(name)._type
-        type_.typeof.foreach { t =>
-          t.resolve match {
+        type_.typeof.foreach { tr =>
+          tr.resolve match {
             case Some(td) => result.addOne((typeDef, td.name))
             case _ =>
           }
         }
-        type_.unionOf.foreach { t =>
-          t.resolve match {
+        type_.unionOf.foreach { tr =>
+          tr.resolve match {
             case Some(td) => result.addOne((typeDef, td.name))
             case _ =>
           }
         }
       case ElementTypeTag.slotDef =>
         val slotView = sv.slotDefinitions(name)
-        slotView.slot.isA.foreach { s =>
-          s.resolve match {
+        slotView.slot.isA.foreach { sr =>
+          sr.resolve match {
             case Some(sd) => result.addOne((slotDef, sd.name))
             case _ =>
           }
         }
-        slotView.slot.mixins.foreach { s =>
-          s.resolve match {
+        slotView.slot.mixins.foreach { sr =>
+          sr.resolve match {
             case Some(sd) => result.addOne((slotDef, sd.name))
             case _ =>
           }
         }
         collectSlotRefs(slotView, result)
       case ElementTypeTag.enumDef =>
-        sv.enums(name)._enum.inherits.foreach { e =>
-          e.resolve match {
+        sv.enums(name)._enum.inherits.foreach { er =>
+          er.resolve match {
             case Some(ed) => result.addOne((enumDef, ed.name))
             case _ =>
           }

--- a/schemaview/src/eu/neverblink/linkml/schemaview/SchemaReachabilityQuery.scala
+++ b/schemaview/src/eu/neverblink/linkml/schemaview/SchemaReachabilityQuery.scala
@@ -75,10 +75,13 @@ final class DerivedReachabilityQuery(
 )(using sv: SchemaView)
     extends SchemaReachabilityQuery {
 
-  protected lazy val resolved: Set[TaggedReference] = {
-    val start = from.map(ev => ElementTypeTag(ev.inner) -> ev.inner.name)
-    Closure.get(start, walk, true, Set.newBuilder[TaggedReference])
-  }
+  protected lazy val resolved: Set[TaggedReference] = Closure.get(
+    start = from.map(ev => (ElementTypeTag(ev.inner), ev.inner.name)),
+    function = walk,
+    reflexive = true,
+    resultBuilder = Set.newBuilder[TaggedReference],
+    useHashCode = true,
+  )
 
   private def walk(current: TaggedReference): Iterable[TaggedReference] = {
     val tag = current.tag
@@ -131,10 +134,13 @@ final class UnderivedReachabilityQuery(
 )(using sv: SchemaView)
     extends SchemaReachabilityQuery {
 
-  protected lazy val resolved: Set[TaggedReference] = {
-    val start = from.map(ev => ElementTypeTag(ev.inner) -> ev.inner.name)
-    Closure.get(start, walk, true, Set.newBuilder[TaggedReference])
-  }
+  protected lazy val resolved: Set[TaggedReference] = Closure.get(
+    start = from.map(ev => (ElementTypeTag(ev.inner), ev.inner.name)),
+    function = walk,
+    reflexive = true,
+    resultBuilder = Set.newBuilder[TaggedReference],
+    useHashCode = true,
+  )
 
   private def walk(current: TaggedReference): Iterable[TaggedReference] =
     val tag = current.tag

--- a/schemaview/src/eu/neverblink/linkml/schemaview/SchemaReachabilityQuery.scala
+++ b/schemaview/src/eu/neverblink/linkml/schemaview/SchemaReachabilityQuery.scala
@@ -4,6 +4,8 @@ import eu.neverblink.linkml.metamodel.*
 import SchemaReachabilityQuery.*
 import ElementTypeTag.*
 
+import scala.collection.mutable
+
 /** Base class for LinkML schema reachability queries. Provides information about whether metamodel
   * [[Element]]s should are reachable in some way, specified by concrete implementations.
   * @todo
@@ -29,13 +31,23 @@ sealed abstract class SchemaReachabilityQuery(using sv: SchemaView) {
     */
   protected lazy val resolved: Set[TaggedReference]
 
-  /** Shared method for computing the [[TaggedReference]]s for a slot's range/domains.
+  /** Shared method for collecting the [[TaggedReference]]s for a slot's range/domains.
     */
-  protected def slotRefs(slot: SlotView): Iterable[TaggedReference] = {
-    val booleanSlots = slot.slot.anyOf.flatMap(_.range.flatMap(_.resolve))
-    val mainRange: Option[Element] = slot.derivedRange.resolve.map(_.inner)
-    val blep = slot.slot.domain.flatMap(_.resolve)
-    (booleanSlots ++ mainRange ++ blep).map(el => ElementTypeTag(el) -> el.name)
+  protected def collectSlotRefs(
+      slot: SlotView,
+      results: mutable.ArrayBuffer[TaggedReference],
+  ): Unit = {
+    slot.slot.anyOf.foreach { anyOfNode =>
+      anyOfNode.range.foreach { rangeNode =>
+        rangeNode.resolve.foreach(el => results.addOne((ElementTypeTag(el), el.name)))
+      }
+    }
+    slot.derivedRange.resolve.foreach { resolvedRange =>
+      results.addOne((ElementTypeTag(resolvedRange.inner), resolvedRange.inner.name))
+    }
+    slot.slot.domain.foreach { domainNode =>
+      domainNode.resolve.foreach(el => results.addOne((ElementTypeTag(el), el.name)))
+    }
   }
 }
 
@@ -64,36 +76,49 @@ final class DerivedReachabilityQuery(
     extends SchemaReachabilityQuery {
 
   protected lazy val resolved: Set[TaggedReference] = {
-    val start: Seq[TaggedReference] = from.map(ev => ElementTypeTag(ev.inner) -> ev.inner.name)
-    Closure.reflexive(start, walk).toSet
+    val start = from.map(ev => ElementTypeTag(ev.inner) -> ev.inner.name)
+    Closure.get(start, walk, true, Set.newBuilder[TaggedReference])
   }
 
   private def walk(current: TaggedReference): Iterable[TaggedReference] = {
-    val (tag, name) = current
-    val res: Iterable[TaggedReference] = tag match {
+    val tag = current.tag
+    val name = current.value
+    val result = new mutable.ArrayBuffer[TaggedReference]
+    tag match {
       case ElementTypeTag.classDef =>
         val classView = sv.classes(name)
-        classView.derivedAttributes.values.flatMap {
+        classView.derivedAttributes.values.foreach {
           // if the classes are going to be derived, then we can simply skip to the ranges of derived attributes
-          case s if !inlinedOnly || s.derivedInlined => slotRefs(s)
-          case _ => None
-        } ++ (
-          if includeClassAncestors
-          then classView.parents.map(classDef -> _.name)
-          else Seq()
-        )
+          case s if !inlinedOnly || s.derivedInlined => collectSlotRefs(s, result)
+          case _ =>
+        }
+        if (includeClassAncestors) {
+          classView.parents.foreach(anc => result.addOne((classDef, anc.name)))
+        }
       case ElementTypeTag.typeDef =>
-        val typeView = sv.types(name)
-        (typeView._type.typeof ++ typeView._type.unionOf)
-          .flatMap(_.resolve)
-          .map(typeDef -> _.name)
-      case ElementTypeTag.slotDef =>
-        None // this should not happen
+        val type_ = sv.types(name)._type
+        type_.typeof.foreach { t =>
+          t.resolve match {
+            case Some(r) => result.addOne((typeDef, r.name))
+            case _ =>
+          }
+        }
+        type_.unionOf.foreach { t =>
+          t.resolve match {
+            case Some(r) => result.addOne((typeDef, r.name))
+            case _ =>
+          }
+        }
       case ElementTypeTag.enumDef =>
-        sv.enums(name)._enum.inherits.flatMap(_.resolve).map(enumDef -> _.name)
-      case _ => None
+        sv.enums(name)._enum.inherits.foreach { t =>
+          t.resolve match {
+            case Some(r) => result.addOne((enumDef, r.name))
+            case _ =>
+          }
+        }
+      case _ =>
     }
-    res
+    result
   }
 }
 
@@ -107,38 +132,67 @@ final class UnderivedReachabilityQuery(
     extends SchemaReachabilityQuery {
 
   protected lazy val resolved: Set[TaggedReference] = {
-    val start: Seq[TaggedReference] = from.map(ev => ElementTypeTag(ev.inner) -> ev.inner.name)
-    Closure.reflexive(start, walk).toSet
+    val start = from.map(ev => ElementTypeTag(ev.inner) -> ev.inner.name)
+    Closure.get(start, walk, true, Set.newBuilder[TaggedReference])
   }
 
   private def walk(current: TaggedReference): Iterable[TaggedReference] =
-    val (typeTag, name) = current
-    typeTag match {
+    val tag = current.tag
+    val name = current.value
+    val result = new mutable.ArrayBuffer[TaggedReference]
+    tag match {
       case ElementTypeTag.classDef =>
         val classView = sv.classes(name)
-        val inheritance = classView.ancestors(reflexive = false).map(classDef -> _.cls.name)
-        val referencedSlots = classView.cls.slots.map(slotDef -> _.value)
+        classView.ancestors(reflexive = false).foreach { anc =>
+          result.addOne(classDef -> anc.cls.name)
+        }
+        classView.cls.slots.foreach(slot => result.addOne(slotDef -> slot.value))
         // The *ranges* of class-defined slots (attributes, slot_usage)
-        val classDefinedSlots =
-          (classView.cls.attributes.values ++ classView.cls.slotUsage.values)
-            .flatMap(sd => slotRefs(SlotView(sd, classView.definingSchema)))
-        inheritance ++ referencedSlots ++ classDefinedSlots
+        classView.cls.attributes.values.foreach { sd =>
+          collectSlotRefs(SlotView(sd, classView.definingSchema), result)
+        }
+        classView.cls.slotUsage.values.foreach { sd =>
+          collectSlotRefs(SlotView(sd, classView.definingSchema), result)
+        }
       case ElementTypeTag.typeDef =>
-        val typeView = sv.types(name)
-        (typeView._type.typeof ++ typeView._type.unionOf)
-          .flatMap(_.resolve)
-          .map(typeDef -> _.name)
+        val type_ = sv.types(name)._type
+        type_.typeof.foreach { t =>
+          t.resolve match {
+            case Some(td) => result.addOne((typeDef, td.name))
+            case _ =>
+          }
+        }
+        type_.unionOf.foreach { t =>
+          t.resolve match {
+            case Some(td) => result.addOne((typeDef, td.name))
+            case _ =>
+          }
+        }
       case ElementTypeTag.slotDef =>
         val slotView = sv.slotDefinitions(name)
-        val inheritance = slotView.slot.isA ++ slotView.slot.mixins
-        val ranges = slotRefs(slotView)
-        inheritance
-          .flatMap(_.resolve)
-          .map(el => ElementTypeTag(el) -> el.name) ++ ranges
+        slotView.slot.isA.foreach { s =>
+          s.resolve match {
+            case Some(sd) => result.addOne((slotDef, sd.name))
+            case _ =>
+          }
+        }
+        slotView.slot.mixins.foreach { s =>
+          s.resolve match {
+            case Some(sd) => result.addOne((slotDef, sd.name))
+            case _ =>
+          }
+        }
+        collectSlotRefs(slotView, result)
       case ElementTypeTag.enumDef =>
-        sv.enums(name)._enum.inherits.flatMap(_.resolve).map(enumDef -> _.name)
-      case _ => None
+        sv.enums(name)._enum.inherits.foreach { t =>
+          t.resolve match {
+            case Some(r) => result.addOne((enumDef, r.name))
+            case _ =>
+          }
+        }
+      case _ =>
     }
+    result
 }
 
 private object SchemaReachabilityQuery {

--- a/schemaview/src/eu/neverblink/linkml/schemaview/SchemaReachabilityQuery.scala
+++ b/schemaview/src/eu/neverblink/linkml/schemaview/SchemaReachabilityQuery.scala
@@ -152,13 +152,15 @@ final class UnderivedReachabilityQuery(
         classView.ancestors(reflexive = false).foreach { anc =>
           result.addOne((classDef, anc.cls.name))
         }
-        classView.cls.slots.foreach(slot => result.addOne(slotDef -> slot.value))
+        val cls = classView.cls
+        cls.slots.foreach(slot => result.addOne(slotDef -> slot.value))
         // The *ranges* of class-defined slots (attributes, slot_usage)
-        classView.cls.attributes.values.foreach { sd =>
-          collectSlotRefs(SlotView(sd, classView.definingSchema), result)
+        val definingSchema = classView.definingSchema
+        cls.attributes.values.foreach { sd =>
+          collectSlotRefs(SlotView(sd, definingSchema), result)
         }
-        classView.cls.slotUsage.values.foreach { sd =>
-          collectSlotRefs(SlotView(sd, classView.definingSchema), result)
+        cls.slotUsage.values.foreach { sd =>
+          collectSlotRefs(SlotView(sd, definingSchema), result)
         }
       case ElementTypeTag.typeDef =>
         val type_ = sv.types(name)._type

--- a/schemaview/src/eu/neverblink/linkml/schemaview/SchemaReachabilityQuery.scala
+++ b/schemaview/src/eu/neverblink/linkml/schemaview/SchemaReachabilityQuery.scala
@@ -43,7 +43,8 @@ sealed abstract class SchemaReachabilityQuery(using sv: SchemaView) {
       }
     }
     slot.derivedRange.resolve.foreach { resolvedRange =>
-      results.addOne((ElementTypeTag(resolvedRange.inner), resolvedRange.inner.name))
+      val el = resolvedRange.inner
+      results.addOne((ElementTypeTag(el), el.name))
     }
     slot.slot.domain.foreach { domainNode =>
       domainNode.resolve.foreach(el => results.addOne((ElementTypeTag(el), el.name)))
@@ -76,7 +77,10 @@ final class DerivedReachabilityQuery(
     extends SchemaReachabilityQuery {
 
   protected lazy val resolved: Set[TaggedReference] = Closure.get(
-    start = from.map(ev => (ElementTypeTag(ev.inner), ev.inner.name)),
+    start = from.map { ev =>
+      val el = ev.inner
+      (ElementTypeTag(el), el.name)
+    },
     function = walk,
     reflexive = true,
     resultBuilder = Set.newBuilder[TaggedReference],
@@ -135,7 +139,10 @@ final class UnderivedReachabilityQuery(
     extends SchemaReachabilityQuery {
 
   protected lazy val resolved: Set[TaggedReference] = Closure.get(
-    start = from.map(ev => (ElementTypeTag(ev.inner), ev.inner.name)),
+    start = from.map { ev =>
+      val el = ev.inner
+      (ElementTypeTag(el), el.name)
+    },
     function = walk,
     reflexive = true,
     resultBuilder = Set.newBuilder[TaggedReference],
@@ -153,7 +160,7 @@ final class UnderivedReachabilityQuery(
           result.addOne((classDef, anc.cls.name))
         }
         val cls = classView.cls
-        cls.slots.foreach(slot => result.addOne(slotDef -> slot.value))
+        cls.slots.foreach(slot => result.addOne((slotDef, slot.value)))
         // The *ranges* of class-defined slots (attributes, slot_usage)
         val definingSchema = classView.definingSchema
         cls.attributes.values.foreach { sd =>


### PR DESCRIPTION
It speeds up LinkML generation even more, below are result comparison with JDK 25 on MacBook.

Before:
```txt
Benchmark                                                         (schema)   Mode  Cnt          Score       Error   Units
GeneratorBench.linkmlFromSchemaView                         cgmes-core.yml  thrpt    5        295.952 ±     2.100   ops/s
GeneratorBench.linkmlFromSchemaView:gc.alloc.rate           cgmes-core.yml  thrpt    5       3067.487 ±    21.393  MB/sec
GeneratorBench.linkmlFromSchemaView:gc.alloc.rate.norm      cgmes-core.yml  thrpt    5   10869874.472 ±     1.368    B/op
GeneratorBench.linkmlFromSchemaView:gc.count                cgmes-core.yml  thrpt    5          6.000              counts
GeneratorBench.linkmlFromSchemaView:gc.time                 cgmes-core.yml  thrpt    5         11.000                  ms
GeneratorBench.linkmlFromSchemaView                     cgmes-dynamics.yml  thrpt    5        138.611 ±     2.577   ops/s
GeneratorBench.linkmlFromSchemaView:gc.alloc.rate       cgmes-dynamics.yml  thrpt    5       3255.858 ±    60.727  MB/sec
GeneratorBench.linkmlFromSchemaView:gc.alloc.rate.norm  cgmes-dynamics.yml  thrpt    5   24633987.818 ±   212.828    B/op
GeneratorBench.linkmlFromSchemaView:gc.count            cgmes-dynamics.yml  thrpt    5          7.000              counts
GeneratorBench.linkmlFromSchemaView:gc.time             cgmes-dynamics.yml  thrpt    5         17.000                  ms
GeneratorBench.linkmlFromSchemaView                            TC57CIM.yml  thrpt    5          8.694 ±     0.196   ops/s
GeneratorBench.linkmlFromSchemaView:gc.alloc.rate              TC57CIM.yml  thrpt    5       1243.106 ±    27.969  MB/sec
GeneratorBench.linkmlFromSchemaView:gc.alloc.rate.norm         TC57CIM.yml  thrpt    5  149943539.378 ± 12740.015    B/op
GeneratorBench.linkmlFromSchemaView:gc.count                   TC57CIM.yml  thrpt    5          3.000              counts
GeneratorBench.linkmlFromSchemaView:gc.time                    TC57CIM.yml  thrpt    5         20.000                  ms
GeneratorBench.linkmlFromSchemas                            cgmes-core.yml  thrpt    5        214.684 ±     4.391   ops/s
GeneratorBench.linkmlFromSchemas:gc.alloc.rate              cgmes-core.yml  thrpt    5       3045.778 ±    62.164  MB/sec
GeneratorBench.linkmlFromSchemas:gc.alloc.rate.norm         cgmes-core.yml  thrpt    5   14878494.584 ±   827.871    B/op
GeneratorBench.linkmlFromSchemas:gc.count                   cgmes-core.yml  thrpt    5          6.000              counts
GeneratorBench.linkmlFromSchemas:gc.time                    cgmes-core.yml  thrpt    5         12.000                  ms
GeneratorBench.linkmlFromSchemas                        cgmes-dynamics.yml  thrpt    5         94.200 ±     4.499   ops/s
GeneratorBench.linkmlFromSchemas:gc.alloc.rate          cgmes-dynamics.yml  thrpt    5       3025.585 ±   144.386  MB/sec
GeneratorBench.linkmlFromSchemas:gc.alloc.rate.norm     cgmes-dynamics.yml  thrpt    5   33683066.052 ±   375.441    B/op
GeneratorBench.linkmlFromSchemas:gc.count               cgmes-dynamics.yml  thrpt    5          6.000              counts
GeneratorBench.linkmlFromSchemas:gc.time                cgmes-dynamics.yml  thrpt    5         13.000                  ms
GeneratorBench.linkmlFromSchemas                               TC57CIM.yml  thrpt    5          7.158 ±     0.259   ops/s
GeneratorBench.linkmlFromSchemas:gc.alloc.rate                 TC57CIM.yml  thrpt    5       1426.739 ±    51.540  MB/sec
GeneratorBench.linkmlFromSchemas:gc.alloc.rate.norm            TC57CIM.yml  thrpt    5  209013654.400 ± 18903.002    B/op
GeneratorBench.linkmlFromSchemas:gc.count                      TC57CIM.yml  thrpt    5          3.000              counts
GeneratorBench.linkmlFromSchemas:gc.time                       TC57CIM.yml  thrpt    5          9.000                  ms
GeneratorBench.linkmlFromYaml                               cgmes-core.yml  thrpt    5        131.475 ±     3.289   ops/s
GeneratorBench.linkmlFromYaml:gc.alloc.rate                 cgmes-core.yml  thrpt    5       2761.173 ±    68.931  MB/sec
GeneratorBench.linkmlFromYaml:gc.alloc.rate.norm            cgmes-core.yml  thrpt    5   22024926.505 ±  1440.038    B/op
GeneratorBench.linkmlFromYaml:gc.count                      cgmes-core.yml  thrpt    5          6.000              counts
GeneratorBench.linkmlFromYaml:gc.time                       cgmes-core.yml  thrpt    5         13.000                  ms
GeneratorBench.linkmlFromYaml                           cgmes-dynamics.yml  thrpt    5         39.138 ±     0.761   ops/s
GeneratorBench.linkmlFromYaml:gc.alloc.rate             cgmes-dynamics.yml  thrpt    5       2397.975 ±    46.362  MB/sec
GeneratorBench.linkmlFromYaml:gc.alloc.rate.norm        cgmes-dynamics.yml  thrpt    5   64254341.234 ±  8447.622    B/op
GeneratorBench.linkmlFromYaml:gc.count                  cgmes-dynamics.yml  thrpt    5          6.000              counts
GeneratorBench.linkmlFromYaml:gc.time                   cgmes-dynamics.yml  thrpt    5         13.000                  ms
GeneratorBench.linkmlFromYaml                                  TC57CIM.yml  thrpt    5          4.794 ±     0.179   ops/s
GeneratorBench.linkmlFromYaml:gc.alloc.rate                    TC57CIM.yml  thrpt    5       1465.688 ±    54.812  MB/sec
GeneratorBench.linkmlFromYaml:gc.alloc.rate.norm               TC57CIM.yml  thrpt    5  320591659.840 ±  4830.510    B/op
GeneratorBench.linkmlFromYaml:gc.count                         TC57CIM.yml  thrpt    5          3.000              counts
GeneratorBench.linkmlFromYaml:gc.time                          TC57CIM.yml  thrpt    5         21.000                  ms
```

After:
```txt
Benchmark                                                         (schema)   Mode  Cnt          Score       Error   Units
GeneratorBench.linkmlFromSchemaView                         cgmes-core.yml  thrpt    5        383.667 ±     4.657   ops/s
GeneratorBench.linkmlFromSchemaView:gc.alloc.rate           cgmes-core.yml  thrpt    5       3825.386 ±    46.433  MB/sec
GeneratorBench.linkmlFromSchemaView:gc.alloc.rate.norm      cgmes-core.yml  thrpt    5   10456222.746 ±     1.755    B/op
GeneratorBench.linkmlFromSchemaView:gc.count                cgmes-core.yml  thrpt    5          9.000              counts
GeneratorBench.linkmlFromSchemaView:gc.time                 cgmes-core.yml  thrpt    5         18.000                  ms
GeneratorBench.linkmlFromSchemaView                     cgmes-dynamics.yml  thrpt    5        178.983 ±     4.185   ops/s
GeneratorBench.linkmlFromSchemaView:gc.alloc.rate       cgmes-dynamics.yml  thrpt    5       4035.654 ±    94.661  MB/sec
GeneratorBench.linkmlFromSchemaView:gc.alloc.rate.norm  cgmes-dynamics.yml  thrpt    5   23646115.925 ±   484.801    B/op
GeneratorBench.linkmlFromSchemaView:gc.count            cgmes-dynamics.yml  thrpt    5          9.000              counts
GeneratorBench.linkmlFromSchemaView:gc.time             cgmes-dynamics.yml  thrpt    5         29.000                  ms
GeneratorBench.linkmlFromSchemaView                            TC57CIM.yml  thrpt    5         21.845 ±     0.332   ops/s
GeneratorBench.linkmlFromSchemaView:gc.alloc.rate              TC57CIM.yml  thrpt    5       2994.384 ±    45.646  MB/sec
GeneratorBench.linkmlFromSchemaView:gc.alloc.rate.norm         TC57CIM.yml  thrpt    5  143750376.215 ±   262.269    B/op
GeneratorBench.linkmlFromSchemaView:gc.count                   TC57CIM.yml  thrpt    5          6.000              counts
GeneratorBench.linkmlFromSchemaView:gc.time                    TC57CIM.yml  thrpt    5         30.000                  ms
GeneratorBench.linkmlFromSchemas                            cgmes-core.yml  thrpt    5        263.132 ±     2.063   ops/s
GeneratorBench.linkmlFromSchemas:gc.alloc.rate              cgmes-core.yml  thrpt    5       3587.183 ±    28.206  MB/sec
GeneratorBench.linkmlFromSchemas:gc.alloc.rate.norm         cgmes-core.yml  thrpt    5   14296631.765 ±   227.026    B/op
GeneratorBench.linkmlFromSchemas:gc.count                   cgmes-core.yml  thrpt    5          8.000              counts
GeneratorBench.linkmlFromSchemas:gc.time                    cgmes-core.yml  thrpt    5         18.000                  ms
GeneratorBench.linkmlFromSchemas                        cgmes-dynamics.yml  thrpt    5        112.454 ±     1.229   ops/s
GeneratorBench.linkmlFromSchemas:gc.alloc.rate          cgmes-dynamics.yml  thrpt    5       3503.780 ±    38.204  MB/sec
GeneratorBench.linkmlFromSchemas:gc.alloc.rate.norm     cgmes-dynamics.yml  thrpt    5   32674769.554 ±     2.208    B/op
GeneratorBench.linkmlFromSchemas:gc.count               cgmes-dynamics.yml  thrpt    5          8.000              counts
GeneratorBench.linkmlFromSchemas:gc.time                cgmes-dynamics.yml  thrpt    5         21.000                  ms
GeneratorBench.linkmlFromSchemas                               TC57CIM.yml  thrpt    5         14.329 ±     0.358   ops/s
GeneratorBench.linkmlFromSchemas:gc.alloc.rate                 TC57CIM.yml  thrpt    5       2770.949 ±    69.764  MB/sec
GeneratorBench.linkmlFromSchemas:gc.alloc.rate.norm            TC57CIM.yml  thrpt    5  202809011.413 ± 23362.304    B/op
GeneratorBench.linkmlFromSchemas:gc.count                      TC57CIM.yml  thrpt    5          7.000              counts
GeneratorBench.linkmlFromSchemas:gc.time                       TC57CIM.yml  thrpt    5         27.000                  ms
GeneratorBench.linkmlFromYaml                               cgmes-core.yml  thrpt    5        144.952 ±     2.547   ops/s
GeneratorBench.linkmlFromYaml:gc.alloc.rate                 cgmes-core.yml  thrpt    5       2949.718 ±    51.673  MB/sec
GeneratorBench.linkmlFromYaml:gc.alloc.rate.norm            cgmes-core.yml  thrpt    5   21340749.739 ±  1522.684    B/op
GeneratorBench.linkmlFromYaml:gc.count                      cgmes-core.yml  thrpt    5          7.000              counts
GeneratorBench.linkmlFromYaml:gc.time                       cgmes-core.yml  thrpt    5         17.000                  ms
GeneratorBench.linkmlFromYaml                           cgmes-dynamics.yml  thrpt    5         41.603 ±     1.835   ops/s
GeneratorBench.linkmlFromYaml:gc.alloc.rate             cgmes-dynamics.yml  thrpt    5       2508.421 ±   110.251  MB/sec
GeneratorBench.linkmlFromYaml:gc.alloc.rate.norm        cgmes-dynamics.yml  thrpt    5   63231270.239 ± 13861.967    B/op
GeneratorBench.linkmlFromYaml:gc.count                  cgmes-dynamics.yml  thrpt    5          5.000              counts
GeneratorBench.linkmlFromYaml:gc.time                   cgmes-dynamics.yml  thrpt    5         26.000                  ms
GeneratorBench.linkmlFromYaml                                  TC57CIM.yml  thrpt    5          7.231 ±     0.081   ops/s
GeneratorBench.linkmlFromYaml:gc.alloc.rate                    TC57CIM.yml  thrpt    5       2169.052 ±    24.272  MB/sec
GeneratorBench.linkmlFromYaml:gc.alloc.rate.norm               TC57CIM.yml  thrpt    5  314570848.400 ±  9598.225    B/op
GeneratorBench.linkmlFromYaml:gc.count                         TC57CIM.yml  thrpt    5          6.000              counts
GeneratorBench.linkmlFromYaml:gc.time                          TC57CIM.yml  thrpt    5         18.000                  ms
```