### PR TITLE
ifabsent implementation for enums

### DIFF
--- a/build.mill
+++ b/build.mill
@@ -231,6 +231,7 @@ object generator extends Module {
         mvn"com.softwaremill.sttp.apispec::jsonschema-circe::0.11.10",
         mvn"com.networknt:json-schema-validator:3.0.6",
         mvn"org.sangria-graphql::sangria:4.2.19",
+        mvn"org.scala-lang::scala3-compiler:$scala",
       )
 
       /** Fetch the linkml-benchmark-schemas datasets used by `BenchmarkSchemaSpec`.

--- a/docs/implementation_differences.md
+++ b/docs/implementation_differences.md
@@ -7,7 +7,7 @@ The following features are not yet supported in LinkML-Scala:
 - Arrays
 - Boolean expressions (`any_of`, `none_of`); initial support in SHACL
 - Defaults & computed values (`ifabsent`, `equals_expression`)
-  - Only enum defaults are supported in the Scala generator
+  - Only enum defaults are supported, only in the Scala generator
 - Type designators (`type_designator`)
 - Enum inheritance, dynamic enums (`include`, `minus`, `reachable_from`)
 - Rules (`rules`)

--- a/docs/implementation_differences.md
+++ b/docs/implementation_differences.md
@@ -7,6 +7,7 @@ The following features are not yet supported in LinkML-Scala:
 - Arrays
 - Boolean expressions (`any_of`, `none_of`); initial support in SHACL
 - Defaults & computed values (`ifabsent`, `equals_expression`)
+  - Only enum defaults are supported in the Scala generator
 - Type designators (`type_designator`)
 - Enum inheritance, dynamic enums (`include`, `minus`, `reachable_from`)
 - Rules (`rules`)

--- a/generator/src/eu/neverblink/linkml/generator/scala/ScalaGenerator.scala
+++ b/generator/src/eu/neverblink/linkml/generator/scala/ScalaGenerator.scala
@@ -200,36 +200,44 @@ final class ScalaGenerator(using sv: SchemaView) {
 
   /** Translates a LinkML range value to the appropriate Scala type.
     *
+    * @param slot
+    *   SlotView of the slot we are generating the Scala type for
     * @param range
     *   Value of the LinkML range
     * @param isInlined
     *   Whether the slot is declared as inlined. Note: The slot may be implicitly inlined when the
     *   range class does not have an identifier.
     * @return
-    *   Scala type which best represents the range
+    *   (Scala type which best represents the range, default value for the type if applicable)
     */
-  private def baseRange(range: Reference[ElementView[?]], isInlined: Boolean): String = {
+  private def baseRange(
+      slot: SlotView,
+      range: Reference[ElementView[?, ?]],
+      isInlined: Boolean,
+  ): (scalaType: String, baseDefault: Option[String]) = {
     range.resolve.get match {
       case classView: ClassView =>
         // Redirect classes with uri == linkml:Any to the runtime class, as by spec it's not a builtin class:
         // From https://linkml.io/linkml/schemas/advanced.html#linkml-any-type
         // "but any class in the schema can take on this roll be being declared as linkml:Any using class_uri"
         val className = Case.PascalCase(classView.cls.name)
-        if (classView.uriStr == "https://w3id.org/linkml/Any") className
-        else if (isInlined) s"${className}Impl"
-        else s"Reference[$className]"
+        if (classView.uriStr == "https://w3id.org/linkml/Any") (className, None)
+        else if (isInlined) (s"${className}Impl", None)
+        else (s"Reference[$className]", None)
       case typeView: TypeView =>
-        if typeView.isPrimitive then typeToRuntime(typeView)
-        else Case.PascalCase(typeView._type.name)
+        if typeView.isPrimitive then (typeToRuntime(typeView), None)
+        else (Case.PascalCase(typeView._type.name), None)
       // True enum support would require working around the dynamic "enums" of LinkML, which I'm sure
       // were a really convenient idea for the biologists, but it adds a lot of complexity for us
       case enumView: EnumView =>
         val enumDef = enumView._enum
-        if (enumDef.permissibleValues.isEmpty) "String" // fallback to String for dynamic enums
+        if (enumDef.permissibleValues.isEmpty)
+          ("String", None) // fallback to String for dynamic enums
         else {
           val enumName = Case.PascalCase(enumDef.name)
-          if (isInlined) enumName
-          else s"Reference[$enumName]"
+          val default: Option[PermissibleValue] = slot.ifAbsent(enumView)
+          if (isInlined) (enumName, default.map(p => s"$enumName.${Case.PascalCase(p.text)}"))
+          else (s"Reference[$enumName]", None) // no idea what to do with that
         }
       case _ => throw RuntimeException(s"Couldn't map range $range")
     }
@@ -246,24 +254,24 @@ final class ScalaGenerator(using sv: SchemaView) {
   private def makeTypedDefault(slot: SlotView): TypedDefault = {
     val range = slot.derivedRange
     val inlined = slot.derivedInlined
-    val base = baseRange(range, inlined)
+    val (scalaType, defaultValue) = baseRange(slot, range, inlined)
     InlineType(slot) match {
-      case InlineType.plain => TypedDefault(base)
-      case InlineType.optional if base == "Boolean" =>
+      case InlineType.plain => TypedDefault(scalaType, defaultValue)
+      case InlineType.optional if scalaType == "Boolean" =>
         TypedDefault(
-          base,
+          scalaType,
           default = Some("false"),
           combineFunc = combineBoolean,
         )
       case InlineType.optional =>
         TypedDefault(
-          s"Option[$base]",
-          default = Some("None"),
+          s"Option[$scalaType]",
+          default = Some(defaultValue.map(v => s"Some($v)").getOrElse("None")),
           combineFunc = combineOption(combineFallback),
         )
       case InlineType.list =>
         TypedDefault(
-          s"Seq[$base]",
+          s"Seq[$scalaType]",
           default = if slot.slot.required then None else Some("Seq()"),
           combineFunc = combineSeq,
         )
@@ -273,7 +281,7 @@ final class ScalaGenerator(using sv: SchemaView) {
           case _: CollectionForm.CompactDict => "@compactDict"
         }
         TypedDefault(
-          s"Map[String, $base]",
+          s"Map[String, $scalaType]",
           default = if slot.slot.required then None else Some("Map()"),
           annotation = Some(annotation),
           combineFunc = combineMap,
@@ -399,7 +407,7 @@ object ScalaGenerator {
             |  * 
             |  * @inheritdoc
             |  */
-            |case class ${name}Impl(
+            |final case class ${name}Impl(
             |    ${fields.map(_.generateCaseClassField).mkString("\n")}
             |) extends $name
             |""".stripMargin

--- a/generator/src/eu/neverblink/linkml/generator/scala/ScalaGenerator.scala
+++ b/generator/src/eu/neverblink/linkml/generator/scala/ScalaGenerator.scala
@@ -236,8 +236,7 @@ final class ScalaGenerator(using sv: SchemaView) {
         else {
           val enumName = Case.PascalCase(enumDef.name)
           val default: Option[PermissibleValue] = slot.ifAbsent(enumView)
-          if (isInlined) (enumName, default.map(p => s"$enumName.${Case.PascalCase(p.text)}"))
-          else (s"Reference[$enumName]", None) // no idea what to do with that
+          (enumName, default.map(p => s"$enumName.${Case.PascalCase(p.text)}"))
         }
       case _ => throw RuntimeException(s"Couldn't map range $range")
     }

--- a/generator/src/eu/neverblink/linkml/generator/shacl/ShaclGenerator.scala
+++ b/generator/src/eu/neverblink/linkml/generator/shacl/ShaclGenerator.scala
@@ -25,7 +25,7 @@ class ShaclGenerator(using sv: SchemaView) extends RdfGenerator {
     // TODO LNK-129 HACK: Skip the main range if any boolean slot is defined.
     if slotExpression.anyOf.isEmpty then
       slotExpression.range.getOrElse(sv.getDefaultRange(slotView.definingSchema))
-        .asInstanceOf[Reference[ElementView[?]]].resolve.foreach {
+        .asInstanceOf[Reference[ElementView[?, ?]]].resolve.foreach {
           case typeView: TypeView =>
             val isIri = typeView.isIri || slotExpression.implicitPrefix.isDefined
             if !isIri then

--- a/generator/src/eu/neverblink/linkml/generator/util/PruningMode.scala
+++ b/generator/src/eu/neverblink/linkml/generator/util/PruningMode.scala
@@ -30,7 +30,7 @@ enum PruningMode:
   /** Don't prune anything */
   case skip
 
-  private def initialSet(using sv: SchemaView): Seq[ElementView[?]] = {
+  private def initialSet(using sv: SchemaView): Seq[ElementView[?, ?]] = {
     lazy val defaultRanges = sv.schemas.map(
       _
         .defaultRange

--- a/generator/test/src-jvm/eu/neverblink/linkml/generator/scala/ScalaGeneratorCompileSpec.scala
+++ b/generator/test/src-jvm/eu/neverblink/linkml/generator/scala/ScalaGeneratorCompileSpec.scala
@@ -1,0 +1,55 @@
+package eu.neverblink.linkml.generator.scala
+
+import eu.neverblink.linkml.tests.{ModelCatalogue, ModelCatalogueSpec}
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
+
+/** Checks that the code emitted by [[ScalaGenerator]] actually compiles, by running the Scala 3
+  * compiler over it. JVM-only, as it needs the compiler and the file system.
+  */
+class ScalaGeneratorCompileSpec extends AnyWordSpec, Matchers, ModelCatalogueSpec {
+  override val skipModels: Map[String, String] = Map(
+    "syntheticUris" ->
+      "LNK-169: element names that are not valid Scala identifiers are emitted without escaping",
+    "nonHermetic" ->
+      "LNK-169: a type whose base has the same name generates a cyclic alias (`type Int = Int`)",
+  )
+
+  /** Compile the given Scala sources with the Scala 3 compiler. The test classpath is reused, so
+    * the generated code is checked against the real `runtime` module it depends on.
+    *
+    * @return
+    *   The compiler output if compilation failed, or None if it succeeded.
+    */
+  def compileScala(sources: Seq[os.Path]): Option[String] = {
+    val out = os.temp.dir(prefix = "linkml-scala-out")
+    val args = Array(
+      "-classpath",
+      System.getProperty("java.class.path"),
+      "-d",
+      out.toString,
+    ) ++ sources.map(_.toString)
+    val log = java.io.ByteArrayOutputStream()
+    val reporter = Console.withErr(log) {
+      Console.withOut(log)(dotty.tools.dotc.Driver().process(args))
+    }
+    Option.when(reporter.hasErrors)(log.toString)
+  }
+
+  "ScalaGenerator" should {
+    for entry <- ModelCatalogue.all do
+      s"generate compilable code for model '${entry.name}'" in {
+        processSkip(entry.name, "")
+        val dir = os.temp.dir(prefix = "linkml-scala-src")
+        val sources = ScalaGenerator(using entry.model).generate("generated").map {
+          (name, content) =>
+            val file = dir / name
+            os.write(file, content)
+            file
+        }.toSeq
+        sources should not be empty
+        val failure = compileScala(sources)
+        withClue(s"compiler output:\n${failure.getOrElse("")}\n")(failure shouldBe None)
+      }
+  }
+}

--- a/generator/test/src/eu/neverblink/linkml/generator/scala/ScalaGeneratorSpec.scala
+++ b/generator/test/src/eu/neverblink/linkml/generator/scala/ScalaGeneratorSpec.scala
@@ -9,6 +9,34 @@ class ScalaGeneratorSpec extends AnyWordSpec, Matchers {
   def decode(schemaYaml: String): SchemaView =
     SchemaView.loadSchemaViewFromString(schemaYaml)
 
+  /** Compile the given Scala sources with the Scala 3 compiler. The test classpath is reused, so
+    * the generated code is checked against the real `runtime` module.
+    *
+    * @return
+    *   The compiler output if compilation failed, or None if it succeeded.
+    */
+  def compileScala(sources: Seq[os.Path]): Option[String] = {
+    val out = os.temp.dir(prefix = "linkml-scala-out")
+    val args = Array(
+      "-classpath",
+      System.getProperty("java.class.path"),
+      "-d",
+      out.toString,
+    ) ++ sources.map(_.toString)
+    val log = java.io.ByteArrayOutputStream()
+    val reporter = Console.withErr(log) {
+      Console.withOut(log)(dotty.tools.dotc.Driver().process(args))
+    }
+    Option.when(reporter.hasErrors)(log.toString)
+  }
+
+  val knownNotCompiling: Map[String, String] = Map(
+    "syntheticUris" ->
+      "LNK-169: element names that are not valid Scala identifiers are emitted without escaping",
+    "nonHermetic" ->
+      "LNK-169: a type whose base has the same name generates a cyclic alias (`type Int = Int`)",
+  )
+
   "Scala generator" should {
     // Shared part of the schema
     val schemaShared =
@@ -729,6 +757,30 @@ class ScalaGeneratorSpec extends AnyWordSpec, Matchers {
       }
     }
 
+    "generate ifabsent default values for enum-ranged slots" in {
+      val files = ScalaGenerator(using ModelCatalogue.ifabsent.enums.model).generate(testPkg).toMap
+      val code = files("SomeClass.scala")
+      Seq(
+        "someSlot: Option[SomeEnum] = Some(SomeEnum.SomeOption)",
+        "someOtherSlot: Option[SomeEnum] = Some(SomeEnum.SomeOtherOption)",
+        "yetAnotherSlot: Option[SomeEnum] = Some(SomeEnum.YetAnotherOption)",
+        // Permissible values that aren't valid Scala identifiers are re-cased in the default, too
+        "withSpaces: Option[SomeEnum] = Some(SomeEnum.OptionWithSpaces)",
+        // No ifabsent metaslot -> no default value
+        "noIfabsent: Option[SomeEnum] = None",
+      ).foreach { snippet =>
+        code should include(snippet)
+      }
+
+      Seq(
+        // The raw permissible value text must not leak into the default value
+        "SomeEnum.SOME_OPTION",
+        "option with spaces",
+      ).foreach { snippet =>
+        code should not include snippet
+      }
+    }
+
     "generate an emit_prefixes object" in {
       val files = ScalaGenerator(using ModelCatalogue.emitPrefixes.model)
         .generate(testPkg).toMap
@@ -798,6 +850,31 @@ class ScalaGeneratorSpec extends AnyWordSpec, Matchers {
           val files = ScalaGenerator(using entry.model).generate("eu.neverblink.linkml.scala.test")
           files should not be empty
           for (_, content) <- files do content should not be ""
+        }
+    }
+
+    "generate code that compiles" when {
+      for entry <- ModelCatalogue.all do
+        val modelName = entry.model.root.name
+        s"model '$modelName'" in {
+          val dir = os.temp.dir(prefix = "linkml-scala-src")
+          val sources = ScalaGenerator(using entry.model).generate("generated").map {
+            (name, content) =>
+              val file = dir / name
+              os.write(file, content)
+              file
+          }.toSeq
+          sources should not be empty
+          val failure = compileScala(sources)
+          knownNotCompiling.get(modelName) match {
+            case None =>
+              withClue(s"compiler output:\n${failure.getOrElse("")}\n")(failure shouldBe None)
+            case Some(reason) =>
+              withClue(
+                s"model '$modelName' is listed as known not to compile ($reason), but it " +
+                  "compiles now - remove it from knownNotCompiling",
+              )(failure should not be None)
+          }
         }
     }
   }

--- a/generator/test/src/eu/neverblink/linkml/generator/scala/ScalaGeneratorSpec.scala
+++ b/generator/test/src/eu/neverblink/linkml/generator/scala/ScalaGeneratorSpec.scala
@@ -9,34 +9,6 @@ class ScalaGeneratorSpec extends AnyWordSpec, Matchers {
   def decode(schemaYaml: String): SchemaView =
     SchemaView.loadSchemaViewFromString(schemaYaml)
 
-  /** Compile the given Scala sources with the Scala 3 compiler. The test classpath is reused, so
-    * the generated code is checked against the real `runtime` module.
-    *
-    * @return
-    *   The compiler output if compilation failed, or None if it succeeded.
-    */
-  def compileScala(sources: Seq[os.Path]): Option[String] = {
-    val out = os.temp.dir(prefix = "linkml-scala-out")
-    val args = Array(
-      "-classpath",
-      System.getProperty("java.class.path"),
-      "-d",
-      out.toString,
-    ) ++ sources.map(_.toString)
-    val log = java.io.ByteArrayOutputStream()
-    val reporter = Console.withErr(log) {
-      Console.withOut(log)(dotty.tools.dotc.Driver().process(args))
-    }
-    Option.when(reporter.hasErrors)(log.toString)
-  }
-
-  val knownNotCompiling: Map[String, String] = Map(
-    "syntheticUris" ->
-      "LNK-169: element names that are not valid Scala identifiers are emitted without escaping",
-    "nonHermetic" ->
-      "LNK-169: a type whose base has the same name generates a cyclic alias (`type Int = Int`)",
-  )
-
   "Scala generator" should {
     // Shared part of the schema
     val schemaShared =
@@ -850,31 +822,6 @@ class ScalaGeneratorSpec extends AnyWordSpec, Matchers {
           val files = ScalaGenerator(using entry.model).generate("eu.neverblink.linkml.scala.test")
           files should not be empty
           for (_, content) <- files do content should not be ""
-        }
-    }
-
-    "generate code that compiles" when {
-      for entry <- ModelCatalogue.all do
-        val modelName = entry.model.root.name
-        s"model '$modelName'" in {
-          val dir = os.temp.dir(prefix = "linkml-scala-src")
-          val sources = ScalaGenerator(using entry.model).generate("generated").map {
-            (name, content) =>
-              val file = dir / name
-              os.write(file, content)
-              file
-          }.toSeq
-          sources should not be empty
-          val failure = compileScala(sources)
-          knownNotCompiling.get(modelName) match {
-            case None =>
-              withClue(s"compiler output:\n${failure.getOrElse("")}\n")(failure shouldBe None)
-            case Some(reason) =>
-              withClue(
-                s"model '$modelName' is listed as known not to compile ($reason), but it " +
-                  "compiles now - remove it from knownNotCompiling",
-              )(failure should not be None)
-          }
         }
     }
   }

--- a/metamodel/src/eu/neverblink/linkml/metamodel/AltDescription.scala
+++ b/metamodel/src/eu/neverblink/linkml/metamodel/AltDescription.scala
@@ -8,7 +8,7 @@ import eu.neverblink.linkml.runtime.*
   *
   * @inheritdoc
   */
-case class AltDescriptionImpl(
+final case class AltDescriptionImpl(
     @id
     @named("source")
     altDescriptionSource: String,

--- a/metamodel/src/eu/neverblink/linkml/metamodel/Annotation.scala
+++ b/metamodel/src/eu/neverblink/linkml/metamodel/Annotation.scala
@@ -8,7 +8,7 @@ import eu.neverblink.linkml.runtime.*
   *
   * @inheritdoc
   */
-case class AnnotationImpl(
+final case class AnnotationImpl(
     @id
     @named("tag")
     extensionTag: UriOrCurie,

--- a/metamodel/src/eu/neverblink/linkml/metamodel/AnonymousClassExpression.scala
+++ b/metamodel/src/eu/neverblink/linkml/metamodel/AnonymousClassExpression.scala
@@ -8,7 +8,7 @@ import eu.neverblink.linkml.runtime.*
   *
   * @inheritdoc
   */
-case class AnonymousClassExpressionImpl(
+final case class AnonymousClassExpressionImpl(
     title: Option[String] = None,
     description: Option[String] = None,
     @named("is_a")

--- a/metamodel/src/eu/neverblink/linkml/metamodel/AnonymousEnumExpression.scala
+++ b/metamodel/src/eu/neverblink/linkml/metamodel/AnonymousEnumExpression.scala
@@ -8,7 +8,7 @@ import eu.neverblink.linkml.runtime.*
   *
   * @inheritdoc
   */
-case class AnonymousEnumExpressionImpl(
+final case class AnonymousEnumExpressionImpl(
     @named("code_set")
     codeSet: Option[UriOrCurie] = None,
     @named("code_set_tag")

--- a/metamodel/src/eu/neverblink/linkml/metamodel/AnonymousSlotExpression.scala
+++ b/metamodel/src/eu/neverblink/linkml/metamodel/AnonymousSlotExpression.scala
@@ -8,7 +8,7 @@ import eu.neverblink.linkml.runtime.*
   *
   * @inheritdoc
   */
-case class AnonymousSlotExpressionImpl(
+final case class AnonymousSlotExpressionImpl(
     title: Option[String] = None,
     description: Option[String] = None,
     multivalued: Boolean = false,

--- a/metamodel/src/eu/neverblink/linkml/metamodel/AnonymousTypeExpression.scala
+++ b/metamodel/src/eu/neverblink/linkml/metamodel/AnonymousTypeExpression.scala
@@ -8,7 +8,7 @@ import eu.neverblink.linkml.runtime.*
   *
   * @inheritdoc
   */
-case class AnonymousTypeExpressionImpl(
+final case class AnonymousTypeExpressionImpl(
     pattern: Option[String] = None,
     @named("any_of")
     anyOf: Seq[AnonymousTypeExpressionImpl] = Seq(),

--- a/metamodel/src/eu/neverblink/linkml/metamodel/ArrayExpression.scala
+++ b/metamodel/src/eu/neverblink/linkml/metamodel/ArrayExpression.scala
@@ -8,7 +8,7 @@ import eu.neverblink.linkml.runtime.*
   *
   * @inheritdoc
   */
-case class ArrayExpressionImpl(
+final case class ArrayExpressionImpl(
     title: Option[String] = None,
     description: Option[String] = None,
     rank: Option[Int] = None,

--- a/metamodel/src/eu/neverblink/linkml/metamodel/ClassDefinition.scala
+++ b/metamodel/src/eu/neverblink/linkml/metamodel/ClassDefinition.scala
@@ -8,7 +8,7 @@ import eu.neverblink.linkml.runtime.*
   *
   * @inheritdoc
   */
-case class ClassDefinitionImpl(
+final case class ClassDefinitionImpl(
     @id
     name: String,
     @named("class_uri")

--- a/metamodel/src/eu/neverblink/linkml/metamodel/ClassRule.scala
+++ b/metamodel/src/eu/neverblink/linkml/metamodel/ClassRule.scala
@@ -8,7 +8,7 @@ import eu.neverblink.linkml.runtime.*
   *
   * @inheritdoc
   */
-case class ClassRuleImpl(
+final case class ClassRuleImpl(
     title: Option[String] = None,
     description: Option[String] = None,
     rank: Option[Int] = None,

--- a/metamodel/src/eu/neverblink/linkml/metamodel/DimensionExpression.scala
+++ b/metamodel/src/eu/neverblink/linkml/metamodel/DimensionExpression.scala
@@ -8,7 +8,7 @@ import eu.neverblink.linkml.runtime.*
   *
   * @inheritdoc
   */
-case class DimensionExpressionImpl(
+final case class DimensionExpressionImpl(
     title: Option[String] = None,
     description: Option[String] = None,
     alias: Option[String] = None,

--- a/metamodel/src/eu/neverblink/linkml/metamodel/EnumBinding.scala
+++ b/metamodel/src/eu/neverblink/linkml/metamodel/EnumBinding.scala
@@ -8,7 +8,7 @@ import eu.neverblink.linkml.runtime.*
   *
   * @inheritdoc
   */
-case class EnumBindingImpl(
+final case class EnumBindingImpl(
     title: Option[String] = None,
     description: Option[String] = None,
     rank: Option[Int] = None,

--- a/metamodel/src/eu/neverblink/linkml/metamodel/EnumDefinition.scala
+++ b/metamodel/src/eu/neverblink/linkml/metamodel/EnumDefinition.scala
@@ -8,7 +8,7 @@ import eu.neverblink.linkml.runtime.*
   *
   * @inheritdoc
   */
-case class EnumDefinitionImpl(
+final case class EnumDefinitionImpl(
     @id
     name: String,
     title: Option[String] = None,

--- a/metamodel/src/eu/neverblink/linkml/metamodel/EnumExpression.scala
+++ b/metamodel/src/eu/neverblink/linkml/metamodel/EnumExpression.scala
@@ -8,7 +8,7 @@ import eu.neverblink.linkml.runtime.*
   *
   * @inheritdoc
   */
-case class EnumExpressionImpl(
+final case class EnumExpressionImpl(
     @named("code_set")
     codeSet: Option[UriOrCurie] = None,
     @named("code_set_tag")

--- a/metamodel/src/eu/neverblink/linkml/metamodel/Example.scala
+++ b/metamodel/src/eu/neverblink/linkml/metamodel/Example.scala
@@ -8,7 +8,7 @@ import eu.neverblink.linkml.runtime.*
   *
   * @inheritdoc
   */
-case class ExampleImpl(
+final case class ExampleImpl(
     value: Option[String] = None,
     @named("description")
     valueDescription: Option[String] = None,

--- a/metamodel/src/eu/neverblink/linkml/metamodel/Extension.scala
+++ b/metamodel/src/eu/neverblink/linkml/metamodel/Extension.scala
@@ -8,7 +8,7 @@ import eu.neverblink.linkml.runtime.*
   *
   * @inheritdoc
   */
-case class ExtensionImpl(
+final case class ExtensionImpl(
     @id
     @named("tag")
     extensionTag: UriOrCurie,

--- a/metamodel/src/eu/neverblink/linkml/metamodel/ExtraSlotsExpression.scala
+++ b/metamodel/src/eu/neverblink/linkml/metamodel/ExtraSlotsExpression.scala
@@ -8,7 +8,7 @@ import eu.neverblink.linkml.runtime.*
   *
   * @inheritdoc
   */
-case class ExtraSlotsExpressionImpl(
+final case class ExtraSlotsExpressionImpl(
     allowed: Boolean = false,
     @named("range_expression")
     rangeExpression: Option[AnonymousSlotExpressionImpl] = None,

--- a/metamodel/src/eu/neverblink/linkml/metamodel/ImportExpression.scala
+++ b/metamodel/src/eu/neverblink/linkml/metamodel/ImportExpression.scala
@@ -8,7 +8,7 @@ import eu.neverblink.linkml.runtime.*
   *
   * @inheritdoc
   */
-case class ImportExpressionImpl(
+final case class ImportExpressionImpl(
     title: Option[String] = None,
     description: Option[String] = None,
     rank: Option[Int] = None,

--- a/metamodel/src/eu/neverblink/linkml/metamodel/LocalName.scala
+++ b/metamodel/src/eu/neverblink/linkml/metamodel/LocalName.scala
@@ -8,7 +8,7 @@ import eu.neverblink.linkml.runtime.*
   *
   * @inheritdoc
   */
-case class LocalNameImpl(
+final case class LocalNameImpl(
     @id
     @named("local_name_source")
     localNameSource: NcName,

--- a/metamodel/src/eu/neverblink/linkml/metamodel/MatchQuery.scala
+++ b/metamodel/src/eu/neverblink/linkml/metamodel/MatchQuery.scala
@@ -8,7 +8,7 @@ import eu.neverblink.linkml.runtime.*
   *
   * @inheritdoc
   */
-case class MatchQueryImpl(
+final case class MatchQueryImpl(
     @named("identifier_pattern")
     identifierPattern: Option[String] = None,
     @named("source_ontology")

--- a/metamodel/src/eu/neverblink/linkml/metamodel/PathExpression.scala
+++ b/metamodel/src/eu/neverblink/linkml/metamodel/PathExpression.scala
@@ -8,7 +8,7 @@ import eu.neverblink.linkml.runtime.*
   *
   * @inheritdoc
   */
-case class PathExpressionImpl(
+final case class PathExpressionImpl(
     title: Option[String] = None,
     description: Option[String] = None,
     rank: Option[Int] = None,

--- a/metamodel/src/eu/neverblink/linkml/metamodel/PatternExpression.scala
+++ b/metamodel/src/eu/neverblink/linkml/metamodel/PatternExpression.scala
@@ -8,7 +8,7 @@ import eu.neverblink.linkml.runtime.*
   *
   * @inheritdoc
   */
-case class PatternExpressionImpl(
+final case class PatternExpressionImpl(
     title: Option[String] = None,
     description: Option[String] = None,
     rank: Option[Int] = None,

--- a/metamodel/src/eu/neverblink/linkml/metamodel/PermissibleValue.scala
+++ b/metamodel/src/eu/neverblink/linkml/metamodel/PermissibleValue.scala
@@ -8,7 +8,7 @@ import eu.neverblink.linkml.runtime.*
   *
   * @inheritdoc
   */
-case class PermissibleValueImpl(
+final case class PermissibleValueImpl(
     @id
     text: String,
     title: Option[String] = None,

--- a/metamodel/src/eu/neverblink/linkml/metamodel/Prefix.scala
+++ b/metamodel/src/eu/neverblink/linkml/metamodel/Prefix.scala
@@ -8,7 +8,7 @@ import eu.neverblink.linkml.runtime.*
   *
   * @inheritdoc
   */
-case class PrefixImpl(
+final case class PrefixImpl(
     @id
     @named("prefix_prefix")
     prefixPrefix: NcName,

--- a/metamodel/src/eu/neverblink/linkml/metamodel/ReachabilityQuery.scala
+++ b/metamodel/src/eu/neverblink/linkml/metamodel/ReachabilityQuery.scala
@@ -8,7 +8,7 @@ import eu.neverblink.linkml.runtime.*
   *
   * @inheritdoc
   */
-case class ReachabilityQueryImpl(
+final case class ReachabilityQueryImpl(
     @named("include_self")
     includeSelf: Boolean = false,
     @named("is_direct")

--- a/metamodel/src/eu/neverblink/linkml/metamodel/SchemaDefinition.scala
+++ b/metamodel/src/eu/neverblink/linkml/metamodel/SchemaDefinition.scala
@@ -8,7 +8,7 @@ import eu.neverblink.linkml.runtime.*
   *
   * @inheritdoc
   */
-case class SchemaDefinitionImpl(
+final case class SchemaDefinitionImpl(
     @id
     name: NcName,
     @value

--- a/metamodel/src/eu/neverblink/linkml/metamodel/Setting.scala
+++ b/metamodel/src/eu/neverblink/linkml/metamodel/Setting.scala
@@ -8,7 +8,7 @@ import eu.neverblink.linkml.runtime.*
   *
   * @inheritdoc
   */
-case class SettingImpl(
+final case class SettingImpl(
     @id
     @named("setting_key")
     settingKey: NcName,

--- a/metamodel/src/eu/neverblink/linkml/metamodel/SlotDefinition.scala
+++ b/metamodel/src/eu/neverblink/linkml/metamodel/SlotDefinition.scala
@@ -8,7 +8,7 @@ import eu.neverblink.linkml.runtime.*
   *
   * @inheritdoc
   */
-case class SlotDefinitionImpl(
+final case class SlotDefinitionImpl(
     @id
     name: String,
     @named("slot_uri")

--- a/metamodel/src/eu/neverblink/linkml/metamodel/StructuredAlias.scala
+++ b/metamodel/src/eu/neverblink/linkml/metamodel/StructuredAlias.scala
@@ -8,7 +8,7 @@ import eu.neverblink.linkml.runtime.*
   *
   * @inheritdoc
   */
-case class StructuredAliasImpl(
+final case class StructuredAliasImpl(
     title: Option[String] = None,
     description: Option[String] = None,
     rank: Option[Int] = None,

--- a/metamodel/src/eu/neverblink/linkml/metamodel/SubsetDefinition.scala
+++ b/metamodel/src/eu/neverblink/linkml/metamodel/SubsetDefinition.scala
@@ -8,7 +8,7 @@ import eu.neverblink.linkml.runtime.*
   *
   * @inheritdoc
   */
-case class SubsetDefinitionImpl(
+final case class SubsetDefinitionImpl(
     @id
     name: String,
     title: Option[String] = None,

--- a/metamodel/src/eu/neverblink/linkml/metamodel/TypeDefinition.scala
+++ b/metamodel/src/eu/neverblink/linkml/metamodel/TypeDefinition.scala
@@ -8,7 +8,7 @@ import eu.neverblink.linkml.runtime.*
   *
   * @inheritdoc
   */
-case class TypeDefinitionImpl(
+final case class TypeDefinitionImpl(
     @id
     name: String,
     @named("uri")

--- a/metamodel/src/eu/neverblink/linkml/metamodel/TypeMapping.scala
+++ b/metamodel/src/eu/neverblink/linkml/metamodel/TypeMapping.scala
@@ -8,7 +8,7 @@ import eu.neverblink.linkml.runtime.*
   *
   * @inheritdoc
   */
-case class TypeMappingImpl(
+final case class TypeMappingImpl(
     @id
     @named("framework")
     frameworkKey: String,

--- a/metamodel/src/eu/neverblink/linkml/metamodel/UniqueKey.scala
+++ b/metamodel/src/eu/neverblink/linkml/metamodel/UniqueKey.scala
@@ -8,7 +8,7 @@ import eu.neverblink.linkml.runtime.*
   *
   * @inheritdoc
   */
-case class UniqueKeyImpl(
+final case class UniqueKeyImpl(
     @id
     @named("unique_key_name")
     uniqueKeyName: String,

--- a/metamodel/src/eu/neverblink/linkml/metamodel/UnitOfMeasure.scala
+++ b/metamodel/src/eu/neverblink/linkml/metamodel/UnitOfMeasure.scala
@@ -8,7 +8,7 @@ import eu.neverblink.linkml.runtime.*
   *
   * @inheritdoc
   */
-case class UnitOfMeasureImpl(
+final case class UnitOfMeasureImpl(
     abbreviation: Option[String] = None,
     derivation: Option[String] = None,
     @named("descriptive_name")

--- a/schemaview/src/eu/neverblink/linkml/schemaview/ElementView.scala
+++ b/schemaview/src/eu/neverblink/linkml/schemaview/ElementView.scala
@@ -18,7 +18,8 @@ import eu.neverblink.linkml.schemaview.expression.ConstructorExpression
   * @tparam E
   *   The type of the underlying Element
   * @tparam R
-  *   The runtime type of the underlying Element, which is used for resolving default values.
+  *   The type of default values for this element when resolving constructor expressions (e.g. from
+  *   the `ifabsent` metaslot).
   */
 sealed trait ElementView[E <: Element, R](using val sv: SchemaView) {
 
@@ -45,7 +46,7 @@ sealed trait ElementView[E <: Element, R](using val sv: SchemaView) {
   def aliasedName: String
 
   /** Evaluate a constructor expression (e.g. from the `ifabsent` metaslot) treating this element as
-    * the range. Dispatches on the element type, so that the result is statically typed as [[R]].
+    * the range.
     *
     * May throw a [[ConstructorExpression.EvaluationException]] if the expression is invalid or
     * cannot be parsed into a value of type [[R]].

--- a/schemaview/src/eu/neverblink/linkml/schemaview/ElementView.scala
+++ b/schemaview/src/eu/neverblink/linkml/schemaview/ElementView.scala
@@ -5,6 +5,7 @@ import eu.neverblink.linkml.metamodel.*
 import eu.neverblink.linkml.runtime.*
 import eu.neverblink.linkml.schemaview
 import eu.neverblink.linkml.schemaview.CollectionForm.{CompactDict, SimpleDict}
+import eu.neverblink.linkml.schemaview.expression.ConstructorExpression
 
 /** Element views provide a rich interface for working with schema elements. They require an
   * implicit [[SchemaView]] and are always linked to a defining schema, which is the schema in which
@@ -14,8 +15,12 @@ import eu.neverblink.linkml.schemaview.CollectionForm.{CompactDict, SimpleDict}
   *
   * @param sv
   *   Root SchemaView that (transitively) imported this Element
+  * @tparam E
+  *   The type of the underlying Element
+  * @tparam R
+  *   The runtime type of the underlying Element, which is used for resolving default values.
   */
-sealed trait ElementView[E <: Element](using val sv: SchemaView) {
+sealed trait ElementView[E <: Element, R](using val sv: SchemaView) {
 
   /** Element type name, e.g. "class", "slot", "type", "enum", "subset", used for error messages.
     */
@@ -38,6 +43,19 @@ sealed trait ElementView[E <: Element](using val sv: SchemaView) {
     * appropriately if needed.
     */
   def aliasedName: String
+
+  /** Evaluate a constructor expression (e.g. from the `ifabsent` metaslot) treating this element as
+    * the range. Dispatches on the element type, so that the result is statically typed as [[R]].
+    *
+    * May throw a [[ConstructorExpression.EvaluationException]] if the expression is invalid or
+    * cannot be parsed into a value of type [[R]].
+    *
+    * @return
+    *   The evaluated value, or None if constructor expressions are not supported for this element
+    *   type.
+    */
+  // TODO LNK-63: implement other types in ifabsent
+  private[schemaview] def evaluateConstructor(expr: String): Option[R] = None
 
   /** The defining schema's prefix resolver */
   given definingPrefixResolver: PrefixResolver = sv.getPrefixResolver(definingSchema)
@@ -64,7 +82,7 @@ private object ClassView:
 
 final case class ClassView(cls: ClassDefinition, definingSchema: SchemaDefinition)(using
     sv: SchemaView,
-) extends ElementView[ClassDefinition] {
+) extends ElementView[ClassDefinition, AnyRef] {
   def elementType: String = "class"
 
   def inner: ClassDefinition = cls
@@ -219,7 +237,7 @@ final case class ClassView(cls: ClassDefinition, definingSchema: SchemaDefinitio
     */
   private def derivedSlot(
       slotRef: Reference[SlotDefinition],
-      source: ElementView[?],
+      source: ElementView[?, ?],
   ): SlotView = {
     // Use empty slot base here to avoid an extra allocation
     var currentSlot = ClassView.emptySlotDef
@@ -328,7 +346,7 @@ final case class ClassView(cls: ClassDefinition, definingSchema: SchemaDefinitio
 
 final case class SlotView(slot: SlotDefinition, definingSchema: SchemaDefinition)(using
     sv: SchemaView,
-) extends ElementView[SlotDefinition] {
+) extends ElementView[SlotDefinition, Nothing] {
   def elementType: String = "slot"
 
   def inner: SlotDefinition = slot
@@ -377,9 +395,20 @@ final case class SlotView(slot: SlotDefinition, definingSchema: SchemaDefinition
     * with `default_range` from the implicit [[SchemaView]]. Does NOT take inheritance into account:
     * Make sure you use this method after class/slot derivation is performed.
     */
-  def derivedRange: Reference[ElementView[?]] =
+  def derivedRange: Reference[ElementView[?, ?]] =
     slot.range.getOrElse(sv.getDefaultRange(definingSchema))
-      .asInstanceOf[Reference[ElementView[?]]]
+      .asInstanceOf[Reference[ElementView[?, ?]]]
+
+  /** Get the default value of this slot if the `ifabsent` metaslot is defined.
+    *
+    * May throw a [[ConstructorExpression.EvaluationException]] if the `ifabsent` expression is
+    * invalid or cannot be parsed into a value of type R.
+    *
+    * @param range
+    *   The range of the slot. Obtain it from [[SlotView.derivedRange]].
+    */
+  def ifAbsent[R](range: ElementView[?, R]): Option[R] =
+    slot.ifabsent.flatMap(range.evaluateConstructor)
 
   /** Get the URI of this slot, using the default prefix of the implicit [[SchemaView]] if not
     * explicitly defined.
@@ -389,17 +418,20 @@ final case class SlotView(slot: SlotDefinition, definingSchema: SchemaDefinition
 
 private object SlotView:
   // Exposed for slot derivation in ClassView.
-  def uri(slotUri: Option[UriOrCurie], slotName: String, context: ElementView[?]): UriOrCurie =
+  def uri(slotUri: Option[UriOrCurie], slotName: String, context: ElementView[?, ?]): UriOrCurie =
     slotUri.getOrElse(Uri.synthetic(context.defaultPrefixUri, Case.deSpaceCase(slotName)))
 
 final case class EnumView(_enum: EnumDefinition, definingSchema: SchemaDefinition)(using
     sv: SchemaView,
-) extends ElementView[EnumDefinition] {
+) extends ElementView[EnumDefinition, PermissibleValue] {
   def elementType: String = "enum"
 
   def inner: EnumDefinition = _enum
 
   override def aliasedName: String = Case.PascalCase(_enum.name)
+
+  override private[schemaview] def evaluateConstructor(expr: String): Option[PermissibleValue] =
+    Some(ConstructorExpression.evaluateEnum(expr, this))
 
   def uriOrCurie: UriOrCurie =
     _enum.enumUri.getOrElse(Uri.synthetic(defaultPrefixUri, Case.PascalCase(_enum.name)))
@@ -417,9 +449,13 @@ final case class EnumView(_enum: EnumDefinition, definingSchema: SchemaDefinitio
     derivedValues.map((x, meaning) => meaning -> x.text).toMap
 }
 
+// TODO LNK-63:
+//  This might be incorrect, to be finalized when we implement default values for datatypes.
+type RuntimeScalar = String | Int | Boolean | Float | Double | BigDecimal | UriOrCurie
+
 final case class TypeView(_type: TypeDefinition, definingSchema: SchemaDefinition)(using
     sv: SchemaView,
-) extends ElementView[TypeDefinition] {
+) extends ElementView[TypeDefinition, RuntimeScalar] {
   def elementType: String = "type"
 
   def inner: TypeDefinition = _type
@@ -496,7 +532,7 @@ final case class TypeView(_type: TypeDefinition, definingSchema: SchemaDefinitio
 
 final case class SubsetView(subset: SubsetDefinition, definingSchema: SchemaDefinition)(using
     sv: SchemaView,
-) extends ElementView[SubsetDefinition] {
+) extends ElementView[SubsetDefinition, Nothing] {
   def elementType: String = "subset"
 
   def inner: SubsetDefinition = subset

--- a/schemaview/src/eu/neverblink/linkml/schemaview/SchemaProblem.scala
+++ b/schemaview/src/eu/neverblink/linkml/schemaview/SchemaProblem.scala
@@ -166,7 +166,7 @@ object SchemaProblem {
     lazy val description: String = s"Undefined prefix $prefix at $position"
     lazy val verbose: String = description
 
-  final case class InvalidUriOrCurie(inElement: ElementView[? <: Element]) extends Error:
+  final case class InvalidUriOrCurie(inElement: ElementView[? <: Element, ?]) extends Error:
     lazy val description: String =
       s"Invalid URI or CURIE '${inElement.uriOrCurie.original}' in ${inElement.elementType} " +
         s"'${inElement.inner.name}' imported from schema '${inElement.definingSchema.id.original}'."

--- a/schemaview/src/eu/neverblink/linkml/schemaview/SchemaReachabilityQuery.scala
+++ b/schemaview/src/eu/neverblink/linkml/schemaview/SchemaReachabilityQuery.scala
@@ -23,7 +23,7 @@ sealed abstract class SchemaReachabilityQuery(using sv: SchemaView) {
   /** @return
     *   true if the underlying [[Element]] of the provided [[ElementView]] is reachable
     */
-  def reachable(element: ElementView[?]): Boolean =
+  def reachable(element: ElementView[?, ?]): Boolean =
     reachable(element.inner.asInstanceOf[Element])
 
   /** Lazily computed set of [[TaggedReference]]s that are reachable for the default implementation
@@ -56,7 +56,7 @@ sealed abstract class SchemaReachabilityQuery(using sv: SchemaView) {
   */
 final class IncludeAllReachabilityQuery(using SchemaView) extends SchemaReachabilityQuery {
   override def reachable(element: Element): Boolean = true
-  override def reachable(element: ElementView[?]): Boolean = true
+  override def reachable(element: ElementView[?, ?]): Boolean = true
   protected lazy val resolved: Set[TaggedReference] = Set.empty
 }
 
@@ -70,7 +70,7 @@ final class IncludeAllReachabilityQuery(using SchemaView) extends SchemaReachabi
   *   If true, will include class' ancestors when computing reachability.
   */
 final class DerivedReachabilityQuery(
-    val from: Seq[ElementView[?]],
+    val from: Seq[ElementView[?, ?]],
     val inlinedOnly: Boolean,
     val includeClassAncestors: Boolean,
 )(using sv: SchemaView)
@@ -134,7 +134,7 @@ final class DerivedReachabilityQuery(
   *   [[Element]]s to start the search from
   */
 final class UnderivedReachabilityQuery(
-    val from: Seq[ElementView[?]],
+    val from: Seq[ElementView[?, ?]],
 )(using sv: SchemaView)
     extends SchemaReachabilityQuery {
 

--- a/schemaview/src/eu/neverblink/linkml/schemaview/SchemaView.scala
+++ b/schemaview/src/eu/neverblink/linkml/schemaview/SchemaView.scala
@@ -45,7 +45,7 @@ final case class SchemaView(schemas: Seq[SchemaDefinition]) extends ReferenceRes
       case _: EnumView => enums.get(ref.value)
       case _: SlotView => slotDefinitions.get(ref.value)
       case _: SubsetView => subsets.get(ref.value)
-      case _: ElementView[?] => getElement(ref.value)
+      case _: ElementView[?, ?] => getElement(ref.value)
       case _ => compiletime.error("SchemaView can't dereference " + compiletime.codeOf(ref))
     }).asInstanceOf[Option[T]]
 
@@ -89,7 +89,7 @@ final case class SchemaView(schemas: Seq[SchemaDefinition]) extends ReferenceRes
       acc
     }.result()
 
-  lazy val elements: Map[String, ElementView[? <: Element]] =
+  lazy val elements: Map[String, ElementView[? <: Element, ?]] =
     subsets ++ slotDefinitions ++ enums ++ types ++ classes
 
   /** Cached prefix resolvers for each schema in the view.
@@ -136,7 +136,7 @@ final case class SchemaView(schemas: Seq[SchemaDefinition]) extends ReferenceRes
     *   Starting set of elements
     */
   def underivedReachabilityQuery(
-      from: Seq[ElementView[?]],
+      from: Seq[ElementView[?, ?]],
   ): UnderivedReachabilityQuery = UnderivedReachabilityQuery(from)
 
   /** Get all elements reachable from a given starting set, following derived attributes and other
@@ -154,14 +154,14 @@ final case class SchemaView(schemas: Seq[SchemaDefinition]) extends ReferenceRes
     *   If true, will include class' ancestors when computing reachability.
     */
   def derivedReachabilityQuery(
-      from: Seq[ElementView[?]],
+      from: Seq[ElementView[?, ?]],
       inlinedOnly: Boolean,
       includeClassAncestors: Boolean,
   ): DerivedReachabilityQuery = DerivedReachabilityQuery(from, inlinedOnly, includeClassAncestors)
 
   /** Get a schema element by its ID
     */
-  def getElement(name: String): Option[ElementView[?]] = elements.get(name)
+  def getElement(name: String): Option[ElementView[?, ?]] = elements.get(name)
 
   /** Get the class defined as `tree_root: true` from the schema, if any is present
     */

--- a/schemaview/src/eu/neverblink/linkml/schemaview/expression/ConstructorExpression.scala
+++ b/schemaview/src/eu/neverblink/linkml/schemaview/expression/ConstructorExpression.scala
@@ -17,6 +17,7 @@ object ConstructorExpression:
     * @param message
     *   The error message.
     */
+  // TODO LNK-63: Make this a SchemaValidator check instead if possible
   final class EvaluationException(message: String) extends RuntimeException(message)
 
   private val enumExprPattern = """^([a-zA-Z_][a-zA-Z0-9_]*)\((.*)\)$""".r

--- a/schemaview/src/eu/neverblink/linkml/schemaview/expression/ConstructorExpression.scala
+++ b/schemaview/src/eu/neverblink/linkml/schemaview/expression/ConstructorExpression.scala
@@ -1,0 +1,40 @@
+package eu.neverblink.linkml.schemaview.expression
+import eu.neverblink.linkml.metamodel.*
+import eu.neverblink.linkml.schemaview.*
+
+/** LinkML constructor expression handling, used in, e.g., `ifabsent`.
+  *
+  * Examples:
+  *   - `ifabsent: int(42)`
+  *   - `ifabsent: string("default")`
+  *   - `ifabsent: SomeEnum(ENUM_VALUE)`
+  *
+  * Note: ifabsent is under-specified, so this is a partial "best guess" implementation. See:
+  * https://github.com/linkml/linkml/issues/3834
+  */
+object ConstructorExpression:
+  /** Exception thrown when parsing a constructor expression fails.
+    * @param message
+    *   The error message.
+    */
+  final class EvaluationException(message: String) extends RuntimeException(message)
+
+  private val enumExprPattern = """^([a-zA-Z_][a-zA-Z0-9_]*)\((.*)\)$""".r
+
+  def evaluateEnum(expr: String, range: EnumView): PermissibleValueImpl =
+    val (enumName, valueName) = enumExprPattern.findFirstMatchIn(expr) match {
+      case Some(v) => (v.group(1), v.group(2))
+      case None => throw EvaluationException(s"Invalid enum constructor expression: '$expr'")
+    }
+    if (enumName != range.name)
+      throw EvaluationException(
+        s"Enum constructor expression '$expr' does not match the expected enum type '${range.name}'",
+      )
+    range._enum.permissibleValues.getOrElse(
+      valueName,
+      throw EvaluationException(
+        s"Value '$valueName' not found in enum '${range.name}'",
+      ),
+    )
+
+  // TODO LNK-63: implement the remaining range types

--- a/schemaview/test/src/eu/neverblink/linkml/schemaview/SchemaViewSpec.scala
+++ b/schemaview/test/src/eu/neverblink/linkml/schemaview/SchemaViewSpec.scala
@@ -2,6 +2,7 @@ package eu.neverblink.linkml.schemaview
 
 import eu.neverblink.linkml.metamodel.*
 import eu.neverblink.linkml.runtime.*
+import eu.neverblink.linkml.schemaview.expression.ConstructorExpression
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
 import org.virtuslab.yaml.parseYaml
@@ -567,6 +568,35 @@ class SchemaViewSpec extends AnyWordSpec, Matchers {
             include("Could not find class 'nonexistent_class'")
         case Success(_) => fail("Expected failure but got success")
       }
+    }
+
+    "resolve the ifabsent default value of a slot" in {
+      val model =
+        """id: http://example.com/ifabsent
+          |name: ifabsent
+          |enums:
+          |  E1:
+          |    permissible_values:
+          |      V1:
+          |      V2:
+          |slots:
+          |  enum_default:
+          |    range: E1
+          |    ifabsent: E1(V2)
+          |  enum_no_default:
+          |    range: E1
+          |  enum_bad_default:
+          |    range: E1
+          |    ifabsent: E1(V9)
+          |""".stripMargin
+      val ifSv = SchemaView.single(parse(model))
+      val e1 = ifSv.enums("E1")
+      val enumDefault: Option[PermissibleValue] = ifSv.slotDefinitions("enum_default").ifAbsent(e1)
+      enumDefault.map(_.text) shouldBe Some("V2")
+      ifSv.slotDefinitions("enum_no_default").ifAbsent(e1) shouldBe None
+      intercept[ConstructorExpression.EvaluationException] {
+        ifSv.slotDefinitions("enum_bad_default").ifAbsent(e1)
+      }.getMessage should include("Value 'V9' not found in enum 'E1'")
     }
 
     def loadSchemaResource(resource: String): SchemaDefinition = parse(Resources.read(resource))

--- a/schemaview/test/src/eu/neverblink/linkml/schemaview/expression/ConstructorExpressionSpec.scala
+++ b/schemaview/test/src/eu/neverblink/linkml/schemaview/expression/ConstructorExpressionSpec.scala
@@ -1,0 +1,77 @@
+package eu.neverblink.linkml.schemaview.expression
+
+import eu.neverblink.linkml.runtime.Curie
+import eu.neverblink.linkml.schemaview.SchemaView
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
+
+class ConstructorExpressionSpec extends AnyWordSpec, Matchers {
+
+  "ConstructorExpression.evaluateEnum" should {
+    val schema =
+      """id: urn:test
+        |name: test
+        |
+        |prefixes:
+        |  ex: https://example.org/
+        |default_prefix: ex
+        |
+        |enums:
+        |  E1:
+        |    permissible_values:
+        |      V1:
+        |        meaning: ex:FirstValue
+        |      V2:
+        |      V 3:
+        |  Other_Enum:
+        |    permissible_values:
+        |      V1:
+        |""".stripMargin
+
+    lazy val sv = SchemaView.loadSchemaViewFromString(schema)
+    lazy val e1 = sv.enums("E1")
+    lazy val otherEnum = sv.enums("Other_Enum")
+
+    "resolve a permissible value" in {
+      ConstructorExpression.evaluateEnum("E1(V2)", e1).text shouldBe "V2"
+    }
+
+    "return the full permissible value, not just its text" in {
+      ConstructorExpression.evaluateEnum("E1(V1)", e1).meaning shouldBe
+        Some(Curie("ex:FirstValue"))
+    }
+
+    "accept enum names containing underscores" in {
+      ConstructorExpression.evaluateEnum("Other_Enum(V1)", otherEnum).text shouldBe "V1"
+    }
+
+    "accept permissible values containing spaces" in {
+      ConstructorExpression.evaluateEnum("E1(V 3)", e1).text shouldBe "V 3"
+    }
+
+    "reject an expression whose enum name does not match the range" in {
+      val e = the[ConstructorExpression.EvaluationException] thrownBy
+        ConstructorExpression.evaluateEnum("Other_Enum(V1)", e1)
+      e.getMessage should include("does not match the expected enum type 'E1'")
+    }
+
+    "reject a value that is not in the enum" in {
+      val e = the[ConstructorExpression.EvaluationException] thrownBy
+        ConstructorExpression.evaluateEnum("E1(nope)", e1)
+      e.getMessage should include("Value 'nope' not found in enum 'E1'")
+    }
+
+    "reject an empty value" in {
+      the[ConstructorExpression.EvaluationException] thrownBy
+        ConstructorExpression.evaluateEnum("E1()", e1)
+    }
+
+    "reject expressions that are not constructor calls" in {
+      for expr <- Seq("V1", "E1", "E1(V1", "E1 V1)", "", "(V1)", "1E(V1)") do
+        withClue(s"expression: '$expr'") {
+          the[ConstructorExpression.EvaluationException] thrownBy
+            ConstructorExpression.evaluateEnum(expr, e1)
+        }
+    }
+  }
+}

--- a/tests/resources/models/ifabsent/enums/model.yaml
+++ b/tests/resources/models/ifabsent/enums/model.yaml
@@ -1,0 +1,33 @@
+id: https://neverblink.eu/linkml/tests/ifabsent/enums/
+name: ifabsent_enums
+
+imports:
+  - linkml:types
+
+classes:
+  SomeClass:
+    tree_root: true
+    attributes:
+      some_slot:
+        range: SomeEnum
+        ifabsent: SomeEnum(SOME_OPTION)
+      some_other_slot:
+        range: SomeEnum
+        ifabsent: SomeEnum(SOME_OTHER_OPTION)
+      yet_another_slot:
+        range: SomeEnum
+        ifabsent: SomeEnum(YET_ANOTHER_OPTION)
+      with_spaces:
+        range: SomeEnum
+        ifabsent: SomeEnum(option with spaces)
+      no_ifabsent:
+        range: SomeEnum
+
+enums:
+  SomeEnum:
+    permissible_values:
+      SOME_OPTION:
+        meaning: rdf:subject
+      SOME_OTHER_OPTION:
+      YET_ANOTHER_OPTION:
+      "option with spaces":

--- a/tests/src/eu/neverblink/linkml/tests/ModelCatalogue.scala
+++ b/tests/src/eu/neverblink/linkml/tests/ModelCatalogue.scala
@@ -180,6 +180,10 @@ object ModelCatalogue {
     val selfCompact3Required: Entry = Entry("/models/inlines/selfCompact3Required/")
   }
 
+  object ifabsent {
+    val enums: Entry = Entry("/models/ifabsent/enums/")
+  }
+
   object metadata {
     val title: Entry = Entry("/models/metadata/title/")
   }


### PR DESCRIPTION
This spans only the Scala generator, but a large part of the machinery for other generators is already implemented. I have only touched enums, because this is what I need for validation schemas.

Also:

- Scala generator: make all emitted case classes `final`, because there is no reason not to.
- Scala generator: run the generated code through the compiler. This actually caught 2 non-compiling test cases, to be solved later.