### PR TITLE
Implement equals_expression string interpolation

### DIFF
--- a/build.mill
+++ b/build.mill
@@ -190,7 +190,7 @@ object metamodel extends Module {
 }
 
 object schemaview extends Module {
-  object jvm extends CommonModule {
+  object jvm extends SchemaViewModule {
     def moduleDeps = Seq(
       build.metamodel.jvm,
     )
@@ -198,12 +198,24 @@ object schemaview extends Module {
     object test extends ScalaTests, CommonTestModule
   }
 
-  object js extends NoBspModule, CommonScalaJSModule {
+  object js extends SchemaViewModule, NoBspModule, CommonScalaJSModule {
     def moduleDeps = Seq(
       build.metamodel.js,
     )
 
     object test extends ScalaJSTests, CommonTestModule
+  }
+
+  trait SchemaViewModule extends CommonModule {
+    def mvnDeps = Seq(
+      mvn"com.lihaoyi::fastparse::3.1.1",
+    )
+
+    // fastparse's `rep`/`StringIn` macros trip -Xcheck-macros ("Expression created in a splice was
+    // used outside of that splice") on Scala 3.8. The generated parsers are correct -- it's a
+    // scope-tracking bug in fastparse's quotes, fixed upstream but unreleased (3.1.1 is latest).
+    // Scoped to this module so the rest of the build keeps the check.
+    override def scalacOptions = super.scalacOptions().filterNot(_ == "-Xcheck-macros")
   }
 }
 

--- a/cli/src/eu/neverblink/linkml/generator/rdf/RdfUtils.scala
+++ b/cli/src/eu/neverblink/linkml/generator/rdf/RdfUtils.scala
@@ -13,7 +13,7 @@ import java.io.{BufferedOutputStream, OutputStream, StringWriter}
   * pretty-printed Turtle. Building the model and running the RDF4J writer is substantially slower
   * than the streaming [[NTriplesRdfSink]], but produces prefixed, blank-node inlined output.
   *
-  * Serialize either straight to an [[OutputStream]] via [[writeTo]] (preferred — no full-document
+  * Serialize either straight to an [[OutputStream]] via [[writeTo]] (preferred – no full-document
   * string is materialized) or as a [[String]] via [[result]].
   */
 final class TurtleRdfSink(using vf: ValueFactory = SimpleValueFactory.getInstance())

--- a/docs/implementation_differences.md
+++ b/docs/implementation_differences.md
@@ -2,12 +2,14 @@
 
 ## Limitations
 
-The following features are not yet supported in LinkML-Scala:
+The following features are not yet supported or are partially supported in LinkML-Scala:
 
 - Arrays
 - Boolean expressions (`any_of`, `none_of`); initial support in SHACL
-- Defaults & computed values (`ifabsent`, `equals_expression`)
+- Partial support for default values (`ifabsent`)
   - Only enum defaults are supported, only in the Scala generator
+- Partial support for computed values (e.g., `equals_expression`)
+  - Only string interpolation is supported, only in the Scala generator
 - Type designators (`type_designator`)
 - Enum inheritance, dynamic enums (`include`, `minus`, `reachable_from`)
 - Rules (`rules`)

--- a/generator/src/eu/neverblink/linkml/generator/graphql/GraphQlGenerator.scala
+++ b/generator/src/eu/neverblink/linkml/generator/graphql/GraphQlGenerator.scala
@@ -75,13 +75,13 @@ class GraphQlGenerator(using sv: SchemaView) {
     lazy val fields = cls.attributeViews.values.map(av => {
       val slotView = av.slotView
       val range = av match {
-        case AnyView(_) =>
+        case AnyView(_, _) =>
           "Any"
         case classAttributeView: ClassAttributeView =>
           classAttributeView.classView.aliasedName
-        case TypeAttributeView(_, typeView) =>
+        case TypeAttributeView(_, _, typeView) =>
           remappedType(typeView)
-        case EnumAttributeView(_, enumView) => enumView.aliasedName
+        case EnumAttributeView(_, _, enumView) => enumView.aliasedName
       }
       GraphQlField(
         slotView.aliasedName,

--- a/generator/src/eu/neverblink/linkml/generator/jsonschema/JsonSchemaGenerator.scala
+++ b/generator/src/eu/neverblink/linkml/generator/jsonschema/JsonSchemaGenerator.scala
@@ -56,8 +56,8 @@ class JsonSchemaGenerator(using sv: SchemaView) {
   ): (MappedSlotName, Schema) = {
     val slot = attributeView.slotView
     val slotSchema = attributeView match {
-      case AnyView(slotView) => Schema.Empty
-      case ClassInlineAttributeView(slotView, classView, inlineType) =>
+      case AnyView(slotView, _) => Schema.Empty
+      case ClassInlineAttributeView(slotView, _, classView, inlineType) =>
         val mappedClassName = className(classView)
         inlineType match {
           case InlineType.plain =>
@@ -79,7 +79,7 @@ class JsonSchemaGenerator(using sv: SchemaView) {
               mappedClassName + "__simple_dict_value",
             ).dictOf // TODO LNK-34: or null
         }
-      case ClassReferenceAttributeView(slotView, classView, identifierView) =>
+      case ClassReferenceAttributeView(slotView, _, classView, identifierView) =>
         typeToRuntime(identifierView.typeView)
           .copy(
             $comment = Some(s"Reference to ${classView.name} class"),
@@ -96,7 +96,7 @@ class JsonSchemaGenerator(using sv: SchemaView) {
             pattern = typeAttribute.pattern.map(Pattern(_)),
           )
           .arrayOfIf(typeAttribute.slotView.slot.multivalued)
-      case EnumAttributeView(slotView, enumView) =>
+      case EnumAttributeView(slotView, _, enumView) =>
         Schema.referenceTo("#/$defs/", enumView._enum.name)
           .arrayOfIf(slotView.slot.multivalued)
     }

--- a/generator/src/eu/neverblink/linkml/generator/scala/ScalaGenerator.scala
+++ b/generator/src/eu/neverblink/linkml/generator/scala/ScalaGenerator.scala
@@ -310,8 +310,9 @@ final class ScalaGenerator(using sv: SchemaView) {
       case _ => rangeCombineFunc
     }
 
-  /** Test whether an attribute is in scope for `equals_expression` support: its range must be
-    * `string` and it must hold a single value.
+  /** Test whether an attribute is a single-valued `string`. That is the only shape a slot can have
+    * to *carry* an `equals_expression`, and the one substitution that needs no [[stringify]]
+    * wrapper.
     */
   private def isSingleValuedString(attribute: AttributeView): Boolean =
     attribute match {
@@ -322,6 +323,24 @@ final class ScalaGenerator(using sv: SchemaView) {
         })
       case _ => false
     }
+
+  /** Describe why `attribute` cannot be substituted into an expression, or None if it can.
+    */
+  private def substitutionProblem(attribute: AttributeView): Option[String] =
+    attribute match {
+      case _: ClassInlineAttributeView =>
+        Some("is an inlined class, which has no string representation")
+      case _ => None
+    }
+
+  /** Whether a slot's Scala field is wrapped in `Option`, and so has to be unwrapped before its
+    * value can be read. Optional booleans are the exception: they are emitted as a plain `Boolean`
+    * defaulting to `false`. Mirrors [[makeTypedDefault]].
+    */
+  private def isOptionField(attribute: AttributeView): Boolean = {
+    val isOptional = InlineType(attribute.slotView) == InlineType.optional
+    isOptional && baseRange(attribute).scalaType != "Boolean"
+  }
 
   /** Build the [[InferredField]]s for a class – one per in-scope slot that has an
     * `equals_expression`.
@@ -346,7 +365,7 @@ final class ScalaGenerator(using sv: SchemaView) {
         InferredField(
           slotName(slot.name),
           slot.name,
-          InlineType(attribute.slotView) == InlineType.optional,
+          isOptionField(attribute),
           renderExpression(classView, attribute, expression),
         )
       }
@@ -367,32 +386,35 @@ final class ScalaGenerator(using sv: SchemaView) {
       expression.elements.map {
         case Literal(value) => scalaStringLiteral(value)
         case substitution: Substitution =>
-          if !isSingleValuedString(substitution.target) then
+          substitutionProblem(substitution.target).foreach { problem =>
             throw RuntimeException(
               s"The equals_expression on '${classView.name}.${target.slotView.slot.name}' " +
-                s"references slot '${substitution.pathString}', which is not a single-valued " +
-                "string",
+                s"references slot '${substitution.pathString}', which $problem",
             )
+          }
           renderPath(substitution.path)
       }.mkString(" + ")
   }
 
-  /** Render a resolved slot path as a Scala expression reading the value at its end. Optional links
-    * along the way are unwrapped with `inferenceInput`, which fails at runtime if the value is
-    * absent. Nested `equals_expression`s are not applied – the value is read as it is.
+  /** Render a resolved slot path as a Scala expression producing the string at its end. Optional
+    * links along the way are unwrapped with `inferenceInput`, which fails at runtime if the value
+    * is absent. Nested `equals_expression`s are not applied – the value is read as it is.
     */
-  private def renderPath(path: Seq[AttributeView]): String =
-    path.foldLeft(("", "")) { case ((expression, prefix), attribute) =>
+  private def renderPath(path: Seq[AttributeView]): String = {
+    val access = path.foldLeft(("", "")) { case ((expression, prefix), attribute) =>
       val name = attribute.slotView.slot.name
       val qualified = if prefix.isEmpty then name else s"$prefix.$name"
-      val access =
+      val field =
         if expression.isEmpty then slotName(name) else s"$expression.${slotName(name)}"
       val unwrapped =
-        if InlineType(attribute.slotView) == InlineType.optional then
-          s"""inferenceInput("$qualified", $access)"""
-        else access
+        if isOptionField(attribute) then s"""inferenceInput("$qualified", $field)"""
+        else field
       (unwrapped, qualified)
     }._1
+    // A string is already what the expression needs. Every other range – numbers, URIs, CURIEs,
+    // dates, references, multivalued slots – goes through the `Stringify` typeclass.
+    if isSingleValuedString(path.last) then access else s"stringify($access)"
+  }
 
   /** Quote and escape a string so it can be emitted as a Scala string literal. */
   private def scalaStringLiteral(value: String): String = {
@@ -635,6 +657,9 @@ object ScalaGenerator {
         else "abstract class"
 
       val kind = extensibleKind + baseKind
+      val declaration =
+        if (sealedInterface) s"$kind $name derives Stringify"
+        else s"$kind $name"
 
       indent"""package $pkg
          |
@@ -643,7 +668,7 @@ object ScalaGenerator {
          |import eu.neverblink.linkml.runtime.*
          |
          |$docs
-         |$kind $name
+         |$declaration
          |
          |object $name {
          |  ${cases.map(_.generateCase).mkString("\n")}

--- a/generator/src/eu/neverblink/linkml/generator/scala/ScalaGenerator.scala
+++ b/generator/src/eu/neverblink/linkml/generator/scala/ScalaGenerator.scala
@@ -218,7 +218,11 @@ final class ScalaGenerator(using sv: SchemaView) {
       case AnyView(slotView, _) =>
         (Case.PascalCase(slotView.derivedRange.resolve.get.name), None)
       case ClassInlineAttributeView(_, _, classView, _) =>
-        (s"${Case.PascalCase(classView.cls.name)}Impl", None)
+        // Abstract classes and mixins get no `...Impl` case class, so an inlined range pointing at
+        // one has to be typed as the interface instead.
+        val className = Case.PascalCase(classView.cls.name)
+        val hasImpl = !classView.cls.`abstract` && !classView.cls.mixin
+        (if hasImpl then s"${className}Impl" else className, None)
       case ClassReferenceAttributeView(_, _, classView, _) =>
         (s"Reference[${Case.PascalCase(classView.cls.name)}]", None)
       case TypeAttributeView(_, _, typeView) =>
@@ -496,14 +500,7 @@ object ScalaGenerator {
             |""".stripMargin
         val inferMethod =
           indent"""
-            |/** Fill in the slots that have an `equals_expression` with their computed values, and
-            |  * check that the values already present agree with what their expressions infer.
-            |  *
-            |  * @throws InferenceException
-            |  *   if a slot's value contradicts the value inferred for it, or if an expression
-            |  *   references a slot that has no value
-            |  */
-            |def infer(): ${name}Impl =
+            |override def infer(): ${name}Impl =
             |  ${
               if inferredFields.isEmpty then "this"
               else indent"""copy(
@@ -570,11 +567,12 @@ object ScalaGenerator {
       // Declared on the interface so callers can infer without knowing the implementation type.
       // The implementation narrows the return type to its own `${name}Impl`.
       val inferDeclaration =
-        indent"""/** Fill in the slots that have an `equals_expression`, and check the values already
-                |  * present against them.
+        indent"""/** Fill in the slots that have an `equals_expression` with their computed values, and
+                |  * check that the values already present agree with what their expressions infer.
                 |  *
-                |  * @throws InferenceException
-                |  *   if a slot's value contradicts the value inferred for it
+                |  * @throws eu.neverblink.linkml.runtime.InferenceException
+                |  *   if a slot's value contradicts the value inferred for it, or if an expression
+                |  *   references a slot that has no value
                 |  */
                 |def infer(): $name
                 |""".stripMargin

--- a/generator/src/eu/neverblink/linkml/generator/scala/ScalaGenerator.scala
+++ b/generator/src/eu/neverblink/linkml/generator/scala/ScalaGenerator.scala
@@ -33,8 +33,8 @@ final class ScalaGenerator(using sv: SchemaView) {
       given PrefixResolver = classView.definingPrefixResolver
       val cls = classView.cls
       val collectionForm = CollectionForm.of(classView)
-      val scalaFields = for slot <- classView.derivedAttributes.values.toIndexedSeq yield {
-        makeScalaField(slot, collectionForm)
+      val scalaFields = for attribute <- classView.attributeViews.values.toIndexedSeq yield {
+        makeScalaField(attribute, collectionForm)
       }
       val shouldBeTrait = cls.mixin || classView.uriStr == "https://w3id.org/linkml/EnumExpression"
       val isSlotDefinitionClass = classView.uriStr == "https://w3id.org/linkml/SlotDefinition"
@@ -198,62 +198,54 @@ final class ScalaGenerator(using sv: SchemaView) {
     case UnknownType => tv.inner.base.getOrElse("Unknown")
   }
 
-  /** Translates a LinkML range value to the appropriate Scala type.
+  /** Translates an attribute's resolved range to the appropriate Scala type.
     *
-    * @param slot
-    *   SlotView of the slot we are generating the Scala type for
-    * @param range
-    *   Value of the LinkML range
-    * @param isInlined
-    *   Whether the slot is declared as inlined. Note: The slot may be implicitly inlined when the
-    *   range class does not have an identifier.
+    * @param attribute
+    *   AttributeView of the slot we are generating the Scala type for
     * @return
     *   (Scala type which best represents the range, default value for the type if applicable)
     */
   private def baseRange(
-      slot: SlotView,
-      range: Reference[ElementView[?, ?]],
-      isInlined: Boolean,
+      attribute: AttributeView,
   ): (scalaType: String, baseDefault: Option[String]) = {
-    range.resolve.get match {
-      case classView: ClassView =>
-        // Redirect classes with uri == linkml:Any to the runtime class, as by spec it's not a builtin class:
-        // From https://linkml.io/linkml/schemas/advanced.html#linkml-any-type
-        // "but any class in the schema can take on this roll be being declared as linkml:Any using class_uri"
-        val className = Case.PascalCase(classView.cls.name)
-        if (classView.uriStr == "https://w3id.org/linkml/Any") (className, None)
-        else if (isInlined) (s"${className}Impl", None)
-        else (s"Reference[$className]", None)
-      case typeView: TypeView =>
+    attribute match {
+      // Redirect classes with uri == linkml:Any to the runtime class, as by spec it's not a builtin class:
+      // From https://linkml.io/linkml/schemas/advanced.html#linkml-any-type
+      // "but any class in the schema can take on this roll be being declared as linkml:Any using class_uri"
+      case AnyView(slotView, _) =>
+        (Case.PascalCase(slotView.derivedRange.resolve.get.name), None)
+      case ClassInlineAttributeView(_, _, classView, _) =>
+        (s"${Case.PascalCase(classView.cls.name)}Impl", None)
+      case ClassReferenceAttributeView(_, _, classView, _) =>
+        (s"Reference[${Case.PascalCase(classView.cls.name)}]", None)
+      case TypeAttributeView(_, _, typeView) =>
         if typeView.isPrimitive then (typeToRuntime(typeView), None)
         else (Case.PascalCase(typeView._type.name), None)
       // True enum support would require working around the dynamic "enums" of LinkML, which I'm sure
       // were a really convenient idea for the biologists, but it adds a lot of complexity for us
-      case enumView: EnumView =>
+      case EnumAttributeView(slotView, _, enumView) =>
         val enumDef = enumView._enum
         if (enumDef.permissibleValues.isEmpty)
           ("String", None) // fallback to String for dynamic enums
         else {
           val enumName = Case.PascalCase(enumDef.name)
-          val default: Option[PermissibleValue] = slot.ifAbsent(enumView)
+          val default: Option[PermissibleValue] = slotView.ifAbsent(enumView)
           (enumName, default.map(p => s"$enumName.${Case.PascalCase(p.text)}"))
         }
-      case _ => throw RuntimeException(s"Couldn't map range $range")
     }
   }
 
   /** Create a [[TypedDefault]] containing all the type-level information for a slot's range / Scala
     * field type. Handles implicit / explicit inlines, inline styles, combining functions and
     * default values (sans `ifabasent`).
-    * @param slot
-    *   Slot to derive the type-level information for
+    * @param attribute
+    *   Attribute to derive the type-level information for
     * @return
     *   The inferred [[TypedDefault]]
     */
-  private def makeTypedDefault(slot: SlotView): TypedDefault = {
-    val range = slot.derivedRange
-    val inlined = slot.derivedInlined
-    val (scalaType, defaultValue) = baseRange(slot, range, inlined)
+  private def makeTypedDefault(attribute: AttributeView): TypedDefault = {
+    val slot = attribute.slotView
+    val (scalaType, defaultValue) = baseRange(attribute)
     InlineType(slot) match {
       case InlineType.plain => TypedDefault(scalaType, defaultValue)
       case InlineType.optional if scalaType == "Boolean" =>
@@ -312,12 +304,16 @@ final class ScalaGenerator(using sv: SchemaView) {
     }
 
   /** Create a [[ScalaField]] instance, by inferring the [[TypedDefault]] and additional annotations
-    * @param v
-    *   Slot to construct the [[ScalaField]] instance for
+    * @param attribute
+    *   Attribute to construct the [[ScalaField]] instance for
     * @param collectionForm
     *   Collection form of the owner class
     */
-  private def makeScalaField(v: SlotView, collectionForm: CollectionForm): ScalaField = {
+  private def makeScalaField(
+      attribute: AttributeView,
+      collectionForm: CollectionForm,
+  ): ScalaField = {
+    val v = attribute.slotView
     val slot = v.slot
     val name = slotName(slot.name)
     // Move id / value to the front, regardless of rank
@@ -331,7 +327,7 @@ final class ScalaGenerator(using sv: SchemaView) {
       slot.alias
         .orElse(if slot.name != name then Some(slot.name) else None)
         .map(s => s"@named(\"${Case.deSpaceCase(s)}\")")
-    val typedDefault = makeTypedDefault(v)
+    val typedDefault = makeTypedDefault(attribute)
     ScalaField(
       name,
       typedDefault.typeName,

--- a/generator/src/eu/neverblink/linkml/generator/scala/ScalaGenerator.scala
+++ b/generator/src/eu/neverblink/linkml/generator/scala/ScalaGenerator.scala
@@ -4,6 +4,8 @@ import eu.neverblink.linkml.generator.util.*
 import eu.neverblink.linkml.metamodel.*
 import eu.neverblink.linkml.runtime.*
 import eu.neverblink.linkml.schemaview.*
+import eu.neverblink.linkml.schemaview.expression.StringInterpolationExpression
+import fastparse.Parsed
 import java.lang
 
 final class ScalaGenerator(using sv: SchemaView) {
@@ -59,6 +61,7 @@ final class ScalaGenerator(using sv: SchemaView) {
             cls.`abstract` || cls.mixin,
             shouldBeTrait,
             isSlotDefinitionClass,
+            makeInferredFields(classView),
             ScalaDoc(classView.materialize, classView.definingSchema.id),
           ).print
       )
@@ -303,6 +306,89 @@ final class ScalaGenerator(using sv: SchemaView) {
       case _ => rangeCombineFunc
     }
 
+  /** Test whether an attribute is in scope for `equals_expression` support: its range must be
+    * `string` and it must hold a single value. Interpolating a collection or a non-string range is
+    * not supported, so such slots are left alone.
+    */
+  private def isSingleValuedString(attribute: AttributeView): Boolean =
+    attribute match {
+      case TypeAttributeView(slotView, _, typeView) =>
+        typeView.runtimeType == StringType && (InlineType(slotView) match {
+          case InlineType.plain | InlineType.optional => true
+          case _ => false
+        })
+      case _ => false
+    }
+
+  /** Build the [[InferredField]]s for a class - one per in-scope slot that has an
+    * `equals_expression`. Out-of-scope slots (see [[isSingleValuedString]]) are skipped, so they
+    * behave exactly as they did before `equals_expression` was supported.
+    *
+    * @throws RuntimeException
+    *   if an in-scope slot's expression fails to parse, or references an out-of-scope slot
+    */
+  private def makeInferredFields(classView: ClassView): Seq[InferredField] =
+    classView.attributeViews.values.toSeq
+      .filter(isSingleValuedString)
+      .flatMap(attribute => attribute.equalsExpression.map(attribute -> _))
+      .map { (attribute, parsed) =>
+        val slot = attribute.slotView.slot
+        val expression = parsed match {
+          case Parsed.Success(value, _) => value
+          case f: Parsed.Failure =>
+            throw RuntimeException(
+              s"Invalid equals_expression on '${classView.name}.${slot.name}': " +
+                f.trace().longAggregateMsg,
+            )
+        }
+        InferredField(
+          slotName(slot.name),
+          slot.name,
+          InlineType(attribute.slotView) == InlineType.optional,
+          renderExpression(classView, attribute, expression),
+        )
+      }
+
+  /** Render a parsed interpolation expression as a Scala string-concatenation expression.
+    *
+    * @throws RuntimeException
+    *   if the expression references an out-of-scope slot
+    */
+  private def renderExpression(
+      classView: ClassView,
+      target: AttributeView,
+      expression: StringInterpolationExpression,
+  ): String = {
+    import StringInterpolationExpression.{Literal, Substitution}
+    if expression.elements.isEmpty then "\"\""
+    else
+      expression.elements.map {
+        case Literal(value) => scalaStringLiteral(value)
+        case Substitution(referenced) =>
+          val name = referenced.slotView.slot.name
+          if !isSingleValuedString(referenced) then
+            throw RuntimeException(
+              s"The equals_expression on '${classView.name}.${target.slotView.slot.name}' " +
+                s"references slot '$name', which is not a single-valued string",
+            )
+          val field = slotName(name)
+          if InlineType(referenced.slotView) == InlineType.optional then
+            s"""inferenceInput("$name", $field)"""
+          else field
+      }.mkString(" + ")
+  }
+
+  /** Quote and escape a string so it can be emitted as a Scala string literal. */
+  private def scalaStringLiteral(value: String): String = {
+    val escaped = value
+      .replace("\\", "\\\\")
+      .replace("\"", "\\\"")
+      .replace("\n", "\\n")
+      .replace("\r", "\\r")
+      .replace("\t", "\\t")
+    s""""$escaped""""
+  }
+
   /** Create a [[ScalaField]] instance, by inferring the [[TypedDefault]] and additional annotations
     * @param attribute
     *   Attribute to construct the [[ScalaField]] instance for
@@ -366,6 +452,9 @@ object ScalaGenerator {
     *   class.
     * @param generateSlotCombining
     *   Whether to generate the slot combining methods for this class.
+    * @param inferredFields
+    *   Fields whose value can be computed from an `equals_expression`. May be empty, in which case
+    *   `infer()` is still generated, but does nothing.
     * @param docs
     *   ScalaDoc for generating Scaladoc for this class.
     */
@@ -378,6 +467,7 @@ object ScalaGenerator {
       skipImpl: Boolean,
       traitInterface: Boolean,
       generateSlotCombining: Boolean,
+      inferredFields: Seq[InferredField],
       docs: ScalaDoc,
   ) extends Printable:
     /** Builds the Scala representation of a LinkML [[ClassDefinition]]
@@ -406,12 +496,32 @@ object ScalaGenerator {
             |    ${fields.map(_.generateCaseClassField).mkString("\n")}
             |) extends $name
             |""".stripMargin
-        val caseClassBody =
-          if !generateSlotCombining then ""
-          else {
-            val combineRange =
-              "combineRange: (Reference[Element], Reference[Element]) => Reference[Element]"
-            val combiningFunctions =
+        val inferMethod =
+          indent"""
+            |/** Fill in the slots that have an `equals_expression` with their computed values, and
+            |  * check that the values already present agree with what their expressions infer.
+            |  *
+            |  * Only single-valued slots with a `string` range are inferred; slots with any other
+            |  * range are left untouched.
+            |  *
+            |  * @throws InferenceException
+            |  *   if a slot's value contradicts the value inferred for it, or if an expression
+            |  *   references a slot that has no value
+            |  */
+            |def infer(): ${name}Impl =
+            |  ${
+              if inferredFields.isEmpty then "this"
+              else indent"""copy(
+                  |  ${inferredFields.map(_.generateInferPart).mkString(",\n")}
+                  |)""".stripMargin
+            }
+            |""".stripMargin
+        val caseClassBody = {
+          val combining =
+            if !generateSlotCombining then ""
+            else {
+              val combineRange =
+                "combineRange: (Reference[Element], Reference[Element]) => Reference[Element]"
               indent"""
               |/** Unfolded slot combining procedure `for metaslot in metaslots` from the spec. This variant
               |  * merges ALL SlotDefinition slots.
@@ -442,12 +552,14 @@ object ScalaGenerator {
                   .mkString(",\n")}
               |  )
               |""".stripMargin
-            indent"""
-            |{
-            |  $combiningFunctions
-            |}
-            |""".stripMargin
-          }
+            }
+          indent"""
+          |{
+          |  $combining
+          |  $inferMethod
+          |}
+          |""".stripMargin
+        }
 
         sb.append(indent"$caseClassConstructor $caseClassBody\n\n")
       }
@@ -460,9 +572,22 @@ object ScalaGenerator {
       val interfaceBody = fields
         .filter(x => interfaceFields.contains(x.name))
         .map(_.generateInterfaceField).mkString("\n")
+      // Declared on the interface so callers can infer without knowing the implementation type.
+      // The implementation narrows the return type to its own `${name}Impl`.
+      val inferDeclaration =
+        indent"""/** Fill in the slots that have an `equals_expression`, and check the values already
+                |  * present against them.
+                |  *
+                |  * @throws InferenceException
+                |  *   if a slot's value contradicts the value inferred for it
+                |  */
+                |def infer(): $name
+                |""".stripMargin
       sb.append(indent"""$docs
                 |$interfaceDef $name $inheritanceList {
                 |  $interfaceBody
+                |
+                |  $inferDeclaration
                 |}
                 |""".stripMargin)
       sb.toString
@@ -632,6 +757,29 @@ object ScalaGenerator {
       */
     def generateCombiningFunctionPart: String =
       s"""$name = ${combineFunc.generate(name, "this", "other")}"""
+
+  /** A field whose value can be computed from the slot's `equals_expression`.
+    *
+    * @param name
+    *   Name of the field, in camelCase.
+    * @param slotName
+    *   Name of the slot as written in the schema, used in error messages at runtime.
+    * @param optional
+    *   Whether the field is an `Option`, and so can be filled in. Required fields can only be
+    *   checked for consistency.
+    * @param expression
+    *   Scala expression computing the field's value from the other fields of the class.
+    */
+  case class InferredField(
+      name: String,
+      slotName: String,
+      optional: Boolean,
+      expression: String,
+  ):
+    /** Generate the `copy()` argument that infers or checks this field. */
+    def generateInferPart: String =
+      if optional then s"""$name = inferOptional("$slotName", $name, $expression)"""
+      else s"""$name = inferRequired("$slotName", $name, $expression)"""
 
   /** Contains all information necessary for generating a Scala enum cases.
     *

--- a/generator/src/eu/neverblink/linkml/generator/scala/ScalaGenerator.scala
+++ b/generator/src/eu/neverblink/linkml/generator/scala/ScalaGenerator.scala
@@ -307,8 +307,7 @@ final class ScalaGenerator(using sv: SchemaView) {
     }
 
   /** Test whether an attribute is in scope for `equals_expression` support: its range must be
-    * `string` and it must hold a single value. Interpolating a collection or a non-string range is
-    * not supported, so such slots are left alone.
+    * `string` and it must hold a single value.
     */
   private def isSingleValuedString(attribute: AttributeView): Boolean =
     attribute match {
@@ -320,9 +319,8 @@ final class ScalaGenerator(using sv: SchemaView) {
       case _ => false
     }
 
-  /** Build the [[InferredField]]s for a class - one per in-scope slot that has an
-    * `equals_expression`. Out-of-scope slots (see [[isSingleValuedString]]) are skipped, so they
-    * behave exactly as they did before `equals_expression` was supported.
+  /** Build the [[InferredField]]s for a class – one per in-scope slot that has an
+    * `equals_expression`.
     *
     * @throws RuntimeException
     *   if an in-scope slot's expression fails to parse, or references an out-of-scope slot

--- a/generator/src/eu/neverblink/linkml/generator/scala/ScalaGenerator.scala
+++ b/generator/src/eu/neverblink/linkml/generator/scala/ScalaGenerator.scala
@@ -499,9 +499,6 @@ object ScalaGenerator {
             |/** Fill in the slots that have an `equals_expression` with their computed values, and
             |  * check that the values already present agree with what their expressions infer.
             |  *
-            |  * Only single-valued slots with a `string` range are inferred; slots with any other
-            |  * range are left untouched.
-            |  *
             |  * @throws InferenceException
             |  *   if a slot's value contradicts the value inferred for it, or if an expression
             |  *   references a slot that has no value

--- a/generator/src/eu/neverblink/linkml/generator/scala/ScalaGenerator.scala
+++ b/generator/src/eu/neverblink/linkml/generator/scala/ScalaGenerator.scala
@@ -366,19 +366,33 @@ final class ScalaGenerator(using sv: SchemaView) {
     else
       expression.elements.map {
         case Literal(value) => scalaStringLiteral(value)
-        case Substitution(referenced) =>
-          val name = referenced.slotView.slot.name
-          if !isSingleValuedString(referenced) then
+        case substitution: Substitution =>
+          if !isSingleValuedString(substitution.target) then
             throw RuntimeException(
               s"The equals_expression on '${classView.name}.${target.slotView.slot.name}' " +
-                s"references slot '$name', which is not a single-valued string",
+                s"references slot '${substitution.pathString}', which is not a single-valued " +
+                "string",
             )
-          val field = slotName(name)
-          if InlineType(referenced.slotView) == InlineType.optional then
-            s"""inferenceInput("$name", $field)"""
-          else field
+          renderPath(substitution.path)
       }.mkString(" + ")
   }
+
+  /** Render a resolved slot path as a Scala expression reading the value at its end. Optional links
+    * along the way are unwrapped with `inferenceInput`, which fails at runtime if the value is
+    * absent. Nested `equals_expression`s are not applied – the value is read as it is.
+    */
+  private def renderPath(path: Seq[AttributeView]): String =
+    path.foldLeft(("", "")) { case ((expression, prefix), attribute) =>
+      val name = attribute.slotView.slot.name
+      val qualified = if prefix.isEmpty then name else s"$prefix.$name"
+      val access =
+        if expression.isEmpty then slotName(name) else s"$expression.${slotName(name)}"
+      val unwrapped =
+        if InlineType(attribute.slotView) == InlineType.optional then
+          s"""inferenceInput("$qualified", $access)"""
+        else access
+      (unwrapped, qualified)
+    }._1
 
   /** Quote and escape a string so it can be emitted as a Scala string literal. */
   private def scalaStringLiteral(value: String): String = {

--- a/generator/src/eu/neverblink/linkml/generator/scala/ScalaGenerator.scala
+++ b/generator/src/eu/neverblink/linkml/generator/scala/ScalaGenerator.scala
@@ -540,6 +540,8 @@ object ScalaGenerator {
             |    ${fields.map(_.generateCaseClassField).mkString("\n")}
             |) extends $name
             |""".stripMargin
+        // TODO LNK-170: consider making infer() a typeclass, so that the generated classes are not
+        // bound to inference logic.
         val inferMethod =
           indent"""
             |override def infer(): ${name}Impl =

--- a/generator/test/src/eu/neverblink/linkml/generator/linkml/LinkMlGeneratorSpec.scala
+++ b/generator/test/src/eu/neverblink/linkml/generator/linkml/LinkMlGeneratorSpec.scala
@@ -288,6 +288,42 @@ class LinkMlGeneratorSpec extends AnyWordSpec, Matchers {
         |}""".stripMargin
     }
 
+    "serialize string values that look like numbers, booleans or nulls as strings" in {
+      val sv = SchemaView.loadSchemaViewFromString("""name: numeric_strings
+          |id: https://example.org/numeric-strings
+          |title: "123"
+          |description: "true"
+          |license: "null"
+          |classes:
+          |  SomeClass:
+          |    description: "3.14"
+          |""".stripMargin)
+
+      LinkMlGenerator(using sv).serialize(outputFormat = LinkMlGenerator.OutputFormat.json) shouldBe
+        """{
+        |  "name": "numeric_strings",
+        |  "id": "https://example.org/numeric-strings",
+        |  "classes": {
+        |    "SomeClass": {
+        |      "class_uri": "https://example.org/numeric-strings/SomeClass",
+        |      "description": "3.14",
+        |      "from_schema": "https://example.org/numeric-strings"
+        |    }
+        |  },
+        |  "title": "123",
+        |  "description": "true",
+        |  "license": "null"
+        |}""".stripMargin
+
+      // The same nodes feed the YAML output, which must quote them for the same reason.
+      val yaml =
+        LinkMlGenerator(using sv).serialize(outputFormat = LinkMlGenerator.OutputFormat.yaml)
+      yaml should include("""title: "123"""")
+      yaml should include("""description: "true"""")
+      yaml should include("""license: "null"""")
+      yaml should include("""description: "3.14"""")
+    }
+
     "generate all catalogue models without errors" when {
       for entry <- ModelCatalogue.all.filter(m => !skipModels.contains(m.model.root.name)) do
         s"model '${entry.model.root.name}'" in {

--- a/generator/test/src/eu/neverblink/linkml/generator/scala/ScalaGeneratorSpec.scala
+++ b/generator/test/src/eu/neverblink/linkml/generator/scala/ScalaGeneratorSpec.scala
@@ -790,6 +790,23 @@ class ScalaGeneratorSpec extends AnyWordSpec, Matchers {
       }
     }
 
+    "generate an infer() method reaching into inlined classes" in {
+      val code = ScalaGenerator(using ModelCatalogue.equalsExpression.model)
+        .generate(testPkg).toMap.apply("SomeClass.scala")
+      Seq(
+        // Every optional link along the path is unwrapped, the outermost one last
+        """fromOptionalNested = inferOptional("from_optional_nested", fromOptionalNested, """ +
+          """inferenceInput("optional_nested.leaf", """ +
+          """inferenceInput("optional_nested", optionalNested).leaf))""",
+        // A required link needs no unwrapping, an optional one further down still does
+        """fromRequiredNested = inferOptional("from_required_nested", fromRequiredNested, """ +
+          """requiredNested.requiredLeaf + " at " + """ +
+          """inferenceInput("required_nested.deeper", requiredNested.deeper).bottom)""",
+      ).foreach { snippet =>
+        code should include(snippet)
+      }
+    }
+
     "generate an infer() method that does nothing when there are no expressions" in {
       val code = ScalaGenerator(using ModelCatalogue.basic.model)
         .generate(testPkg).toMap.apply("SomeClass.scala")

--- a/generator/test/src/eu/neverblink/linkml/generator/scala/ScalaGeneratorSpec.scala
+++ b/generator/test/src/eu/neverblink/linkml/generator/scala/ScalaGeneratorSpec.scala
@@ -729,6 +729,51 @@ class ScalaGeneratorSpec extends AnyWordSpec, Matchers {
       }
     }
 
+    "generate an infer() method from equals_expression" in {
+      val code = ScalaGenerator(using ModelCatalogue.equalsExpression.model)
+        .generate(testPkg).toMap.apply("SomeClass.scala")
+      Seq(
+        // Declared on the interface, narrowed to the implementation type in the impl
+        "def infer(): SomeClass\n",
+        "def infer(): SomeClassImpl",
+        // Optional target is filled in, the Option-ranged reference is unwrapped
+        """optionalMessage = inferOptional("optional_message", optionalMessage, """ +
+          """"Unknown reference to element '" + inferenceInput("reference_value", """ +
+          """referenceValue) + "'")""",
+        // Required target is checked only
+        """requiredMessage = inferRequired("required_message", requiredMessage, """ +
+          """"ref is " + inferenceInput("reference_value", referenceValue))""",
+        // A required reference needs no unwrapping
+        """fromRequired = inferOptional("from_required", fromRequired, """ +
+          """requiredSource + " / " + requiredSource)""",
+        // A literal-only expression is emitted as a plain string
+        """literalOnly = inferOptional("literal_only", literalOnly, "no substitutions here")""",
+        // `{{`/`}}` are unescaped, and quotes are escaped for the Scala literal
+        """withEscapes = inferOptional("with_escapes", withEscapes, """ +
+          """"braces {like this} and a \"quote\"")""",
+      ).foreach { snippet =>
+        code should include(snippet)
+      }
+
+      Seq(
+        // Slots without an expression are not inferred
+        "noExpression = infer",
+        // Out of scope: only single-valued string slots are inferred
+        "multivaluedIgnored = infer",
+        "integerIgnored = infer",
+      ).foreach { snippet =>
+        code should not include snippet
+      }
+    }
+
+    "generate an infer() method that does nothing when there are no expressions" in {
+      val code = ScalaGenerator(using ModelCatalogue.basic.model)
+        .generate(testPkg).toMap.apply("SomeClass.scala")
+      code should include("def infer(): SomeClassImpl")
+      code should include("def infer(): SomeClass\n")
+      code should not include "inferOptional"
+    }
+
     "generate ifabsent default values for enum-ranged slots" in {
       val files = ScalaGenerator(using ModelCatalogue.ifabsent.enums.model).generate(testPkg).toMap
       val code = files("SomeClass.scala")

--- a/generator/test/src/eu/neverblink/linkml/generator/scala/ScalaGeneratorSpec.scala
+++ b/generator/test/src/eu/neverblink/linkml/generator/scala/ScalaGeneratorSpec.scala
@@ -199,6 +199,30 @@ class ScalaGeneratorSpec extends AnyWordSpec, Matchers {
       }
     }
 
+    "type inlined ranges of abstract classes and mixins as the interface" in {
+      // Abstract classes and mixins get no `...Impl` case class, so an inlined range pointing at
+      // one has to be typed as the interface, or the generated code does not compile.
+      given SchemaView = ModelCatalogue.inlines.inlineAbstract.model
+
+      val code = ScalaGenerator().generate(testPkg).toMap.apply("Container.scala")
+      Seq(
+        "toAbstract: Option[AbstractRange] = None",
+        "toMixin: Option[MixinRange] = None",
+        "manyAbstract: Seq[AbstractRange] = Seq()",
+        // A concrete range still gets the implementation type
+        "toConcrete: Option[ConcreteRangeImpl] = None",
+      ).foreach { snippet =>
+        code should include(snippet)
+      }
+
+      Seq(
+        "AbstractRangeImpl",
+        "MixinRangeImpl",
+      ).foreach { snippet =>
+        code should not include snippet
+      }
+    }
+
     "provide annotations for the 'alias' slot" in {
       val input =
         s"""$schemaShared

--- a/generator/test/src/eu/neverblink/linkml/generator/scala/ScalaGeneratorSpec.scala
+++ b/generator/test/src/eu/neverblink/linkml/generator/scala/ScalaGeneratorSpec.scala
@@ -683,7 +683,7 @@ class ScalaGeneratorSpec extends AnyWordSpec, Matchers {
           |  * @see
           |  *   From schema: https://neverblink.eu/linkml/scala/test
           |  */
-          |sealed abstract class SomeEnum
+          |sealed abstract class SomeEnum derives Stringify
           |
           |object SomeEnum {
           |  /** Value 1.
@@ -805,6 +805,104 @@ class ScalaGeneratorSpec extends AnyWordSpec, Matchers {
       ).foreach { snippet =>
         code should include(snippet)
       }
+    }
+
+    "generate an infer() method that stringifies non-string ranges" in {
+      val code = ScalaGenerator(using ModelCatalogue.equalsExpression.model)
+        .generate(testPkg).toMap.apply("SomeClass.scala")
+      Seq(
+        """fromNumbers = inferOptional("from_numbers", fromNumbers, """ +
+          """stringify(inferenceInput("count", count)) + " items, ratio " + """ +
+          """stringify(inferenceInput("ratio", ratio)) + ", flag " + stringify(flag) + """ +
+          """", on " + stringify(inferenceInput("created", created)))""",
+        // A required URI needs no unwrapping, optional CURIEs still do
+        """fromUris = inferOptional("from_uris", fromUris, stringify(homepage) + " | " + """ +
+          """stringify(inferenceInput("term", term)) + " | " + """ +
+          """stringify(inferenceInput("either", either)))""",
+        // Multivalued slots are never Option-wrapped, so they go straight to `stringify`
+        """fromMultivalued = inferOptional("from_multivalued", fromMultivalued, """ +
+          """"tags: [" + stringify(tags) + "], codes: [" + stringify(codes) + "]")""",
+        // References stringify to the identifier they hold
+        """fromReferences = inferOptional("from_references", fromReferences, """ +
+          """stringify(inferenceInput("target", target)) + " <- " + stringify(targets))""",
+      ).foreach { snippet =>
+        code should include(snippet)
+      }
+
+      // A plain string is already a string, so it is not wrapped
+      code should include(""""ref is " + inferenceInput("reference_value", referenceValue)""")
+    }
+
+    "refuse to substitute an inlined class into an expression" in {
+      val input =
+        s"""$schemaShared
+           |classes:
+           |  Inner:
+           |    attributes:
+           |      a:
+           |        range: string
+           |  SomeClass:
+           |    attributes:
+           |      inner:
+           |        range: Inner
+           |        inlined: true
+           |      message:
+           |        range: string
+           |        equals_expression: "{inner}"
+           |""".stripMargin
+      val error = intercept[RuntimeException] {
+        ScalaGenerator(using decode(input)).generate(testPkg).toMap
+      }
+      error.getMessage should include("SomeClass.message")
+      error.getMessage should include("inner")
+      error.getMessage should include("inlined class")
+    }
+
+    "substitute a static enum, which stringifies to its LinkML text" in {
+      val code = ScalaGenerator(using ModelCatalogue.equalsExpression.model)
+        .generate(testPkg).toMap
+      // The instance is derived from the sealed hierarchy, reading the `@named` text
+      code("StatusEnum.scala") should include("sealed abstract class StatusEnum derives Stringify")
+      code("StatusEnum.scala") should include("""@named("in progress") case object InProgress""")
+      code("SomeClass.scala") should include(
+        """fromEnum = inferOptional("from_enum", fromEnum, """ +
+          """stringify(inferenceInput("status", status)) + " of (" + stringify(statuses) + ")")""",
+      )
+    }
+
+    "not derive Stringify for a non-sealed enum" in {
+      val input =
+        s"""$schemaShared
+           |enums:
+           |  SomeEnum:
+           |    abstract: true
+           |    permissible_values:
+           |      a:
+           |""".stripMargin
+      val code = ScalaGenerator(using decode(input)).generate(testPkg).toMap
+        .apply("SomeEnum.scala")
+      code should include("abstract class SomeEnum")
+      code should not include "derives Stringify"
+    }
+
+    "substitute a dynamic enum, which is generated as a plain string" in {
+      val input =
+        s"""$schemaShared
+           |enums:
+           |  SomeEnum: {}
+           |classes:
+           |  SomeClass:
+           |    attributes:
+           |      choice:
+           |        range: SomeEnum
+           |      message:
+           |        range: string
+           |        equals_expression: "{choice}"
+           |""".stripMargin
+      val code = ScalaGenerator(using decode(input)).generate(testPkg).toMap
+        .apply("SomeClass.scala")
+      code should include("choice: Option[String]")
+      code should include("""inferenceInput("choice", choice)""")
     }
 
     "generate an infer() method that does nothing when there are no expressions" in {

--- a/metamodel/src/eu/neverblink/linkml/metamodel/AliasPredicateEnum.scala
+++ b/metamodel/src/eu/neverblink/linkml/metamodel/AliasPredicateEnum.scala
@@ -9,7 +9,7 @@ import eu.neverblink.linkml.runtime.*
   * @see
   *   From schema: https://w3id.org/linkml/meta
   */
-sealed abstract class AliasPredicateEnum
+sealed abstract class AliasPredicateEnum derives Stringify
 
 object AliasPredicateEnum {
 

--- a/metamodel/src/eu/neverblink/linkml/metamodel/AltDescription.scala
+++ b/metamodel/src/eu/neverblink/linkml/metamodel/AltDescription.scala
@@ -17,14 +17,7 @@ final case class AltDescriptionImpl(
     altDescriptionText: String,
 ) extends AltDescription {
 
-  /** Fill in the slots that have an `equals_expression` with their computed values, and check that
-    * the values already present agree with what their expressions infer.
-    *
-    * @throws InferenceException
-    *   if a slot's value contradicts the value inferred for it, or if an expression references a
-    *   slot that has no value
-    */
-  def infer(): AltDescriptionImpl =
+  override def infer(): AltDescriptionImpl =
     this
 }
 
@@ -51,11 +44,12 @@ abstract class AltDescription {
     */
   def altDescriptionText: String
 
-  /** Fill in the slots that have an `equals_expression`, and check the values already present
-    * against them.
+  /** Fill in the slots that have an `equals_expression` with their computed values, and check that
+    * the values already present agree with what their expressions infer.
     *
-    * @throws InferenceException
-    *   if a slot's value contradicts the value inferred for it
+    * @throws eu.neverblink.linkml.runtime.InferenceException
+    *   if a slot's value contradicts the value inferred for it, or if an expression references a
+    *   slot that has no value
     */
   def infer(): AltDescription
 }

--- a/metamodel/src/eu/neverblink/linkml/metamodel/AltDescription.scala
+++ b/metamodel/src/eu/neverblink/linkml/metamodel/AltDescription.scala
@@ -15,7 +15,21 @@ final case class AltDescriptionImpl(
     @value
     @named("description")
     altDescriptionText: String,
-) extends AltDescription
+) extends AltDescription {
+
+  /** Fill in the slots that have an `equals_expression` with their computed values, and check that
+    * the values already present agree with what their expressions infer.
+    *
+    * Only single-valued slots with a `string` range are inferred; slots with any other range are
+    * left untouched.
+    *
+    * @throws InferenceException
+    *   if a slot's value contradicts the value inferred for it, or if an expression references a
+    *   slot that has no value
+    */
+  def infer(): AltDescriptionImpl =
+    this
+}
 
 /** An attributed description
   *
@@ -39,4 +53,12 @@ abstract class AltDescription {
     *   From schema: https://w3id.org/linkml/meta
     */
   def altDescriptionText: String
+
+  /** Fill in the slots that have an `equals_expression`, and check the values already present
+    * against them.
+    *
+    * @throws InferenceException
+    *   if a slot's value contradicts the value inferred for it
+    */
+  def infer(): AltDescription
 }

--- a/metamodel/src/eu/neverblink/linkml/metamodel/AltDescription.scala
+++ b/metamodel/src/eu/neverblink/linkml/metamodel/AltDescription.scala
@@ -20,9 +20,6 @@ final case class AltDescriptionImpl(
   /** Fill in the slots that have an `equals_expression` with their computed values, and check that
     * the values already present agree with what their expressions infer.
     *
-    * Only single-valued slots with a `string` range are inferred; slots with any other range are
-    * left untouched.
-    *
     * @throws InferenceException
     *   if a slot's value contradicts the value inferred for it, or if an expression references a
     *   slot that has no value

--- a/metamodel/src/eu/neverblink/linkml/metamodel/Annotatable.scala
+++ b/metamodel/src/eu/neverblink/linkml/metamodel/Annotatable.scala
@@ -15,4 +15,12 @@ trait Annotatable {
     *   From schema: https://w3id.org/linkml/annotations
     */
   def annotations: Map[String, AnnotationImpl]
+
+  /** Fill in the slots that have an `equals_expression`, and check the values already present
+    * against them.
+    *
+    * @throws InferenceException
+    *   if a slot's value contradicts the value inferred for it
+    */
+  def infer(): Annotatable
 }

--- a/metamodel/src/eu/neverblink/linkml/metamodel/Annotatable.scala
+++ b/metamodel/src/eu/neverblink/linkml/metamodel/Annotatable.scala
@@ -16,11 +16,12 @@ trait Annotatable {
     */
   def annotations: Map[String, AnnotationImpl]
 
-  /** Fill in the slots that have an `equals_expression`, and check the values already present
-    * against them.
+  /** Fill in the slots that have an `equals_expression` with their computed values, and check that
+    * the values already present agree with what their expressions infer.
     *
-    * @throws InferenceException
-    *   if a slot's value contradicts the value inferred for it
+    * @throws eu.neverblink.linkml.runtime.InferenceException
+    *   if a slot's value contradicts the value inferred for it, or if an expression references a
+    *   slot that has no value
     */
   def infer(): Annotatable
 }

--- a/metamodel/src/eu/neverblink/linkml/metamodel/Annotation.scala
+++ b/metamodel/src/eu/neverblink/linkml/metamodel/Annotation.scala
@@ -19,7 +19,21 @@ final case class AnnotationImpl(
     annotations: Map[String, AnnotationImpl] = Map(),
     @simpleDict
     extensions: Map[String, ExtensionImpl] = Map(),
-) extends Annotation
+) extends Annotation {
+
+  /** Fill in the slots that have an `equals_expression` with their computed values, and check that
+    * the values already present agree with what their expressions infer.
+    *
+    * Only single-valued slots with a `string` range are inferred; slots with any other range are
+    * left untouched.
+    *
+    * @throws InferenceException
+    *   if a slot's value contradicts the value inferred for it, or if an expression references a
+    *   slot that has no value
+    */
+  def infer(): AnnotationImpl =
+    this
+}
 
 /** A tag/value pair with the semantics of OWL Annotation
   *
@@ -34,4 +48,12 @@ abstract class Annotation extends Extension, Annotatable {
     *   From schema: https://w3id.org/linkml/annotations
     */
   def annotations: Map[String, AnnotationImpl]
+
+  /** Fill in the slots that have an `equals_expression`, and check the values already present
+    * against them.
+    *
+    * @throws InferenceException
+    *   if a slot's value contradicts the value inferred for it
+    */
+  def infer(): Annotation
 }

--- a/metamodel/src/eu/neverblink/linkml/metamodel/Annotation.scala
+++ b/metamodel/src/eu/neverblink/linkml/metamodel/Annotation.scala
@@ -24,9 +24,6 @@ final case class AnnotationImpl(
   /** Fill in the slots that have an `equals_expression` with their computed values, and check that
     * the values already present agree with what their expressions infer.
     *
-    * Only single-valued slots with a `string` range are inferred; slots with any other range are
-    * left untouched.
-    *
     * @throws InferenceException
     *   if a slot's value contradicts the value inferred for it, or if an expression references a
     *   slot that has no value

--- a/metamodel/src/eu/neverblink/linkml/metamodel/Annotation.scala
+++ b/metamodel/src/eu/neverblink/linkml/metamodel/Annotation.scala
@@ -21,14 +21,7 @@ final case class AnnotationImpl(
     extensions: Map[String, ExtensionImpl] = Map(),
 ) extends Annotation {
 
-  /** Fill in the slots that have an `equals_expression` with their computed values, and check that
-    * the values already present agree with what their expressions infer.
-    *
-    * @throws InferenceException
-    *   if a slot's value contradicts the value inferred for it, or if an expression references a
-    *   slot that has no value
-    */
-  def infer(): AnnotationImpl =
+  override def infer(): AnnotationImpl =
     this
 }
 
@@ -46,11 +39,12 @@ abstract class Annotation extends Extension, Annotatable {
     */
   def annotations: Map[String, AnnotationImpl]
 
-  /** Fill in the slots that have an `equals_expression`, and check the values already present
-    * against them.
+  /** Fill in the slots that have an `equals_expression` with their computed values, and check that
+    * the values already present agree with what their expressions infer.
     *
-    * @throws InferenceException
-    *   if a slot's value contradicts the value inferred for it
+    * @throws eu.neverblink.linkml.runtime.InferenceException
+    *   if a slot's value contradicts the value inferred for it, or if an expression references a
+    *   slot that has no value
     */
   def infer(): Annotation
 }

--- a/metamodel/src/eu/neverblink/linkml/metamodel/AnonymousClassExpression.scala
+++ b/metamodel/src/eu/neverblink/linkml/metamodel/AnonymousClassExpression.scala
@@ -83,9 +83,6 @@ final case class AnonymousClassExpressionImpl(
   /** Fill in the slots that have an `equals_expression` with their computed values, and check that
     * the values already present agree with what their expressions infer.
     *
-    * Only single-valued slots with a `string` range are inferred; slots with any other range are
-    * left untouched.
-    *
     * @throws InferenceException
     *   if a slot's value contradicts the value inferred for it, or if an expression references a
     *   slot that has no value

--- a/metamodel/src/eu/neverblink/linkml/metamodel/AnonymousClassExpression.scala
+++ b/metamodel/src/eu/neverblink/linkml/metamodel/AnonymousClassExpression.scala
@@ -80,14 +80,7 @@ final case class AnonymousClassExpressionImpl(
     todos: Seq[String] = Seq(),
 ) extends AnonymousClassExpression {
 
-  /** Fill in the slots that have an `equals_expression` with their computed values, and check that
-    * the values already present agree with what their expressions infer.
-    *
-    * @throws InferenceException
-    *   if a slot's value contradicts the value inferred for it, or if an expression references a
-    *   slot that has no value
-    */
-  def infer(): AnonymousClassExpressionImpl =
+  override def infer(): AnonymousClassExpressionImpl =
     this
 }
 
@@ -108,11 +101,12 @@ abstract class AnonymousClassExpression extends AnonymousExpression, ClassExpres
     */
   def isA: Option[Reference[Definition]]
 
-  /** Fill in the slots that have an `equals_expression`, and check the values already present
-    * against them.
+  /** Fill in the slots that have an `equals_expression` with their computed values, and check that
+    * the values already present agree with what their expressions infer.
     *
-    * @throws InferenceException
-    *   if a slot's value contradicts the value inferred for it
+    * @throws eu.neverblink.linkml.runtime.InferenceException
+    *   if a slot's value contradicts the value inferred for it, or if an expression references a
+    *   slot that has no value
     */
   def infer(): AnonymousClassExpression
 }

--- a/metamodel/src/eu/neverblink/linkml/metamodel/AnonymousClassExpression.scala
+++ b/metamodel/src/eu/neverblink/linkml/metamodel/AnonymousClassExpression.scala
@@ -78,7 +78,21 @@ final case class AnonymousClassExpressionImpl(
     @named("structured_aliases")
     structuredAliases: Seq[StructuredAliasImpl] = Seq(),
     todos: Seq[String] = Seq(),
-) extends AnonymousClassExpression
+) extends AnonymousClassExpression {
+
+  /** Fill in the slots that have an `equals_expression` with their computed values, and check that
+    * the values already present agree with what their expressions infer.
+    *
+    * Only single-valued slots with a `string` range are inferred; slots with any other range are
+    * left untouched.
+    *
+    * @throws InferenceException
+    *   if a slot's value contradicts the value inferred for it, or if an expression references a
+    *   slot that has no value
+    */
+  def infer(): AnonymousClassExpressionImpl =
+    this
+}
 
 /** @see
   *   From schema: https://w3id.org/linkml/meta
@@ -96,4 +110,12 @@ abstract class AnonymousClassExpression extends AnonymousExpression, ClassExpres
     *   From schema: https://w3id.org/linkml/meta
     */
   def isA: Option[Reference[Definition]]
+
+  /** Fill in the slots that have an `equals_expression`, and check the values already present
+    * against them.
+    *
+    * @throws InferenceException
+    *   if a slot's value contradicts the value inferred for it
+    */
+  def infer(): AnonymousClassExpression
 }

--- a/metamodel/src/eu/neverblink/linkml/metamodel/AnonymousEnumExpression.scala
+++ b/metamodel/src/eu/neverblink/linkml/metamodel/AnonymousEnumExpression.scala
@@ -29,14 +29,7 @@ final case class AnonymousEnumExpressionImpl(
     reachableFrom: Option[ReachabilityQueryImpl] = None,
 ) extends AnonymousEnumExpression {
 
-  /** Fill in the slots that have an `equals_expression` with their computed values, and check that
-    * the values already present agree with what their expressions infer.
-    *
-    * @throws InferenceException
-    *   if a slot's value contradicts the value inferred for it, or if an expression references a
-    *   slot that has no value
-    */
-  def infer(): AnonymousEnumExpressionImpl =
+  override def infer(): AnonymousEnumExpressionImpl =
     this
 }
 
@@ -47,11 +40,12 @@ final case class AnonymousEnumExpressionImpl(
   */
 abstract class AnonymousEnumExpression extends EnumExpression {
 
-  /** Fill in the slots that have an `equals_expression`, and check the values already present
-    * against them.
+  /** Fill in the slots that have an `equals_expression` with their computed values, and check that
+    * the values already present agree with what their expressions infer.
     *
-    * @throws InferenceException
-    *   if a slot's value contradicts the value inferred for it
+    * @throws eu.neverblink.linkml.runtime.InferenceException
+    *   if a slot's value contradicts the value inferred for it, or if an expression references a
+    *   slot that has no value
     */
   def infer(): AnonymousEnumExpression
 }

--- a/metamodel/src/eu/neverblink/linkml/metamodel/AnonymousEnumExpression.scala
+++ b/metamodel/src/eu/neverblink/linkml/metamodel/AnonymousEnumExpression.scala
@@ -32,9 +32,6 @@ final case class AnonymousEnumExpressionImpl(
   /** Fill in the slots that have an `equals_expression` with their computed values, and check that
     * the values already present agree with what their expressions infer.
     *
-    * Only single-valued slots with a `string` range are inferred; slots with any other range are
-    * left untouched.
-    *
     * @throws InferenceException
     *   if a slot's value contradicts the value inferred for it, or if an expression references a
     *   slot that has no value

--- a/metamodel/src/eu/neverblink/linkml/metamodel/AnonymousEnumExpression.scala
+++ b/metamodel/src/eu/neverblink/linkml/metamodel/AnonymousEnumExpression.scala
@@ -27,11 +27,34 @@ final case class AnonymousEnumExpressionImpl(
     pvFormula: Option[PvFormulaOptions] = None,
     @named("reachable_from")
     reachableFrom: Option[ReachabilityQueryImpl] = None,
-) extends AnonymousEnumExpression
+) extends AnonymousEnumExpression {
+
+  /** Fill in the slots that have an `equals_expression` with their computed values, and check that
+    * the values already present agree with what their expressions infer.
+    *
+    * Only single-valued slots with a `string` range are inferred; slots with any other range are
+    * left untouched.
+    *
+    * @throws InferenceException
+    *   if a slot's value contradicts the value inferred for it, or if an expression references a
+    *   slot that has no value
+    */
+  def infer(): AnonymousEnumExpressionImpl =
+    this
+}
 
 /** An enum_expression that is not named
   *
   * @see
   *   From schema: https://w3id.org/linkml/meta
   */
-abstract class AnonymousEnumExpression extends EnumExpression {}
+abstract class AnonymousEnumExpression extends EnumExpression {
+
+  /** Fill in the slots that have an `equals_expression`, and check the values already present
+    * against them.
+    *
+    * @throws InferenceException
+    *   if a slot's value contradicts the value inferred for it
+    */
+  def infer(): AnonymousEnumExpression
+}

--- a/metamodel/src/eu/neverblink/linkml/metamodel/AnonymousExpression.scala
+++ b/metamodel/src/eu/neverblink/linkml/metamodel/AnonymousExpression.scala
@@ -10,4 +10,13 @@ package eu.neverblink.linkml.metamodel
   *   Anonymous expressions are useful for when it is necessary to build a complex expression
   *   without introducing a named element for each sub-expression
   */
-abstract class AnonymousExpression extends Expression, Extensible, Annotatable, CommonMetadata {}
+abstract class AnonymousExpression extends Expression, Extensible, Annotatable, CommonMetadata {
+
+  /** Fill in the slots that have an `equals_expression`, and check the values already present
+    * against them.
+    *
+    * @throws InferenceException
+    *   if a slot's value contradicts the value inferred for it
+    */
+  def infer(): AnonymousExpression
+}

--- a/metamodel/src/eu/neverblink/linkml/metamodel/AnonymousExpression.scala
+++ b/metamodel/src/eu/neverblink/linkml/metamodel/AnonymousExpression.scala
@@ -12,11 +12,12 @@ package eu.neverblink.linkml.metamodel
   */
 abstract class AnonymousExpression extends Expression, Extensible, Annotatable, CommonMetadata {
 
-  /** Fill in the slots that have an `equals_expression`, and check the values already present
-    * against them.
+  /** Fill in the slots that have an `equals_expression` with their computed values, and check that
+    * the values already present agree with what their expressions infer.
     *
-    * @throws InferenceException
-    *   if a slot's value contradicts the value inferred for it
+    * @throws eu.neverblink.linkml.runtime.InferenceException
+    *   if a slot's value contradicts the value inferred for it, or if an expression references a
+    *   slot that has no value
     */
   def infer(): AnonymousExpression
 }

--- a/metamodel/src/eu/neverblink/linkml/metamodel/AnonymousSlotExpression.scala
+++ b/metamodel/src/eu/neverblink/linkml/metamodel/AnonymousSlotExpression.scala
@@ -118,14 +118,7 @@ final case class AnonymousSlotExpressionImpl(
     valuePresence: Option[PresenceEnum] = None,
 ) extends AnonymousSlotExpression {
 
-  /** Fill in the slots that have an `equals_expression` with their computed values, and check that
-    * the values already present agree with what their expressions infer.
-    *
-    * @throws InferenceException
-    *   if a slot's value contradicts the value inferred for it, or if an expression references a
-    *   slot that has no value
-    */
-  def infer(): AnonymousSlotExpressionImpl =
+  override def infer(): AnonymousSlotExpressionImpl =
     this
 }
 
@@ -134,11 +127,12 @@ final case class AnonymousSlotExpressionImpl(
   */
 abstract class AnonymousSlotExpression extends AnonymousExpression, SlotExpression {
 
-  /** Fill in the slots that have an `equals_expression`, and check the values already present
-    * against them.
+  /** Fill in the slots that have an `equals_expression` with their computed values, and check that
+    * the values already present agree with what their expressions infer.
     *
-    * @throws InferenceException
-    *   if a slot's value contradicts the value inferred for it
+    * @throws eu.neverblink.linkml.runtime.InferenceException
+    *   if a slot's value contradicts the value inferred for it, or if an expression references a
+    *   slot that has no value
     */
   def infer(): AnonymousSlotExpression
 }

--- a/metamodel/src/eu/neverblink/linkml/metamodel/AnonymousSlotExpression.scala
+++ b/metamodel/src/eu/neverblink/linkml/metamodel/AnonymousSlotExpression.scala
@@ -121,9 +121,6 @@ final case class AnonymousSlotExpressionImpl(
   /** Fill in the slots that have an `equals_expression` with their computed values, and check that
     * the values already present agree with what their expressions infer.
     *
-    * Only single-valued slots with a `string` range are inferred; slots with any other range are
-    * left untouched.
-    *
     * @throws InferenceException
     *   if a slot's value contradicts the value inferred for it, or if an expression references a
     *   slot that has no value

--- a/metamodel/src/eu/neverblink/linkml/metamodel/AnonymousSlotExpression.scala
+++ b/metamodel/src/eu/neverblink/linkml/metamodel/AnonymousSlotExpression.scala
@@ -116,9 +116,32 @@ final case class AnonymousSlotExpressionImpl(
     unit: Option[UnitOfMeasureImpl] = None,
     @named("value_presence")
     valuePresence: Option[PresenceEnum] = None,
-) extends AnonymousSlotExpression
+) extends AnonymousSlotExpression {
+
+  /** Fill in the slots that have an `equals_expression` with their computed values, and check that
+    * the values already present agree with what their expressions infer.
+    *
+    * Only single-valued slots with a `string` range are inferred; slots with any other range are
+    * left untouched.
+    *
+    * @throws InferenceException
+    *   if a slot's value contradicts the value inferred for it, or if an expression references a
+    *   slot that has no value
+    */
+  def infer(): AnonymousSlotExpressionImpl =
+    this
+}
 
 /** @see
   *   From schema: https://w3id.org/linkml/meta
   */
-abstract class AnonymousSlotExpression extends AnonymousExpression, SlotExpression {}
+abstract class AnonymousSlotExpression extends AnonymousExpression, SlotExpression {
+
+  /** Fill in the slots that have an `equals_expression`, and check the values already present
+    * against them.
+    *
+    * @throws InferenceException
+    *   if a slot's value contradicts the value inferred for it
+    */
+  def infer(): AnonymousSlotExpression
+}

--- a/metamodel/src/eu/neverblink/linkml/metamodel/AnonymousTypeExpression.scala
+++ b/metamodel/src/eu/neverblink/linkml/metamodel/AnonymousTypeExpression.scala
@@ -38,9 +38,6 @@ final case class AnonymousTypeExpressionImpl(
   /** Fill in the slots that have an `equals_expression` with their computed values, and check that
     * the values already present agree with what their expressions infer.
     *
-    * Only single-valued slots with a `string` range are inferred; slots with any other range are
-    * left untouched.
-    *
     * @throws InferenceException
     *   if a slot's value contradicts the value inferred for it, or if an expression references a
     *   slot that has no value

--- a/metamodel/src/eu/neverblink/linkml/metamodel/AnonymousTypeExpression.scala
+++ b/metamodel/src/eu/neverblink/linkml/metamodel/AnonymousTypeExpression.scala
@@ -35,14 +35,7 @@ final case class AnonymousTypeExpressionImpl(
     unit: Option[UnitOfMeasureImpl] = None,
 ) extends AnonymousTypeExpression {
 
-  /** Fill in the slots that have an `equals_expression` with their computed values, and check that
-    * the values already present agree with what their expressions infer.
-    *
-    * @throws InferenceException
-    *   if a slot's value contradicts the value inferred for it, or if an expression references a
-    *   slot that has no value
-    */
-  def infer(): AnonymousTypeExpressionImpl =
+  override def infer(): AnonymousTypeExpressionImpl =
     this
 }
 
@@ -53,11 +46,12 @@ final case class AnonymousTypeExpressionImpl(
   */
 abstract class AnonymousTypeExpression extends TypeExpression {
 
-  /** Fill in the slots that have an `equals_expression`, and check the values already present
-    * against them.
+  /** Fill in the slots that have an `equals_expression` with their computed values, and check that
+    * the values already present agree with what their expressions infer.
     *
-    * @throws InferenceException
-    *   if a slot's value contradicts the value inferred for it
+    * @throws eu.neverblink.linkml.runtime.InferenceException
+    *   if a slot's value contradicts the value inferred for it, or if an expression references a
+    *   slot that has no value
     */
   def infer(): AnonymousTypeExpression
 }

--- a/metamodel/src/eu/neverblink/linkml/metamodel/AnonymousTypeExpression.scala
+++ b/metamodel/src/eu/neverblink/linkml/metamodel/AnonymousTypeExpression.scala
@@ -33,11 +33,34 @@ final case class AnonymousTypeExpressionImpl(
     @named("structured_pattern")
     structuredPattern: Option[PatternExpressionImpl] = None,
     unit: Option[UnitOfMeasureImpl] = None,
-) extends AnonymousTypeExpression
+) extends AnonymousTypeExpression {
+
+  /** Fill in the slots that have an `equals_expression` with their computed values, and check that
+    * the values already present agree with what their expressions infer.
+    *
+    * Only single-valued slots with a `string` range are inferred; slots with any other range are
+    * left untouched.
+    *
+    * @throws InferenceException
+    *   if a slot's value contradicts the value inferred for it, or if an expression references a
+    *   slot that has no value
+    */
+  def infer(): AnonymousTypeExpressionImpl =
+    this
+}
 
 /** A type expression that is not a top-level named type definition. Used for nesting.
   *
   * @see
   *   From schema: https://w3id.org/linkml/meta
   */
-abstract class AnonymousTypeExpression extends TypeExpression {}
+abstract class AnonymousTypeExpression extends TypeExpression {
+
+  /** Fill in the slots that have an `equals_expression`, and check the values already present
+    * against them.
+    *
+    * @throws InferenceException
+    *   if a slot's value contradicts the value inferred for it
+    */
+  def infer(): AnonymousTypeExpression
+}

--- a/metamodel/src/eu/neverblink/linkml/metamodel/ArrayExpression.scala
+++ b/metamodel/src/eu/neverblink/linkml/metamodel/ArrayExpression.scala
@@ -77,9 +77,6 @@ final case class ArrayExpressionImpl(
   /** Fill in the slots that have an `equals_expression` with their computed values, and check that
     * the values already present agree with what their expressions infer.
     *
-    * Only single-valued slots with a `string` range are inferred; slots with any other range are
-    * left untouched.
-    *
     * @throws InferenceException
     *   if a slot's value contradicts the value inferred for it, or if an expression references a
     *   slot that has no value

--- a/metamodel/src/eu/neverblink/linkml/metamodel/ArrayExpression.scala
+++ b/metamodel/src/eu/neverblink/linkml/metamodel/ArrayExpression.scala
@@ -72,7 +72,21 @@ final case class ArrayExpressionImpl(
     @named("structured_aliases")
     structuredAliases: Seq[StructuredAliasImpl] = Seq(),
     todos: Seq[String] = Seq(),
-) extends ArrayExpression
+) extends ArrayExpression {
+
+  /** Fill in the slots that have an `equals_expression` with their computed values, and check that
+    * the values already present agree with what their expressions infer.
+    *
+    * Only single-valued slots with a `string` range are inferred; slots with any other range are
+    * left untouched.
+    *
+    * @throws InferenceException
+    *   if a slot's value contradicts the value inferred for it, or if an expression references a
+    *   slot that has no value
+    */
+  def infer(): ArrayExpressionImpl =
+    this
+}
 
 /** Defines the dimensions of an array
   *
@@ -120,4 +134,12 @@ abstract class ArrayExpression extends Extensible, Annotatable, CommonMetadata {
     *   Minimum_cardinality cannot be greater than maximum_cardinality
     */
   def minimumNumberDimensions: Option[Int]
+
+  /** Fill in the slots that have an `equals_expression`, and check the values already present
+    * against them.
+    *
+    * @throws InferenceException
+    *   if a slot's value contradicts the value inferred for it
+    */
+  def infer(): ArrayExpression
 }

--- a/metamodel/src/eu/neverblink/linkml/metamodel/ArrayExpression.scala
+++ b/metamodel/src/eu/neverblink/linkml/metamodel/ArrayExpression.scala
@@ -74,14 +74,7 @@ final case class ArrayExpressionImpl(
     todos: Seq[String] = Seq(),
 ) extends ArrayExpression {
 
-  /** Fill in the slots that have an `equals_expression` with their computed values, and check that
-    * the values already present agree with what their expressions infer.
-    *
-    * @throws InferenceException
-    *   if a slot's value contradicts the value inferred for it, or if an expression references a
-    *   slot that has no value
-    */
-  def infer(): ArrayExpressionImpl =
+  override def infer(): ArrayExpressionImpl =
     this
 }
 
@@ -132,11 +125,12 @@ abstract class ArrayExpression extends Extensible, Annotatable, CommonMetadata {
     */
   def minimumNumberDimensions: Option[Int]
 
-  /** Fill in the slots that have an `equals_expression`, and check the values already present
-    * against them.
+  /** Fill in the slots that have an `equals_expression` with their computed values, and check that
+    * the values already present agree with what their expressions infer.
     *
-    * @throws InferenceException
-    *   if a slot's value contradicts the value inferred for it
+    * @throws eu.neverblink.linkml.runtime.InferenceException
+    *   if a slot's value contradicts the value inferred for it, or if an expression references a
+    *   slot that has no value
     */
   def infer(): ArrayExpression
 }

--- a/metamodel/src/eu/neverblink/linkml/metamodel/ClassDefinition.scala
+++ b/metamodel/src/eu/neverblink/linkml/metamodel/ClassDefinition.scala
@@ -141,9 +141,6 @@ final case class ClassDefinitionImpl(
   /** Fill in the slots that have an `equals_expression` with their computed values, and check that
     * the values already present agree with what their expressions infer.
     *
-    * Only single-valued slots with a `string` range are inferred; slots with any other range are
-    * left untouched.
-    *
     * @throws InferenceException
     *   if a slot's value contradicts the value inferred for it, or if an expression references a
     *   slot that has no value

--- a/metamodel/src/eu/neverblink/linkml/metamodel/ClassDefinition.scala
+++ b/metamodel/src/eu/neverblink/linkml/metamodel/ClassDefinition.scala
@@ -136,7 +136,21 @@ final case class ClassDefinitionImpl(
     uniqueKeys: Map[String, UniqueKeyImpl] = Map(),
     @named("values_from")
     valuesFrom: Seq[UriOrCurie] = Seq(),
-) extends ClassDefinition
+) extends ClassDefinition {
+
+  /** Fill in the slots that have an `equals_expression` with their computed values, and check that
+    * the values already present agree with what their expressions infer.
+    *
+    * Only single-valued slots with a `string` range are inferred; slots with any other range are
+    * left untouched.
+    *
+    * @throws InferenceException
+    *   if a slot's value contradicts the value inferred for it, or if an expression references a
+    *   slot that has no value
+    */
+  def infer(): ClassDefinitionImpl =
+    this
+}
 
 /** An element whose instances are complex objects that may have slot-value assignments
   *
@@ -376,4 +390,12 @@ abstract class ClassDefinition extends Definition, ClassExpression {
     *   unique keys and identifiers have additional effects that compound keys do not have.\n
     */
   def uniqueKeys: Map[String, UniqueKeyImpl]
+
+  /** Fill in the slots that have an `equals_expression`, and check the values already present
+    * against them.
+    *
+    * @throws InferenceException
+    *   if a slot's value contradicts the value inferred for it
+    */
+  def infer(): ClassDefinition
 }

--- a/metamodel/src/eu/neverblink/linkml/metamodel/ClassDefinition.scala
+++ b/metamodel/src/eu/neverblink/linkml/metamodel/ClassDefinition.scala
@@ -138,14 +138,7 @@ final case class ClassDefinitionImpl(
     valuesFrom: Seq[UriOrCurie] = Seq(),
 ) extends ClassDefinition {
 
-  /** Fill in the slots that have an `equals_expression` with their computed values, and check that
-    * the values already present agree with what their expressions infer.
-    *
-    * @throws InferenceException
-    *   if a slot's value contradicts the value inferred for it, or if an expression references a
-    *   slot that has no value
-    */
-  def infer(): ClassDefinitionImpl =
+  override def infer(): ClassDefinitionImpl =
     this
 }
 
@@ -388,11 +381,12 @@ abstract class ClassDefinition extends Definition, ClassExpression {
     */
   def uniqueKeys: Map[String, UniqueKeyImpl]
 
-  /** Fill in the slots that have an `equals_expression`, and check the values already present
-    * against them.
+  /** Fill in the slots that have an `equals_expression` with their computed values, and check that
+    * the values already present agree with what their expressions infer.
     *
-    * @throws InferenceException
-    *   if a slot's value contradicts the value inferred for it
+    * @throws eu.neverblink.linkml.runtime.InferenceException
+    *   if a slot's value contradicts the value inferred for it, or if an expression references a
+    *   slot that has no value
     */
   def infer(): ClassDefinition
 }

--- a/metamodel/src/eu/neverblink/linkml/metamodel/ClassExpression.scala
+++ b/metamodel/src/eu/neverblink/linkml/metamodel/ClassExpression.scala
@@ -51,4 +51,12 @@ trait ClassExpression {
     *   From schema: https://w3id.org/linkml/meta
     */
   def slotConditions: Map[String, SlotDefinitionImpl]
+
+  /** Fill in the slots that have an `equals_expression`, and check the values already present
+    * against them.
+    *
+    * @throws InferenceException
+    *   if a slot's value contradicts the value inferred for it
+    */
+  def infer(): ClassExpression
 }

--- a/metamodel/src/eu/neverblink/linkml/metamodel/ClassExpression.scala
+++ b/metamodel/src/eu/neverblink/linkml/metamodel/ClassExpression.scala
@@ -52,11 +52,12 @@ trait ClassExpression {
     */
   def slotConditions: Map[String, SlotDefinitionImpl]
 
-  /** Fill in the slots that have an `equals_expression`, and check the values already present
-    * against them.
+  /** Fill in the slots that have an `equals_expression` with their computed values, and check that
+    * the values already present agree with what their expressions infer.
     *
-    * @throws InferenceException
-    *   if a slot's value contradicts the value inferred for it
+    * @throws eu.neverblink.linkml.runtime.InferenceException
+    *   if a slot's value contradicts the value inferred for it, or if an expression references a
+    *   slot that has no value
     */
   def infer(): ClassExpression
 }

--- a/metamodel/src/eu/neverblink/linkml/metamodel/ClassLevelRule.scala
+++ b/metamodel/src/eu/neverblink/linkml/metamodel/ClassLevelRule.scala
@@ -9,11 +9,12 @@ package eu.neverblink.linkml.metamodel
   */
 abstract class ClassLevelRule {
 
-  /** Fill in the slots that have an `equals_expression`, and check the values already present
-    * against them.
+  /** Fill in the slots that have an `equals_expression` with their computed values, and check that
+    * the values already present agree with what their expressions infer.
     *
-    * @throws InferenceException
-    *   if a slot's value contradicts the value inferred for it
+    * @throws eu.neverblink.linkml.runtime.InferenceException
+    *   if a slot's value contradicts the value inferred for it, or if an expression references a
+    *   slot that has no value
     */
   def infer(): ClassLevelRule
 }

--- a/metamodel/src/eu/neverblink/linkml/metamodel/ClassLevelRule.scala
+++ b/metamodel/src/eu/neverblink/linkml/metamodel/ClassLevelRule.scala
@@ -7,4 +7,13 @@ package eu.neverblink.linkml.metamodel
   * @see
   *   From schema: https://w3id.org/linkml/meta
   */
-abstract class ClassLevelRule {}
+abstract class ClassLevelRule {
+
+  /** Fill in the slots that have an `equals_expression`, and check the values already present
+    * against them.
+    *
+    * @throws InferenceException
+    *   if a slot's value contradicts the value inferred for it
+    */
+  def infer(): ClassLevelRule
+}

--- a/metamodel/src/eu/neverblink/linkml/metamodel/ClassRule.scala
+++ b/metamodel/src/eu/neverblink/linkml/metamodel/ClassRule.scala
@@ -72,7 +72,21 @@ final case class ClassRuleImpl(
     @named("structured_aliases")
     structuredAliases: Seq[StructuredAliasImpl] = Seq(),
     todos: Seq[String] = Seq(),
-) extends ClassRule
+) extends ClassRule {
+
+  /** Fill in the slots that have an `equals_expression` with their computed values, and check that
+    * the values already present agree with what their expressions infer.
+    *
+    * Only single-valued slots with a `string` range are inferred; slots with any other range are
+    * left untouched.
+    *
+    * @throws InferenceException
+    *   if a slot's value contradicts the value inferred for it, or if an expression references a
+    *   slot that has no value
+    */
+  def infer(): ClassRuleImpl =
+    this
+}
 
 /** A rule that applies to instances of a class
   *
@@ -151,4 +165,12 @@ abstract class ClassRule extends ClassLevelRule, Extensible, Annotatable, Common
     *   From schema: https://w3id.org/linkml/meta
     */
   def openWorld: Boolean
+
+  /** Fill in the slots that have an `equals_expression`, and check the values already present
+    * against them.
+    *
+    * @throws InferenceException
+    *   if a slot's value contradicts the value inferred for it
+    */
+  def infer(): ClassRule
 }

--- a/metamodel/src/eu/neverblink/linkml/metamodel/ClassRule.scala
+++ b/metamodel/src/eu/neverblink/linkml/metamodel/ClassRule.scala
@@ -77,9 +77,6 @@ final case class ClassRuleImpl(
   /** Fill in the slots that have an `equals_expression` with their computed values, and check that
     * the values already present agree with what their expressions infer.
     *
-    * Only single-valued slots with a `string` range are inferred; slots with any other range are
-    * left untouched.
-    *
     * @throws InferenceException
     *   if a slot's value contradicts the value inferred for it, or if an expression references a
     *   slot that has no value

--- a/metamodel/src/eu/neverblink/linkml/metamodel/ClassRule.scala
+++ b/metamodel/src/eu/neverblink/linkml/metamodel/ClassRule.scala
@@ -74,14 +74,7 @@ final case class ClassRuleImpl(
     todos: Seq[String] = Seq(),
 ) extends ClassRule {
 
-  /** Fill in the slots that have an `equals_expression` with their computed values, and check that
-    * the values already present agree with what their expressions infer.
-    *
-    * @throws InferenceException
-    *   if a slot's value contradicts the value inferred for it, or if an expression references a
-    *   slot that has no value
-    */
-  def infer(): ClassRuleImpl =
+  override def infer(): ClassRuleImpl =
     this
 }
 
@@ -163,11 +156,12 @@ abstract class ClassRule extends ClassLevelRule, Extensible, Annotatable, Common
     */
   def openWorld: Boolean
 
-  /** Fill in the slots that have an `equals_expression`, and check the values already present
-    * against them.
+  /** Fill in the slots that have an `equals_expression` with their computed values, and check that
+    * the values already present agree with what their expressions infer.
     *
-    * @throws InferenceException
-    *   if a slot's value contradicts the value inferred for it
+    * @throws eu.neverblink.linkml.runtime.InferenceException
+    *   if a slot's value contradicts the value inferred for it, or if an expression references a
+    *   slot that has no value
     */
   def infer(): ClassRule
 }

--- a/metamodel/src/eu/neverblink/linkml/metamodel/CommonMetadata.scala
+++ b/metamodel/src/eu/neverblink/linkml/metamodel/CommonMetadata.scala
@@ -289,11 +289,12 @@ trait CommonMetadata {
     */
   def todos: Seq[String]
 
-  /** Fill in the slots that have an `equals_expression`, and check the values already present
-    * against them.
+  /** Fill in the slots that have an `equals_expression` with their computed values, and check that
+    * the values already present agree with what their expressions infer.
     *
-    * @throws InferenceException
-    *   if a slot's value contradicts the value inferred for it
+    * @throws eu.neverblink.linkml.runtime.InferenceException
+    *   if a slot's value contradicts the value inferred for it, or if an expression references a
+    *   slot that has no value
     */
   def infer(): CommonMetadata
 }

--- a/metamodel/src/eu/neverblink/linkml/metamodel/CommonMetadata.scala
+++ b/metamodel/src/eu/neverblink/linkml/metamodel/CommonMetadata.scala
@@ -288,4 +288,12 @@ trait CommonMetadata {
     *   From schema: https://w3id.org/linkml/meta
     */
   def todos: Seq[String]
+
+  /** Fill in the slots that have an `equals_expression`, and check the values already present
+    * against them.
+    *
+    * @throws InferenceException
+    *   if a slot's value contradicts the value inferred for it
+    */
+  def infer(): CommonMetadata
 }

--- a/metamodel/src/eu/neverblink/linkml/metamodel/Definition.scala
+++ b/metamodel/src/eu/neverblink/linkml/metamodel/Definition.scala
@@ -102,11 +102,12 @@ abstract class Definition extends Element {
     */
   def valuesFrom: Seq[UriOrCurie]
 
-  /** Fill in the slots that have an `equals_expression`, and check the values already present
-    * against them.
+  /** Fill in the slots that have an `equals_expression` with their computed values, and check that
+    * the values already present agree with what their expressions infer.
     *
-    * @throws InferenceException
-    *   if a slot's value contradicts the value inferred for it
+    * @throws eu.neverblink.linkml.runtime.InferenceException
+    *   if a slot's value contradicts the value inferred for it, or if an expression references a
+    *   slot that has no value
     */
   def infer(): Definition
 }

--- a/metamodel/src/eu/neverblink/linkml/metamodel/Definition.scala
+++ b/metamodel/src/eu/neverblink/linkml/metamodel/Definition.scala
@@ -101,4 +101,12 @@ abstract class Definition extends Element {
     *   From schema: https://w3id.org/linkml/meta
     */
   def valuesFrom: Seq[UriOrCurie]
+
+  /** Fill in the slots that have an `equals_expression`, and check the values already present
+    * against them.
+    *
+    * @throws InferenceException
+    *   if a slot's value contradicts the value inferred for it
+    */
+  def infer(): Definition
 }

--- a/metamodel/src/eu/neverblink/linkml/metamodel/DimensionExpression.scala
+++ b/metamodel/src/eu/neverblink/linkml/metamodel/DimensionExpression.scala
@@ -72,7 +72,21 @@ final case class DimensionExpressionImpl(
     @named("structured_aliases")
     structuredAliases: Seq[StructuredAliasImpl] = Seq(),
     todos: Seq[String] = Seq(),
-) extends DimensionExpression
+) extends DimensionExpression {
+
+  /** Fill in the slots that have an `equals_expression` with their computed values, and check that
+    * the values already present agree with what their expressions infer.
+    *
+    * Only single-valued slots with a `string` range are inferred; slots with any other range are
+    * left untouched.
+    *
+    * @throws InferenceException
+    *   if a slot's value contradicts the value inferred for it, or if an expression references a
+    *   slot that has no value
+    */
+  def infer(): DimensionExpressionImpl =
+    this
+}
 
 /** Defines one of the dimensions of an array
   *
@@ -121,4 +135,12 @@ abstract class DimensionExpression extends Extensible, Annotatable, CommonMetada
     *   Minimum_cardinality cannot be greater than maximum_cardinality
     */
   def minimumCardinality: Option[Int]
+
+  /** Fill in the slots that have an `equals_expression`, and check the values already present
+    * against them.
+    *
+    * @throws InferenceException
+    *   if a slot's value contradicts the value inferred for it
+    */
+  def infer(): DimensionExpression
 }

--- a/metamodel/src/eu/neverblink/linkml/metamodel/DimensionExpression.scala
+++ b/metamodel/src/eu/neverblink/linkml/metamodel/DimensionExpression.scala
@@ -77,9 +77,6 @@ final case class DimensionExpressionImpl(
   /** Fill in the slots that have an `equals_expression` with their computed values, and check that
     * the values already present agree with what their expressions infer.
     *
-    * Only single-valued slots with a `string` range are inferred; slots with any other range are
-    * left untouched.
-    *
     * @throws InferenceException
     *   if a slot's value contradicts the value inferred for it, or if an expression references a
     *   slot that has no value

--- a/metamodel/src/eu/neverblink/linkml/metamodel/DimensionExpression.scala
+++ b/metamodel/src/eu/neverblink/linkml/metamodel/DimensionExpression.scala
@@ -74,14 +74,7 @@ final case class DimensionExpressionImpl(
     todos: Seq[String] = Seq(),
 ) extends DimensionExpression {
 
-  /** Fill in the slots that have an `equals_expression` with their computed values, and check that
-    * the values already present agree with what their expressions infer.
-    *
-    * @throws InferenceException
-    *   if a slot's value contradicts the value inferred for it, or if an expression references a
-    *   slot that has no value
-    */
-  def infer(): DimensionExpressionImpl =
+  override def infer(): DimensionExpressionImpl =
     this
 }
 
@@ -133,11 +126,12 @@ abstract class DimensionExpression extends Extensible, Annotatable, CommonMetada
     */
   def minimumCardinality: Option[Int]
 
-  /** Fill in the slots that have an `equals_expression`, and check the values already present
-    * against them.
+  /** Fill in the slots that have an `equals_expression` with their computed values, and check that
+    * the values already present agree with what their expressions infer.
     *
-    * @throws InferenceException
-    *   if a slot's value contradicts the value inferred for it
+    * @throws eu.neverblink.linkml.runtime.InferenceException
+    *   if a slot's value contradicts the value inferred for it, or if an expression references a
+    *   slot that has no value
     */
   def infer(): DimensionExpression
 }

--- a/metamodel/src/eu/neverblink/linkml/metamodel/Element.scala
+++ b/metamodel/src/eu/neverblink/linkml/metamodel/Element.scala
@@ -101,11 +101,12 @@ abstract class Element extends Extensible, Annotatable, CommonMetadata {
     */
   def localNames: Map[String, LocalNameImpl]
 
-  /** Fill in the slots that have an `equals_expression`, and check the values already present
-    * against them.
+  /** Fill in the slots that have an `equals_expression` with their computed values, and check that
+    * the values already present agree with what their expressions infer.
     *
-    * @throws InferenceException
-    *   if a slot's value contradicts the value inferred for it
+    * @throws eu.neverblink.linkml.runtime.InferenceException
+    *   if a slot's value contradicts the value inferred for it, or if an expression references a
+    *   slot that has no value
     */
   def infer(): Element
 }

--- a/metamodel/src/eu/neverblink/linkml/metamodel/Element.scala
+++ b/metamodel/src/eu/neverblink/linkml/metamodel/Element.scala
@@ -100,4 +100,12 @@ abstract class Element extends Extensible, Annotatable, CommonMetadata {
     *   From schema: https://w3id.org/linkml/meta
     */
   def localNames: Map[String, LocalNameImpl]
+
+  /** Fill in the slots that have an `equals_expression`, and check the values already present
+    * against them.
+    *
+    * @throws InferenceException
+    *   if a slot's value contradicts the value inferred for it
+    */
+  def infer(): Element
 }

--- a/metamodel/src/eu/neverblink/linkml/metamodel/EnumBinding.scala
+++ b/metamodel/src/eu/neverblink/linkml/metamodel/EnumBinding.scala
@@ -77,9 +77,6 @@ final case class EnumBindingImpl(
   /** Fill in the slots that have an `equals_expression` with their computed values, and check that
     * the values already present agree with what their expressions infer.
     *
-    * Only single-valued slots with a `string` range are inferred; slots with any other range are
-    * left untouched.
-    *
     * @throws InferenceException
     *   if a slot's value contradicts the value inferred for it, or if an expression references a
     *   slot that has no value

--- a/metamodel/src/eu/neverblink/linkml/metamodel/EnumBinding.scala
+++ b/metamodel/src/eu/neverblink/linkml/metamodel/EnumBinding.scala
@@ -74,14 +74,7 @@ final case class EnumBindingImpl(
     todos: Seq[String] = Seq(),
 ) extends EnumBinding {
 
-  /** Fill in the slots that have an `equals_expression` with their computed values, and check that
-    * the values already present agree with what their expressions infer.
-    *
-    * @throws InferenceException
-    *   if a slot's value contradicts the value inferred for it, or if an expression references a
-    *   slot that has no value
-    */
-  def infer(): EnumBindingImpl =
+  override def infer(): EnumBindingImpl =
     this
 }
 
@@ -133,11 +126,12 @@ abstract class EnumBinding extends Extensible, Annotatable, CommonMetadata {
     */
   def range: Option[Reference[EnumDefinition]]
 
-  /** Fill in the slots that have an `equals_expression`, and check the values already present
-    * against them.
+  /** Fill in the slots that have an `equals_expression` with their computed values, and check that
+    * the values already present agree with what their expressions infer.
     *
-    * @throws InferenceException
-    *   if a slot's value contradicts the value inferred for it
+    * @throws eu.neverblink.linkml.runtime.InferenceException
+    *   if a slot's value contradicts the value inferred for it, or if an expression references a
+    *   slot that has no value
     */
   def infer(): EnumBinding
 }

--- a/metamodel/src/eu/neverblink/linkml/metamodel/EnumBinding.scala
+++ b/metamodel/src/eu/neverblink/linkml/metamodel/EnumBinding.scala
@@ -72,7 +72,21 @@ final case class EnumBindingImpl(
     @named("structured_aliases")
     structuredAliases: Seq[StructuredAliasImpl] = Seq(),
     todos: Seq[String] = Seq(),
-) extends EnumBinding
+) extends EnumBinding {
+
+  /** Fill in the slots that have an `equals_expression` with their computed values, and check that
+    * the values already present agree with what their expressions infer.
+    *
+    * Only single-valued slots with a `string` range are inferred; slots with any other range are
+    * left untouched.
+    *
+    * @throws InferenceException
+    *   if a slot's value contradicts the value inferred for it, or if an expression references a
+    *   slot that has no value
+    */
+  def infer(): EnumBindingImpl =
+    this
+}
 
 /** A binding of a slot or a class to a permissible value from an enumeration.
   *
@@ -121,4 +135,12 @@ abstract class EnumBinding extends Extensible, Annotatable, CommonMetadata {
     *   To use a URI or CURIE as the range, create a class with the URI or curie as the class_uri
     */
   def range: Option[Reference[EnumDefinition]]
+
+  /** Fill in the slots that have an `equals_expression`, and check the values already present
+    * against them.
+    *
+    * @throws InferenceException
+    *   if a slot's value contradicts the value inferred for it
+    */
+  def infer(): EnumBinding
 }

--- a/metamodel/src/eu/neverblink/linkml/metamodel/EnumDefinition.scala
+++ b/metamodel/src/eu/neverblink/linkml/metamodel/EnumDefinition.scala
@@ -114,14 +114,7 @@ final case class EnumDefinitionImpl(
     valuesFrom: Seq[UriOrCurie] = Seq(),
 ) extends EnumDefinition {
 
-  /** Fill in the slots that have an `equals_expression` with their computed values, and check that
-    * the values already present agree with what their expressions infer.
-    *
-    * @throws InferenceException
-    *   if a slot's value contradicts the value inferred for it, or if an expression references a
-    *   slot that has no value
-    */
-  def infer(): EnumDefinitionImpl =
+  override def infer(): EnumDefinitionImpl =
     this
 }
 
@@ -145,11 +138,12 @@ abstract class EnumDefinition extends Definition, EnumExpression {
     */
   def enumUri: Option[UriOrCurie]
 
-  /** Fill in the slots that have an `equals_expression`, and check the values already present
-    * against them.
+  /** Fill in the slots that have an `equals_expression` with their computed values, and check that
+    * the values already present agree with what their expressions infer.
     *
-    * @throws InferenceException
-    *   if a slot's value contradicts the value inferred for it
+    * @throws eu.neverblink.linkml.runtime.InferenceException
+    *   if a slot's value contradicts the value inferred for it, or if an expression references a
+    *   slot that has no value
     */
   def infer(): EnumDefinition
 }

--- a/metamodel/src/eu/neverblink/linkml/metamodel/EnumDefinition.scala
+++ b/metamodel/src/eu/neverblink/linkml/metamodel/EnumDefinition.scala
@@ -117,9 +117,6 @@ final case class EnumDefinitionImpl(
   /** Fill in the slots that have an `equals_expression` with their computed values, and check that
     * the values already present agree with what their expressions infer.
     *
-    * Only single-valued slots with a `string` range are inferred; slots with any other range are
-    * left untouched.
-    *
     * @throws InferenceException
     *   if a slot's value contradicts the value inferred for it, or if an expression references a
     *   slot that has no value

--- a/metamodel/src/eu/neverblink/linkml/metamodel/EnumDefinition.scala
+++ b/metamodel/src/eu/neverblink/linkml/metamodel/EnumDefinition.scala
@@ -112,7 +112,21 @@ final case class EnumDefinitionImpl(
     todos: Seq[String] = Seq(),
     @named("values_from")
     valuesFrom: Seq[UriOrCurie] = Seq(),
-) extends EnumDefinition
+) extends EnumDefinition {
+
+  /** Fill in the slots that have an `equals_expression` with their computed values, and check that
+    * the values already present agree with what their expressions infer.
+    *
+    * Only single-valued slots with a `string` range are inferred; slots with any other range are
+    * left untouched.
+    *
+    * @throws InferenceException
+    *   if a slot's value contradicts the value inferred for it, or if an expression references a
+    *   slot that has no value
+    */
+  def infer(): EnumDefinitionImpl =
+    this
+}
 
 /** An element whose instances must be drawn from a specified set of permissible values
   *
@@ -133,4 +147,12 @@ abstract class EnumDefinition extends Definition, EnumExpression {
     *   From schema: https://w3id.org/linkml/meta
     */
   def enumUri: Option[UriOrCurie]
+
+  /** Fill in the slots that have an `equals_expression`, and check the values already present
+    * against them.
+    *
+    * @throws InferenceException
+    *   if a slot's value contradicts the value inferred for it
+    */
+  def infer(): EnumDefinition
 }

--- a/metamodel/src/eu/neverblink/linkml/metamodel/EnumExpression.scala
+++ b/metamodel/src/eu/neverblink/linkml/metamodel/EnumExpression.scala
@@ -29,14 +29,7 @@ final case class EnumExpressionImpl(
     reachableFrom: Option[ReachabilityQueryImpl] = None,
 ) extends EnumExpression {
 
-  /** Fill in the slots that have an `equals_expression` with their computed values, and check that
-    * the values already present agree with what their expressions infer.
-    *
-    * @throws InferenceException
-    *   if a slot's value contradicts the value inferred for it, or if an expression references a
-    *   slot that has no value
-    */
-  def infer(): EnumExpressionImpl =
+  override def infer(): EnumExpressionImpl =
     this
 }
 
@@ -139,11 +132,12 @@ trait EnumExpression extends Expression {
     */
   def reachableFrom: Option[ReachabilityQueryImpl]
 
-  /** Fill in the slots that have an `equals_expression`, and check the values already present
-    * against them.
+  /** Fill in the slots that have an `equals_expression` with their computed values, and check that
+    * the values already present agree with what their expressions infer.
     *
-    * @throws InferenceException
-    *   if a slot's value contradicts the value inferred for it
+    * @throws eu.neverblink.linkml.runtime.InferenceException
+    *   if a slot's value contradicts the value inferred for it, or if an expression references a
+    *   slot that has no value
     */
   def infer(): EnumExpression
 }

--- a/metamodel/src/eu/neverblink/linkml/metamodel/EnumExpression.scala
+++ b/metamodel/src/eu/neverblink/linkml/metamodel/EnumExpression.scala
@@ -27,7 +27,21 @@ final case class EnumExpressionImpl(
     pvFormula: Option[PvFormulaOptions] = None,
     @named("reachable_from")
     reachableFrom: Option[ReachabilityQueryImpl] = None,
-) extends EnumExpression
+) extends EnumExpression {
+
+  /** Fill in the slots that have an `equals_expression` with their computed values, and check that
+    * the values already present agree with what their expressions infer.
+    *
+    * Only single-valued slots with a `string` range are inferred; slots with any other range are
+    * left untouched.
+    *
+    * @throws InferenceException
+    *   if a slot's value contradicts the value inferred for it, or if an expression references a
+    *   slot that has no value
+    */
+  def infer(): EnumExpressionImpl =
+    this
+}
 
 /** An expression that constrains the range of a slot
   *
@@ -127,4 +141,12 @@ trait EnumExpression extends Expression {
     *   From schema: https://w3id.org/linkml/meta
     */
   def reachableFrom: Option[ReachabilityQueryImpl]
+
+  /** Fill in the slots that have an `equals_expression`, and check the values already present
+    * against them.
+    *
+    * @throws InferenceException
+    *   if a slot's value contradicts the value inferred for it
+    */
+  def infer(): EnumExpression
 }

--- a/metamodel/src/eu/neverblink/linkml/metamodel/EnumExpression.scala
+++ b/metamodel/src/eu/neverblink/linkml/metamodel/EnumExpression.scala
@@ -32,9 +32,6 @@ final case class EnumExpressionImpl(
   /** Fill in the slots that have an `equals_expression` with their computed values, and check that
     * the values already present agree with what their expressions infer.
     *
-    * Only single-valued slots with a `string` range are inferred; slots with any other range are
-    * left untouched.
-    *
     * @throws InferenceException
     *   if a slot's value contradicts the value inferred for it, or if an expression references a
     *   slot that has no value

--- a/metamodel/src/eu/neverblink/linkml/metamodel/Example.scala
+++ b/metamodel/src/eu/neverblink/linkml/metamodel/Example.scala
@@ -16,14 +16,7 @@ final case class ExampleImpl(
     valueObject: Option[Anything] = None,
 ) extends Example {
 
-  /** Fill in the slots that have an `equals_expression` with their computed values, and check that
-    * the values already present agree with what their expressions infer.
-    *
-    * @throws InferenceException
-    *   if a slot's value contradicts the value inferred for it, or if an expression references a
-    *   slot that has no value
-    */
-  def infer(): ExampleImpl =
+  override def infer(): ExampleImpl =
     this
 }
 
@@ -55,11 +48,12 @@ abstract class Example {
     */
   def valueObject: Option[Anything]
 
-  /** Fill in the slots that have an `equals_expression`, and check the values already present
-    * against them.
+  /** Fill in the slots that have an `equals_expression` with their computed values, and check that
+    * the values already present agree with what their expressions infer.
     *
-    * @throws InferenceException
-    *   if a slot's value contradicts the value inferred for it
+    * @throws eu.neverblink.linkml.runtime.InferenceException
+    *   if a slot's value contradicts the value inferred for it, or if an expression references a
+    *   slot that has no value
     */
   def infer(): Example
 }

--- a/metamodel/src/eu/neverblink/linkml/metamodel/Example.scala
+++ b/metamodel/src/eu/neverblink/linkml/metamodel/Example.scala
@@ -19,9 +19,6 @@ final case class ExampleImpl(
   /** Fill in the slots that have an `equals_expression` with their computed values, and check that
     * the values already present agree with what their expressions infer.
     *
-    * Only single-valued slots with a `string` range are inferred; slots with any other range are
-    * left untouched.
-    *
     * @throws InferenceException
     *   if a slot's value contradicts the value inferred for it, or if an expression references a
     *   slot that has no value

--- a/metamodel/src/eu/neverblink/linkml/metamodel/Example.scala
+++ b/metamodel/src/eu/neverblink/linkml/metamodel/Example.scala
@@ -14,7 +14,21 @@ final case class ExampleImpl(
     valueDescription: Option[String] = None,
     @named("object")
     valueObject: Option[Anything] = None,
-) extends Example
+) extends Example {
+
+  /** Fill in the slots that have an `equals_expression` with their computed values, and check that
+    * the values already present agree with what their expressions infer.
+    *
+    * Only single-valued slots with a `string` range are inferred; slots with any other range are
+    * left untouched.
+    *
+    * @throws InferenceException
+    *   if a slot's value contradicts the value inferred for it, or if an expression references a
+    *   slot that has no value
+    */
+  def infer(): ExampleImpl =
+    this
+}
 
 /** Usage example and description
   *
@@ -43,4 +57,12 @@ abstract class Example {
     *   From schema: https://w3id.org/linkml/meta
     */
   def valueObject: Option[Anything]
+
+  /** Fill in the slots that have an `equals_expression`, and check the values already present
+    * against them.
+    *
+    * @throws InferenceException
+    *   if a slot's value contradicts the value inferred for it
+    */
+  def infer(): Example
 }

--- a/metamodel/src/eu/neverblink/linkml/metamodel/Expression.scala
+++ b/metamodel/src/eu/neverblink/linkml/metamodel/Expression.scala
@@ -7,4 +7,13 @@ package eu.neverblink.linkml.metamodel
   * @see
   *   From schema: https://w3id.org/linkml/meta
   */
-trait Expression {}
+trait Expression {
+
+  /** Fill in the slots that have an `equals_expression`, and check the values already present
+    * against them.
+    *
+    * @throws InferenceException
+    *   if a slot's value contradicts the value inferred for it
+    */
+  def infer(): Expression
+}

--- a/metamodel/src/eu/neverblink/linkml/metamodel/Expression.scala
+++ b/metamodel/src/eu/neverblink/linkml/metamodel/Expression.scala
@@ -9,11 +9,12 @@ package eu.neverblink.linkml.metamodel
   */
 trait Expression {
 
-  /** Fill in the slots that have an `equals_expression`, and check the values already present
-    * against them.
+  /** Fill in the slots that have an `equals_expression` with their computed values, and check that
+    * the values already present agree with what their expressions infer.
     *
-    * @throws InferenceException
-    *   if a slot's value contradicts the value inferred for it
+    * @throws eu.neverblink.linkml.runtime.InferenceException
+    *   if a slot's value contradicts the value inferred for it, or if an expression references a
+    *   slot that has no value
     */
   def infer(): Expression
 }

--- a/metamodel/src/eu/neverblink/linkml/metamodel/Extensible.scala
+++ b/metamodel/src/eu/neverblink/linkml/metamodel/Extensible.scala
@@ -15,4 +15,12 @@ trait Extensible {
     *   From schema: https://w3id.org/linkml/extensions
     */
   def extensions: Map[String, ExtensionImpl]
+
+  /** Fill in the slots that have an `equals_expression`, and check the values already present
+    * against them.
+    *
+    * @throws InferenceException
+    *   if a slot's value contradicts the value inferred for it
+    */
+  def infer(): Extensible
 }

--- a/metamodel/src/eu/neverblink/linkml/metamodel/Extensible.scala
+++ b/metamodel/src/eu/neverblink/linkml/metamodel/Extensible.scala
@@ -16,11 +16,12 @@ trait Extensible {
     */
   def extensions: Map[String, ExtensionImpl]
 
-  /** Fill in the slots that have an `equals_expression`, and check the values already present
-    * against them.
+  /** Fill in the slots that have an `equals_expression` with their computed values, and check that
+    * the values already present agree with what their expressions infer.
     *
-    * @throws InferenceException
-    *   if a slot's value contradicts the value inferred for it
+    * @throws eu.neverblink.linkml.runtime.InferenceException
+    *   if a slot's value contradicts the value inferred for it, or if an expression references a
+    *   slot that has no value
     */
   def infer(): Extensible
 }

--- a/metamodel/src/eu/neverblink/linkml/metamodel/Extension.scala
+++ b/metamodel/src/eu/neverblink/linkml/metamodel/Extension.scala
@@ -19,14 +19,7 @@ final case class ExtensionImpl(
     extensions: Map[String, ExtensionImpl] = Map(),
 ) extends Extension {
 
-  /** Fill in the slots that have an `equals_expression` with their computed values, and check that
-    * the values already present agree with what their expressions infer.
-    *
-    * @throws InferenceException
-    *   if a slot's value contradicts the value inferred for it, or if an expression references a
-    *   slot that has no value
-    */
-  def infer(): ExtensionImpl =
+  override def infer(): ExtensionImpl =
     this
 }
 
@@ -58,11 +51,12 @@ abstract class Extension {
     */
   def extensions: Map[String, ExtensionImpl]
 
-  /** Fill in the slots that have an `equals_expression`, and check the values already present
-    * against them.
+  /** Fill in the slots that have an `equals_expression` with their computed values, and check that
+    * the values already present agree with what their expressions infer.
     *
-    * @throws InferenceException
-    *   if a slot's value contradicts the value inferred for it
+    * @throws eu.neverblink.linkml.runtime.InferenceException
+    *   if a slot's value contradicts the value inferred for it, or if an expression references a
+    *   slot that has no value
     */
   def infer(): Extension
 }

--- a/metamodel/src/eu/neverblink/linkml/metamodel/Extension.scala
+++ b/metamodel/src/eu/neverblink/linkml/metamodel/Extension.scala
@@ -22,9 +22,6 @@ final case class ExtensionImpl(
   /** Fill in the slots that have an `equals_expression` with their computed values, and check that
     * the values already present agree with what their expressions infer.
     *
-    * Only single-valued slots with a `string` range are inferred; slots with any other range are
-    * left untouched.
-    *
     * @throws InferenceException
     *   if a slot's value contradicts the value inferred for it, or if an expression references a
     *   slot that has no value

--- a/metamodel/src/eu/neverblink/linkml/metamodel/Extension.scala
+++ b/metamodel/src/eu/neverblink/linkml/metamodel/Extension.scala
@@ -17,7 +17,21 @@ final case class ExtensionImpl(
     extensionValue: AnyValue,
     @simpleDict
     extensions: Map[String, ExtensionImpl] = Map(),
-) extends Extension
+) extends Extension {
+
+  /** Fill in the slots that have an `equals_expression` with their computed values, and check that
+    * the values already present agree with what their expressions infer.
+    *
+    * Only single-valued slots with a `string` range are inferred; slots with any other range are
+    * left untouched.
+    *
+    * @throws InferenceException
+    *   if a slot's value contradicts the value inferred for it, or if an expression references a
+    *   slot that has no value
+    */
+  def infer(): ExtensionImpl =
+    this
+}
 
 /** A tag/value pair used to add non-model information to an entry
   *
@@ -46,4 +60,12 @@ abstract class Extension {
     *   From schema: https://w3id.org/linkml/extensions
     */
   def extensions: Map[String, ExtensionImpl]
+
+  /** Fill in the slots that have an `equals_expression`, and check the values already present
+    * against them.
+    *
+    * @throws InferenceException
+    *   if a slot's value contradicts the value inferred for it
+    */
+  def infer(): Extension
 }

--- a/metamodel/src/eu/neverblink/linkml/metamodel/ExtraSlotsExpression.scala
+++ b/metamodel/src/eu/neverblink/linkml/metamodel/ExtraSlotsExpression.scala
@@ -12,7 +12,21 @@ final case class ExtraSlotsExpressionImpl(
     allowed: Boolean = false,
     @named("range_expression")
     rangeExpression: Option[AnonymousSlotExpressionImpl] = None,
-) extends ExtraSlotsExpression
+) extends ExtraSlotsExpression {
+
+  /** Fill in the slots that have an `equals_expression` with their computed values, and check that
+    * the values already present agree with what their expressions infer.
+    *
+    * Only single-valued slots with a `string` range are inferred; slots with any other range are
+    * left untouched.
+    *
+    * @throws InferenceException
+    *   if a slot's value contradicts the value inferred for it, or if an expression references a
+    *   slot that has no value
+    */
+  def infer(): ExtraSlotsExpressionImpl =
+    this
+}
 
 /** An expression that defines how to handle additional data in an instance of class beyond the
   * slots/attributes defined for that class. See `extra_slots` for usage examples.
@@ -38,4 +52,12 @@ abstract class ExtraSlotsExpression extends Expression {
     *   combine two enums
     */
   def rangeExpression: Option[AnonymousSlotExpressionImpl]
+
+  /** Fill in the slots that have an `equals_expression`, and check the values already present
+    * against them.
+    *
+    * @throws InferenceException
+    *   if a slot's value contradicts the value inferred for it
+    */
+  def infer(): ExtraSlotsExpression
 }

--- a/metamodel/src/eu/neverblink/linkml/metamodel/ExtraSlotsExpression.scala
+++ b/metamodel/src/eu/neverblink/linkml/metamodel/ExtraSlotsExpression.scala
@@ -17,9 +17,6 @@ final case class ExtraSlotsExpressionImpl(
   /** Fill in the slots that have an `equals_expression` with their computed values, and check that
     * the values already present agree with what their expressions infer.
     *
-    * Only single-valued slots with a `string` range are inferred; slots with any other range are
-    * left untouched.
-    *
     * @throws InferenceException
     *   if a slot's value contradicts the value inferred for it, or if an expression references a
     *   slot that has no value

--- a/metamodel/src/eu/neverblink/linkml/metamodel/ExtraSlotsExpression.scala
+++ b/metamodel/src/eu/neverblink/linkml/metamodel/ExtraSlotsExpression.scala
@@ -14,14 +14,7 @@ final case class ExtraSlotsExpressionImpl(
     rangeExpression: Option[AnonymousSlotExpressionImpl] = None,
 ) extends ExtraSlotsExpression {
 
-  /** Fill in the slots that have an `equals_expression` with their computed values, and check that
-    * the values already present agree with what their expressions infer.
-    *
-    * @throws InferenceException
-    *   if a slot's value contradicts the value inferred for it, or if an expression references a
-    *   slot that has no value
-    */
-  def infer(): ExtraSlotsExpressionImpl =
+  override def infer(): ExtraSlotsExpressionImpl =
     this
 }
 
@@ -50,11 +43,12 @@ abstract class ExtraSlotsExpression extends Expression {
     */
   def rangeExpression: Option[AnonymousSlotExpressionImpl]
 
-  /** Fill in the slots that have an `equals_expression`, and check the values already present
-    * against them.
+  /** Fill in the slots that have an `equals_expression` with their computed values, and check that
+    * the values already present agree with what their expressions infer.
     *
-    * @throws InferenceException
-    *   if a slot's value contradicts the value inferred for it
+    * @throws eu.neverblink.linkml.runtime.InferenceException
+    *   if a slot's value contradicts the value inferred for it, or if an expression references a
+    *   slot that has no value
     */
   def infer(): ExtraSlotsExpression
 }

--- a/metamodel/src/eu/neverblink/linkml/metamodel/ImportExpression.scala
+++ b/metamodel/src/eu/neverblink/linkml/metamodel/ImportExpression.scala
@@ -74,14 +74,7 @@ final case class ImportExpressionImpl(
     todos: Seq[String] = Seq(),
 ) extends ImportExpression {
 
-  /** Fill in the slots that have an `equals_expression` with their computed values, and check that
-    * the values already present agree with what their expressions infer.
-    *
-    * @throws InferenceException
-    *   if a slot's value contradicts the value inferred for it, or if an expression references a
-    *   slot that has no value
-    */
-  def infer(): ImportExpressionImpl =
+  override def infer(): ImportExpressionImpl =
     this
 }
 
@@ -107,11 +100,12 @@ abstract class ImportExpression extends Extensible, Annotatable, CommonMetadata 
     */
   def importMap: Map[String, SettingImpl]
 
-  /** Fill in the slots that have an `equals_expression`, and check the values already present
-    * against them.
+  /** Fill in the slots that have an `equals_expression` with their computed values, and check that
+    * the values already present agree with what their expressions infer.
     *
-    * @throws InferenceException
-    *   if a slot's value contradicts the value inferred for it
+    * @throws eu.neverblink.linkml.runtime.InferenceException
+    *   if a slot's value contradicts the value inferred for it, or if an expression references a
+    *   slot that has no value
     */
   def infer(): ImportExpression
 }

--- a/metamodel/src/eu/neverblink/linkml/metamodel/ImportExpression.scala
+++ b/metamodel/src/eu/neverblink/linkml/metamodel/ImportExpression.scala
@@ -72,7 +72,21 @@ final case class ImportExpressionImpl(
     @named("structured_aliases")
     structuredAliases: Seq[StructuredAliasImpl] = Seq(),
     todos: Seq[String] = Seq(),
-) extends ImportExpression
+) extends ImportExpression {
+
+  /** Fill in the slots that have an `equals_expression` with their computed values, and check that
+    * the values already present agree with what their expressions infer.
+    *
+    * Only single-valued slots with a `string` range are inferred; slots with any other range are
+    * left untouched.
+    *
+    * @throws InferenceException
+    *   if a slot's value contradicts the value inferred for it, or if an expression references a
+    *   slot that has no value
+    */
+  def infer(): ImportExpressionImpl =
+    this
+}
 
 /** An expression describing an import
   *
@@ -95,4 +109,12 @@ abstract class ImportExpression extends Extensible, Annotatable, CommonMetadata 
     *   From schema: https://w3id.org/linkml/meta
     */
   def importMap: Map[String, SettingImpl]
+
+  /** Fill in the slots that have an `equals_expression`, and check the values already present
+    * against them.
+    *
+    * @throws InferenceException
+    *   if a slot's value contradicts the value inferred for it
+    */
+  def infer(): ImportExpression
 }

--- a/metamodel/src/eu/neverblink/linkml/metamodel/ImportExpression.scala
+++ b/metamodel/src/eu/neverblink/linkml/metamodel/ImportExpression.scala
@@ -77,9 +77,6 @@ final case class ImportExpressionImpl(
   /** Fill in the slots that have an `equals_expression` with their computed values, and check that
     * the values already present agree with what their expressions infer.
     *
-    * Only single-valued slots with a `string` range are inferred; slots with any other range are
-    * left untouched.
-    *
     * @throws InferenceException
     *   if a slot's value contradicts the value inferred for it, or if an expression references a
     *   slot that has no value

--- a/metamodel/src/eu/neverblink/linkml/metamodel/LocalName.scala
+++ b/metamodel/src/eu/neverblink/linkml/metamodel/LocalName.scala
@@ -20,9 +20,6 @@ final case class LocalNameImpl(
   /** Fill in the slots that have an `equals_expression` with their computed values, and check that
     * the values already present agree with what their expressions infer.
     *
-    * Only single-valued slots with a `string` range are inferred; slots with any other range are
-    * left untouched.
-    *
     * @throws InferenceException
     *   if a slot's value contradicts the value inferred for it, or if an expression references a
     *   slot that has no value

--- a/metamodel/src/eu/neverblink/linkml/metamodel/LocalName.scala
+++ b/metamodel/src/eu/neverblink/linkml/metamodel/LocalName.scala
@@ -17,14 +17,7 @@ final case class LocalNameImpl(
     localNameValue: String,
 ) extends LocalName {
 
-  /** Fill in the slots that have an `equals_expression` with their computed values, and check that
-    * the values already present agree with what their expressions infer.
-    *
-    * @throws InferenceException
-    *   if a slot's value contradicts the value inferred for it, or if an expression references a
-    *   slot that has no value
-    */
-  def infer(): LocalNameImpl =
+  override def infer(): LocalNameImpl =
     this
 }
 
@@ -49,11 +42,12 @@ abstract class LocalName {
     */
   def localNameValue: String
 
-  /** Fill in the slots that have an `equals_expression`, and check the values already present
-    * against them.
+  /** Fill in the slots that have an `equals_expression` with their computed values, and check that
+    * the values already present agree with what their expressions infer.
     *
-    * @throws InferenceException
-    *   if a slot's value contradicts the value inferred for it
+    * @throws eu.neverblink.linkml.runtime.InferenceException
+    *   if a slot's value contradicts the value inferred for it, or if an expression references a
+    *   slot that has no value
     */
   def infer(): LocalName
 }

--- a/metamodel/src/eu/neverblink/linkml/metamodel/LocalName.scala
+++ b/metamodel/src/eu/neverblink/linkml/metamodel/LocalName.scala
@@ -15,7 +15,21 @@ final case class LocalNameImpl(
     @value
     @named("local_name_value")
     localNameValue: String,
-) extends LocalName
+) extends LocalName {
+
+  /** Fill in the slots that have an `equals_expression` with their computed values, and check that
+    * the values already present agree with what their expressions infer.
+    *
+    * Only single-valued slots with a `string` range are inferred; slots with any other range are
+    * left untouched.
+    *
+    * @throws InferenceException
+    *   if a slot's value contradicts the value inferred for it, or if an expression references a
+    *   slot that has no value
+    */
+  def infer(): LocalNameImpl =
+    this
+}
 
 /** An attributed label
   *
@@ -37,4 +51,12 @@ abstract class LocalName {
     *   From schema: https://w3id.org/linkml/meta
     */
   def localNameValue: String
+
+  /** Fill in the slots that have an `equals_expression`, and check the values already present
+    * against them.
+    *
+    * @throws InferenceException
+    *   if a slot's value contradicts the value inferred for it
+    */
+  def infer(): LocalName
 }

--- a/metamodel/src/eu/neverblink/linkml/metamodel/MatchQuery.scala
+++ b/metamodel/src/eu/neverblink/linkml/metamodel/MatchQuery.scala
@@ -13,7 +13,21 @@ final case class MatchQueryImpl(
     identifierPattern: Option[String] = None,
     @named("source_ontology")
     sourceOntology: Option[UriOrCurie] = None,
-) extends MatchQuery
+) extends MatchQuery {
+
+  /** Fill in the slots that have an `equals_expression` with their computed values, and check that
+    * the values already present agree with what their expressions infer.
+    *
+    * Only single-valued slots with a `string` range are inferred; slots with any other range are
+    * left untouched.
+    *
+    * @throws InferenceException
+    *   if a slot's value contradicts the value inferred for it, or if an expression references a
+    *   slot that has no value
+    */
+  def infer(): MatchQueryImpl =
+    this
+}
 
 /** A query that is used on an enum expression to dynamically obtain a set of permissible values via
   * a query that matches on properties of the external concepts.
@@ -44,4 +58,12 @@ abstract class MatchQuery {
     *   For obo ontologies we recommend CURIEs of the form obo:cl, obo:envo, etc
     */
   def sourceOntology: Option[UriOrCurie]
+
+  /** Fill in the slots that have an `equals_expression`, and check the values already present
+    * against them.
+    *
+    * @throws InferenceException
+    *   if a slot's value contradicts the value inferred for it
+    */
+  def infer(): MatchQuery
 }

--- a/metamodel/src/eu/neverblink/linkml/metamodel/MatchQuery.scala
+++ b/metamodel/src/eu/neverblink/linkml/metamodel/MatchQuery.scala
@@ -18,9 +18,6 @@ final case class MatchQueryImpl(
   /** Fill in the slots that have an `equals_expression` with their computed values, and check that
     * the values already present agree with what their expressions infer.
     *
-    * Only single-valued slots with a `string` range are inferred; slots with any other range are
-    * left untouched.
-    *
     * @throws InferenceException
     *   if a slot's value contradicts the value inferred for it, or if an expression references a
     *   slot that has no value

--- a/metamodel/src/eu/neverblink/linkml/metamodel/MatchQuery.scala
+++ b/metamodel/src/eu/neverblink/linkml/metamodel/MatchQuery.scala
@@ -15,14 +15,7 @@ final case class MatchQueryImpl(
     sourceOntology: Option[UriOrCurie] = None,
 ) extends MatchQuery {
 
-  /** Fill in the slots that have an `equals_expression` with their computed values, and check that
-    * the values already present agree with what their expressions infer.
-    *
-    * @throws InferenceException
-    *   if a slot's value contradicts the value inferred for it, or if an expression references a
-    *   slot that has no value
-    */
-  def infer(): MatchQueryImpl =
+  override def infer(): MatchQueryImpl =
     this
 }
 
@@ -56,11 +49,12 @@ abstract class MatchQuery {
     */
   def sourceOntology: Option[UriOrCurie]
 
-  /** Fill in the slots that have an `equals_expression`, and check the values already present
-    * against them.
+  /** Fill in the slots that have an `equals_expression` with their computed values, and check that
+    * the values already present agree with what their expressions infer.
     *
-    * @throws InferenceException
-    *   if a slot's value contradicts the value inferred for it
+    * @throws eu.neverblink.linkml.runtime.InferenceException
+    *   if a slot's value contradicts the value inferred for it, or if an expression references a
+    *   slot that has no value
     */
   def infer(): MatchQuery
 }

--- a/metamodel/src/eu/neverblink/linkml/metamodel/ObligationLevelEnum.scala
+++ b/metamodel/src/eu/neverblink/linkml/metamodel/ObligationLevelEnum.scala
@@ -9,7 +9,7 @@ import eu.neverblink.linkml.runtime.*
   * @see
   *   From schema: https://w3id.org/linkml/meta
   */
-sealed abstract class ObligationLevelEnum
+sealed abstract class ObligationLevelEnum derives Stringify
 
 object ObligationLevelEnum {
 

--- a/metamodel/src/eu/neverblink/linkml/metamodel/PathExpression.scala
+++ b/metamodel/src/eu/neverblink/linkml/metamodel/PathExpression.scala
@@ -84,9 +84,6 @@ final case class PathExpressionImpl(
   /** Fill in the slots that have an `equals_expression` with their computed values, and check that
     * the values already present agree with what their expressions infer.
     *
-    * Only single-valued slots with a `string` range are inferred; slots with any other range are
-    * left untouched.
-    *
     * @throws InferenceException
     *   if a slot's value contradicts the value inferred for it, or if an expression references a
     *   slot that has no value

--- a/metamodel/src/eu/neverblink/linkml/metamodel/PathExpression.scala
+++ b/metamodel/src/eu/neverblink/linkml/metamodel/PathExpression.scala
@@ -79,7 +79,21 @@ final case class PathExpressionImpl(
     structuredAliases: Seq[StructuredAliasImpl] = Seq(),
     todos: Seq[String] = Seq(),
     traverse: Option[Reference[SlotDefinition]] = None,
-) extends PathExpression
+) extends PathExpression {
+
+  /** Fill in the slots that have an `equals_expression` with their computed values, and check that
+    * the values already present agree with what their expressions infer.
+    *
+    * Only single-valued slots with a `string` range are inferred; slots with any other range are
+    * left untouched.
+    *
+    * @throws InferenceException
+    *   if a slot's value contradicts the value inferred for it, or if an expression references a
+    *   slot that has no value
+    */
+  def infer(): PathExpressionImpl =
+    this
+}
 
 /** An expression that describes an abstract path from an object to another through a sequence of
   * slot lookups
@@ -155,4 +169,12 @@ abstract class PathExpression extends Expression, Extensible, Annotatable, Commo
     *   From schema: https://w3id.org/linkml/meta
     */
   def traverse: Option[Reference[SlotDefinition]]
+
+  /** Fill in the slots that have an `equals_expression`, and check the values already present
+    * against them.
+    *
+    * @throws InferenceException
+    *   if a slot's value contradicts the value inferred for it
+    */
+  def infer(): PathExpression
 }

--- a/metamodel/src/eu/neverblink/linkml/metamodel/PathExpression.scala
+++ b/metamodel/src/eu/neverblink/linkml/metamodel/PathExpression.scala
@@ -81,14 +81,7 @@ final case class PathExpressionImpl(
     traverse: Option[Reference[SlotDefinition]] = None,
 ) extends PathExpression {
 
-  /** Fill in the slots that have an `equals_expression` with their computed values, and check that
-    * the values already present agree with what their expressions infer.
-    *
-    * @throws InferenceException
-    *   if a slot's value contradicts the value inferred for it, or if an expression references a
-    *   slot that has no value
-    */
-  def infer(): PathExpressionImpl =
+  override def infer(): PathExpressionImpl =
     this
 }
 
@@ -167,11 +160,12 @@ abstract class PathExpression extends Expression, Extensible, Annotatable, Commo
     */
   def traverse: Option[Reference[SlotDefinition]]
 
-  /** Fill in the slots that have an `equals_expression`, and check the values already present
-    * against them.
+  /** Fill in the slots that have an `equals_expression` with their computed values, and check that
+    * the values already present agree with what their expressions infer.
     *
-    * @throws InferenceException
-    *   if a slot's value contradicts the value inferred for it
+    * @throws eu.neverblink.linkml.runtime.InferenceException
+    *   if a slot's value contradicts the value inferred for it, or if an expression references a
+    *   slot that has no value
     */
   def infer(): PathExpression
 }

--- a/metamodel/src/eu/neverblink/linkml/metamodel/PatternExpression.scala
+++ b/metamodel/src/eu/neverblink/linkml/metamodel/PatternExpression.scala
@@ -69,7 +69,21 @@ final case class PatternExpressionImpl(
     structuredAliases: Seq[StructuredAliasImpl] = Seq(),
     syntax: Option[String] = None,
     todos: Seq[String] = Seq(),
-) extends PatternExpression
+) extends PatternExpression {
+
+  /** Fill in the slots that have an `equals_expression` with their computed values, and check that
+    * the values already present agree with what their expressions infer.
+    *
+    * Only single-valued slots with a `string` range are inferred; slots with any other range are
+    * left untouched.
+    *
+    * @throws InferenceException
+    *   if a slot's value contradicts the value inferred for it, or if an expression references a
+    *   slot that has no value
+    */
+  def infer(): PatternExpressionImpl =
+    this
+}
 
 /** A regular expression pattern used to evaluate conformance of a string
   *
@@ -99,4 +113,12 @@ abstract class PatternExpression extends Extensible, Annotatable, CommonMetadata
     *   From schema: https://w3id.org/linkml/meta
     */
   def syntax: Option[String]
+
+  /** Fill in the slots that have an `equals_expression`, and check the values already present
+    * against them.
+    *
+    * @throws InferenceException
+    *   if a slot's value contradicts the value inferred for it
+    */
+  def infer(): PatternExpression
 }

--- a/metamodel/src/eu/neverblink/linkml/metamodel/PatternExpression.scala
+++ b/metamodel/src/eu/neverblink/linkml/metamodel/PatternExpression.scala
@@ -71,14 +71,7 @@ final case class PatternExpressionImpl(
     todos: Seq[String] = Seq(),
 ) extends PatternExpression {
 
-  /** Fill in the slots that have an `equals_expression` with their computed values, and check that
-    * the values already present agree with what their expressions infer.
-    *
-    * @throws InferenceException
-    *   if a slot's value contradicts the value inferred for it, or if an expression references a
-    *   slot that has no value
-    */
-  def infer(): PatternExpressionImpl =
+  override def infer(): PatternExpressionImpl =
     this
 }
 
@@ -111,11 +104,12 @@ abstract class PatternExpression extends Extensible, Annotatable, CommonMetadata
     */
   def syntax: Option[String]
 
-  /** Fill in the slots that have an `equals_expression`, and check the values already present
-    * against them.
+  /** Fill in the slots that have an `equals_expression` with their computed values, and check that
+    * the values already present agree with what their expressions infer.
     *
-    * @throws InferenceException
-    *   if a slot's value contradicts the value inferred for it
+    * @throws eu.neverblink.linkml.runtime.InferenceException
+    *   if a slot's value contradicts the value inferred for it, or if an expression references a
+    *   slot that has no value
     */
   def infer(): PatternExpression
 }

--- a/metamodel/src/eu/neverblink/linkml/metamodel/PatternExpression.scala
+++ b/metamodel/src/eu/neverblink/linkml/metamodel/PatternExpression.scala
@@ -74,9 +74,6 @@ final case class PatternExpressionImpl(
   /** Fill in the slots that have an `equals_expression` with their computed values, and check that
     * the values already present agree with what their expressions infer.
     *
-    * Only single-valued slots with a `string` range are inferred; slots with any other range are
-    * left untouched.
-    *
     * @throws InferenceException
     *   if a slot's value contradicts the value inferred for it, or if an expression references a
     *   slot that has no value

--- a/metamodel/src/eu/neverblink/linkml/metamodel/PermissibleValue.scala
+++ b/metamodel/src/eu/neverblink/linkml/metamodel/PermissibleValue.scala
@@ -79,9 +79,6 @@ final case class PermissibleValueImpl(
   /** Fill in the slots that have an `equals_expression` with their computed values, and check that
     * the values already present agree with what their expressions infer.
     *
-    * Only single-valued slots with a `string` range are inferred; slots with any other range are
-    * left untouched.
-    *
     * @throws InferenceException
     *   if a slot's value contradicts the value inferred for it, or if an expression references a
     *   slot that has no value

--- a/metamodel/src/eu/neverblink/linkml/metamodel/PermissibleValue.scala
+++ b/metamodel/src/eu/neverblink/linkml/metamodel/PermissibleValue.scala
@@ -74,7 +74,21 @@ final case class PermissibleValueImpl(
     structuredAliases: Seq[StructuredAliasImpl] = Seq(),
     todos: Seq[String] = Seq(),
     unit: Option[UnitOfMeasureImpl] = None,
-) extends PermissibleValue
+) extends PermissibleValue {
+
+  /** Fill in the slots that have an `equals_expression` with their computed values, and check that
+    * the values already present agree with what their expressions infer.
+    *
+    * Only single-valued slots with a `string` range are inferred; slots with any other range are
+    * left untouched.
+    *
+    * @throws InferenceException
+    *   if a slot's value contradicts the value inferred for it, or if an expression references a
+    *   slot that has no value
+    */
+  def infer(): PermissibleValueImpl =
+    this
+}
 
 /** A permissible value, accompanied by intended text and an optional mapping to a concept URI
   *
@@ -169,4 +183,12 @@ abstract class PermissibleValue extends Extensible, Annotatable, CommonMetadata 
     *   From schema: https://w3id.org/linkml/units
     */
   def unit: Option[UnitOfMeasureImpl]
+
+  /** Fill in the slots that have an `equals_expression`, and check the values already present
+    * against them.
+    *
+    * @throws InferenceException
+    *   if a slot's value contradicts the value inferred for it
+    */
+  def infer(): PermissibleValue
 }

--- a/metamodel/src/eu/neverblink/linkml/metamodel/PermissibleValue.scala
+++ b/metamodel/src/eu/neverblink/linkml/metamodel/PermissibleValue.scala
@@ -76,14 +76,7 @@ final case class PermissibleValueImpl(
     unit: Option[UnitOfMeasureImpl] = None,
 ) extends PermissibleValue {
 
-  /** Fill in the slots that have an `equals_expression` with their computed values, and check that
-    * the values already present agree with what their expressions infer.
-    *
-    * @throws InferenceException
-    *   if a slot's value contradicts the value inferred for it, or if an expression references a
-    *   slot that has no value
-    */
-  def infer(): PermissibleValueImpl =
+  override def infer(): PermissibleValueImpl =
     this
 }
 
@@ -181,11 +174,12 @@ abstract class PermissibleValue extends Extensible, Annotatable, CommonMetadata 
     */
   def unit: Option[UnitOfMeasureImpl]
 
-  /** Fill in the slots that have an `equals_expression`, and check the values already present
-    * against them.
+  /** Fill in the slots that have an `equals_expression` with their computed values, and check that
+    * the values already present agree with what their expressions infer.
     *
-    * @throws InferenceException
-    *   if a slot's value contradicts the value inferred for it
+    * @throws eu.neverblink.linkml.runtime.InferenceException
+    *   if a slot's value contradicts the value inferred for it, or if an expression references a
+    *   slot that has no value
     */
   def infer(): PermissibleValue
 }

--- a/metamodel/src/eu/neverblink/linkml/metamodel/Prefix.scala
+++ b/metamodel/src/eu/neverblink/linkml/metamodel/Prefix.scala
@@ -17,14 +17,7 @@ final case class PrefixImpl(
     prefixReference: Uri,
 ) extends Prefix {
 
-  /** Fill in the slots that have an `equals_expression` with their computed values, and check that
-    * the values already present agree with what their expressions infer.
-    *
-    * @throws InferenceException
-    *   if a slot's value contradicts the value inferred for it, or if an expression references a
-    *   slot that has no value
-    */
-  def infer(): PrefixImpl =
+  override def infer(): PrefixImpl =
     this
 }
 
@@ -50,11 +43,12 @@ abstract class Prefix {
     */
   def prefixReference: Uri
 
-  /** Fill in the slots that have an `equals_expression`, and check the values already present
-    * against them.
+  /** Fill in the slots that have an `equals_expression` with their computed values, and check that
+    * the values already present agree with what their expressions infer.
     *
-    * @throws InferenceException
-    *   if a slot's value contradicts the value inferred for it
+    * @throws eu.neverblink.linkml.runtime.InferenceException
+    *   if a slot's value contradicts the value inferred for it, or if an expression references a
+    *   slot that has no value
     */
   def infer(): Prefix
 }

--- a/metamodel/src/eu/neverblink/linkml/metamodel/Prefix.scala
+++ b/metamodel/src/eu/neverblink/linkml/metamodel/Prefix.scala
@@ -15,7 +15,21 @@ final case class PrefixImpl(
     @value
     @named("prefix_reference")
     prefixReference: Uri,
-) extends Prefix
+) extends Prefix {
+
+  /** Fill in the slots that have an `equals_expression` with their computed values, and check that
+    * the values already present agree with what their expressions infer.
+    *
+    * Only single-valued slots with a `string` range are inferred; slots with any other range are
+    * left untouched.
+    *
+    * @throws InferenceException
+    *   if a slot's value contradicts the value inferred for it, or if an expression references a
+    *   slot that has no value
+    */
+  def infer(): PrefixImpl =
+    this
+}
 
 /** Prefix URI tuple
   *
@@ -38,4 +52,12 @@ abstract class Prefix {
     *   From schema: https://w3id.org/linkml/meta
     */
   def prefixReference: Uri
+
+  /** Fill in the slots that have an `equals_expression`, and check the values already present
+    * against them.
+    *
+    * @throws InferenceException
+    *   if a slot's value contradicts the value inferred for it
+    */
+  def infer(): Prefix
 }

--- a/metamodel/src/eu/neverblink/linkml/metamodel/Prefix.scala
+++ b/metamodel/src/eu/neverblink/linkml/metamodel/Prefix.scala
@@ -20,9 +20,6 @@ final case class PrefixImpl(
   /** Fill in the slots that have an `equals_expression` with their computed values, and check that
     * the values already present agree with what their expressions infer.
     *
-    * Only single-valued slots with a `string` range are inferred; slots with any other range are
-    * left untouched.
-    *
     * @throws InferenceException
     *   if a slot's value contradicts the value inferred for it, or if an expression references a
     *   slot that has no value

--- a/metamodel/src/eu/neverblink/linkml/metamodel/PresenceEnum.scala
+++ b/metamodel/src/eu/neverblink/linkml/metamodel/PresenceEnum.scala
@@ -9,7 +9,7 @@ import eu.neverblink.linkml.runtime.*
   * @see
   *   From schema: https://w3id.org/linkml/meta
   */
-sealed abstract class PresenceEnum
+sealed abstract class PresenceEnum derives Stringify
 
 object PresenceEnum {
 

--- a/metamodel/src/eu/neverblink/linkml/metamodel/PvFormulaOptions.scala
+++ b/metamodel/src/eu/neverblink/linkml/metamodel/PvFormulaOptions.scala
@@ -9,7 +9,7 @@ import eu.neverblink.linkml.runtime.*
   * @see
   *   From schema: https://w3id.org/linkml/meta
   */
-sealed abstract class PvFormulaOptions
+sealed abstract class PvFormulaOptions derives Stringify
 
 object PvFormulaOptions {
 

--- a/metamodel/src/eu/neverblink/linkml/metamodel/ReachabilityQuery.scala
+++ b/metamodel/src/eu/neverblink/linkml/metamodel/ReachabilityQuery.scala
@@ -23,14 +23,7 @@ final case class ReachabilityQueryImpl(
     traverseUp: Boolean = false,
 ) extends ReachabilityQuery {
 
-  /** Fill in the slots that have an `equals_expression` with their computed values, and check that
-    * the values already present agree with what their expressions infer.
-    *
-    * @throws InferenceException
-    *   if a slot's value contradicts the value inferred for it, or if an expression references a
-    *   slot that has no value
-    */
-  def infer(): ReachabilityQueryImpl =
+  override def infer(): ReachabilityQueryImpl =
     this
 }
 
@@ -101,11 +94,12 @@ abstract class ReachabilityQuery {
     */
   def traverseUp: Boolean
 
-  /** Fill in the slots that have an `equals_expression`, and check the values already present
-    * against them.
+  /** Fill in the slots that have an `equals_expression` with their computed values, and check that
+    * the values already present agree with what their expressions infer.
     *
-    * @throws InferenceException
-    *   if a slot's value contradicts the value inferred for it
+    * @throws eu.neverblink.linkml.runtime.InferenceException
+    *   if a slot's value contradicts the value inferred for it, or if an expression references a
+    *   slot that has no value
     */
   def infer(): ReachabilityQuery
 }

--- a/metamodel/src/eu/neverblink/linkml/metamodel/ReachabilityQuery.scala
+++ b/metamodel/src/eu/neverblink/linkml/metamodel/ReachabilityQuery.scala
@@ -21,7 +21,21 @@ final case class ReachabilityQueryImpl(
     sourceOntology: Option[UriOrCurie] = None,
     @named("traverse_up")
     traverseUp: Boolean = false,
-) extends ReachabilityQuery
+) extends ReachabilityQuery {
+
+  /** Fill in the slots that have an `equals_expression` with their computed values, and check that
+    * the values already present agree with what their expressions infer.
+    *
+    * Only single-valued slots with a `string` range are inferred; slots with any other range are
+    * left untouched.
+    *
+    * @throws InferenceException
+    *   if a slot's value contradicts the value inferred for it, or if an expression references a
+    *   slot that has no value
+    */
+  def infer(): ReachabilityQueryImpl =
+    this
+}
 
 /** A query that is used on an enum expression to dynamically obtain a set of permissible values via
   * walking from a set of source nodes to a set of descendants or ancestors over a set of
@@ -89,4 +103,12 @@ abstract class ReachabilityQuery {
     *   From schema: https://w3id.org/linkml/meta
     */
   def traverseUp: Boolean
+
+  /** Fill in the slots that have an `equals_expression`, and check the values already present
+    * against them.
+    *
+    * @throws InferenceException
+    *   if a slot's value contradicts the value inferred for it
+    */
+  def infer(): ReachabilityQuery
 }

--- a/metamodel/src/eu/neverblink/linkml/metamodel/ReachabilityQuery.scala
+++ b/metamodel/src/eu/neverblink/linkml/metamodel/ReachabilityQuery.scala
@@ -26,9 +26,6 @@ final case class ReachabilityQueryImpl(
   /** Fill in the slots that have an `equals_expression` with their computed values, and check that
     * the values already present agree with what their expressions infer.
     *
-    * Only single-valued slots with a `string` range are inferred; slots with any other range are
-    * left untouched.
-    *
     * @throws InferenceException
     *   if a slot's value contradicts the value inferred for it, or if an expression references a
     *   slot that has no value

--- a/metamodel/src/eu/neverblink/linkml/metamodel/RelationalRoleEnum.scala
+++ b/metamodel/src/eu/neverblink/linkml/metamodel/RelationalRoleEnum.scala
@@ -9,7 +9,7 @@ import eu.neverblink.linkml.runtime.*
   * @see
   *   From schema: https://w3id.org/linkml/meta
   */
-sealed abstract class RelationalRoleEnum
+sealed abstract class RelationalRoleEnum derives Stringify
 
 object RelationalRoleEnum {
 

--- a/metamodel/src/eu/neverblink/linkml/metamodel/SchemaDefinition.scala
+++ b/metamodel/src/eu/neverblink/linkml/metamodel/SchemaDefinition.scala
@@ -121,7 +121,21 @@ final case class SchemaDefinitionImpl(
     structuredAliases: Seq[StructuredAliasImpl] = Seq(),
     todos: Seq[String] = Seq(),
     version: Option[String] = None,
-) extends SchemaDefinition
+) extends SchemaDefinition {
+
+  /** Fill in the slots that have an `equals_expression` with their computed values, and check that
+    * the values already present agree with what their expressions infer.
+    *
+    * Only single-valued slots with a `string` range are inferred; slots with any other range are
+    * left untouched.
+    *
+    * @throws InferenceException
+    *   if a slot's value contradicts the value inferred for it, or if an expression references a
+    *   slot that has no value
+    */
+  def infer(): SchemaDefinitionImpl =
+    this
+}
 
 /** A collection of definitions that make up a schema or a data model.
   *
@@ -317,4 +331,12 @@ abstract class SchemaDefinition extends Element {
     *   From schema: https://w3id.org/linkml/meta
     */
   def version: Option[String]
+
+  /** Fill in the slots that have an `equals_expression`, and check the values already present
+    * against them.
+    *
+    * @throws InferenceException
+    *   if a slot's value contradicts the value inferred for it
+    */
+  def infer(): SchemaDefinition
 }

--- a/metamodel/src/eu/neverblink/linkml/metamodel/SchemaDefinition.scala
+++ b/metamodel/src/eu/neverblink/linkml/metamodel/SchemaDefinition.scala
@@ -126,9 +126,6 @@ final case class SchemaDefinitionImpl(
   /** Fill in the slots that have an `equals_expression` with their computed values, and check that
     * the values already present agree with what their expressions infer.
     *
-    * Only single-valued slots with a `string` range are inferred; slots with any other range are
-    * left untouched.
-    *
     * @throws InferenceException
     *   if a slot's value contradicts the value inferred for it, or if an expression references a
     *   slot that has no value

--- a/metamodel/src/eu/neverblink/linkml/metamodel/SchemaDefinition.scala
+++ b/metamodel/src/eu/neverblink/linkml/metamodel/SchemaDefinition.scala
@@ -123,14 +123,7 @@ final case class SchemaDefinitionImpl(
     version: Option[String] = None,
 ) extends SchemaDefinition {
 
-  /** Fill in the slots that have an `equals_expression` with their computed values, and check that
-    * the values already present agree with what their expressions infer.
-    *
-    * @throws InferenceException
-    *   if a slot's value contradicts the value inferred for it, or if an expression references a
-    *   slot that has no value
-    */
-  def infer(): SchemaDefinitionImpl =
+  override def infer(): SchemaDefinitionImpl =
     this
 }
 
@@ -329,11 +322,12 @@ abstract class SchemaDefinition extends Element {
     */
   def version: Option[String]
 
-  /** Fill in the slots that have an `equals_expression`, and check the values already present
-    * against them.
+  /** Fill in the slots that have an `equals_expression` with their computed values, and check that
+    * the values already present agree with what their expressions infer.
     *
-    * @throws InferenceException
-    *   if a slot's value contradicts the value inferred for it
+    * @throws eu.neverblink.linkml.runtime.InferenceException
+    *   if a slot's value contradicts the value inferred for it, or if an expression references a
+    *   slot that has no value
     */
   def infer(): SchemaDefinition
 }

--- a/metamodel/src/eu/neverblink/linkml/metamodel/Setting.scala
+++ b/metamodel/src/eu/neverblink/linkml/metamodel/Setting.scala
@@ -15,7 +15,21 @@ final case class SettingImpl(
     @value
     @named("setting_value")
     settingValue: String,
-) extends Setting
+) extends Setting {
+
+  /** Fill in the slots that have an `equals_expression` with their computed values, and check that
+    * the values already present agree with what their expressions infer.
+    *
+    * Only single-valued slots with a `string` range are inferred; slots with any other range are
+    * left untouched.
+    *
+    * @throws InferenceException
+    *   if a slot's value contradicts the value inferred for it, or if an expression references a
+    *   slot that has no value
+    */
+  def infer(): SettingImpl =
+    this
+}
 
 /** Assignment of a key to a value
   *
@@ -37,4 +51,12 @@ abstract class Setting {
     *   From schema: https://w3id.org/linkml/meta
     */
   def settingValue: String
+
+  /** Fill in the slots that have an `equals_expression`, and check the values already present
+    * against them.
+    *
+    * @throws InferenceException
+    *   if a slot's value contradicts the value inferred for it
+    */
+  def infer(): Setting
 }

--- a/metamodel/src/eu/neverblink/linkml/metamodel/Setting.scala
+++ b/metamodel/src/eu/neverblink/linkml/metamodel/Setting.scala
@@ -20,9 +20,6 @@ final case class SettingImpl(
   /** Fill in the slots that have an `equals_expression` with their computed values, and check that
     * the values already present agree with what their expressions infer.
     *
-    * Only single-valued slots with a `string` range are inferred; slots with any other range are
-    * left untouched.
-    *
     * @throws InferenceException
     *   if a slot's value contradicts the value inferred for it, or if an expression references a
     *   slot that has no value

--- a/metamodel/src/eu/neverblink/linkml/metamodel/Setting.scala
+++ b/metamodel/src/eu/neverblink/linkml/metamodel/Setting.scala
@@ -17,14 +17,7 @@ final case class SettingImpl(
     settingValue: String,
 ) extends Setting {
 
-  /** Fill in the slots that have an `equals_expression` with their computed values, and check that
-    * the values already present agree with what their expressions infer.
-    *
-    * @throws InferenceException
-    *   if a slot's value contradicts the value inferred for it, or if an expression references a
-    *   slot that has no value
-    */
-  def infer(): SettingImpl =
+  override def infer(): SettingImpl =
     this
 }
 
@@ -49,11 +42,12 @@ abstract class Setting {
     */
   def settingValue: String
 
-  /** Fill in the slots that have an `equals_expression`, and check the values already present
-    * against them.
+  /** Fill in the slots that have an `equals_expression` with their computed values, and check that
+    * the values already present agree with what their expressions infer.
     *
-    * @throws InferenceException
-    *   if a slot's value contradicts the value inferred for it
+    * @throws eu.neverblink.linkml.runtime.InferenceException
+    *   if a slot's value contradicts the value inferred for it, or if an expression references a
+    *   slot that has no value
     */
   def infer(): Setting
 }

--- a/metamodel/src/eu/neverblink/linkml/metamodel/SlotDefinition.scala
+++ b/metamodel/src/eu/neverblink/linkml/metamodel/SlotDefinition.scala
@@ -407,15 +407,7 @@ final case class SlotDefinitionImpl(
         combineOption(this.structuredPattern, other.structuredPattern, combineFallback),
       valuePresence = combineOption(this.valuePresence, other.valuePresence, combineFallback),
     )
-
-  /** Fill in the slots that have an `equals_expression` with their computed values, and check that
-    * the values already present agree with what their expressions infer.
-    *
-    * @throws InferenceException
-    *   if a slot's value contradicts the value inferred for it, or if an expression references a
-    *   slot that has no value
-    */
-  def infer(): SlotDefinitionImpl =
+  override def infer(): SlotDefinitionImpl =
     this
 }
 
@@ -859,11 +851,12 @@ abstract class SlotDefinition extends Definition, SlotExpression {
     */
   def usageSlotName: Option[String]
 
-  /** Fill in the slots that have an `equals_expression`, and check the values already present
-    * against them.
+  /** Fill in the slots that have an `equals_expression` with their computed values, and check that
+    * the values already present agree with what their expressions infer.
     *
-    * @throws InferenceException
-    *   if a slot's value contradicts the value inferred for it
+    * @throws eu.neverblink.linkml.runtime.InferenceException
+    *   if a slot's value contradicts the value inferred for it, or if an expression references a
+    *   slot that has no value
     */
   def infer(): SlotDefinition
 }

--- a/metamodel/src/eu/neverblink/linkml/metamodel/SlotDefinition.scala
+++ b/metamodel/src/eu/neverblink/linkml/metamodel/SlotDefinition.scala
@@ -411,9 +411,6 @@ final case class SlotDefinitionImpl(
   /** Fill in the slots that have an `equals_expression` with their computed values, and check that
     * the values already present agree with what their expressions infer.
     *
-    * Only single-valued slots with a `string` range are inferred; slots with any other range are
-    * left untouched.
-    *
     * @throws InferenceException
     *   if a slot's value contradicts the value inferred for it, or if an expression references a
     *   slot that has no value

--- a/metamodel/src/eu/neverblink/linkml/metamodel/SlotDefinition.scala
+++ b/metamodel/src/eu/neverblink/linkml/metamodel/SlotDefinition.scala
@@ -407,6 +407,19 @@ final case class SlotDefinitionImpl(
         combineOption(this.structuredPattern, other.structuredPattern, combineFallback),
       valuePresence = combineOption(this.valuePresence, other.valuePresence, combineFallback),
     )
+
+  /** Fill in the slots that have an `equals_expression` with their computed values, and check that
+    * the values already present agree with what their expressions infer.
+    *
+    * Only single-valued slots with a `string` range are inferred; slots with any other range are
+    * left untouched.
+    *
+    * @throws InferenceException
+    *   if a slot's value contradicts the value inferred for it, or if an expression references a
+    *   slot that has no value
+    */
+  def infer(): SlotDefinitionImpl =
+    this
 }
 
 /** An element that describes how instances are related to other instances
@@ -848,4 +861,12 @@ abstract class SlotDefinition extends Definition, SlotExpression {
     *   From schema: https://w3id.org/linkml/meta
     */
   def usageSlotName: Option[String]
+
+  /** Fill in the slots that have an `equals_expression`, and check the values already present
+    * against them.
+    *
+    * @throws InferenceException
+    *   if a slot's value contradicts the value inferred for it
+    */
+  def infer(): SlotDefinition
 }

--- a/metamodel/src/eu/neverblink/linkml/metamodel/SlotExpression.scala
+++ b/metamodel/src/eu/neverblink/linkml/metamodel/SlotExpression.scala
@@ -309,4 +309,12 @@ trait SlotExpression extends Expression {
     *   a value to be present
     */
   def valuePresence: Option[PresenceEnum]
+
+  /** Fill in the slots that have an `equals_expression`, and check the values already present
+    * against them.
+    *
+    * @throws InferenceException
+    *   if a slot's value contradicts the value inferred for it
+    */
+  def infer(): SlotExpression
 }

--- a/metamodel/src/eu/neverblink/linkml/metamodel/SlotExpression.scala
+++ b/metamodel/src/eu/neverblink/linkml/metamodel/SlotExpression.scala
@@ -310,11 +310,12 @@ trait SlotExpression extends Expression {
     */
   def valuePresence: Option[PresenceEnum]
 
-  /** Fill in the slots that have an `equals_expression`, and check the values already present
-    * against them.
+  /** Fill in the slots that have an `equals_expression` with their computed values, and check that
+    * the values already present agree with what their expressions infer.
     *
-    * @throws InferenceException
-    *   if a slot's value contradicts the value inferred for it
+    * @throws eu.neverblink.linkml.runtime.InferenceException
+    *   if a slot's value contradicts the value inferred for it, or if an expression references a
+    *   slot that has no value
     */
   def infer(): SlotExpression
 }

--- a/metamodel/src/eu/neverblink/linkml/metamodel/StructuredAlias.scala
+++ b/metamodel/src/eu/neverblink/linkml/metamodel/StructuredAlias.scala
@@ -71,7 +71,21 @@ final case class StructuredAliasImpl(
     @named("structured_aliases")
     structuredAliases: Seq[StructuredAliasImpl] = Seq(),
     todos: Seq[String] = Seq(),
-) extends StructuredAlias
+) extends StructuredAlias {
+
+  /** Fill in the slots that have an `equals_expression` with their computed values, and check that
+    * the values already present agree with what their expressions infer.
+    *
+    * Only single-valued slots with a `string` range are inferred; slots with any other range are
+    * left untouched.
+    *
+    * @throws InferenceException
+    *   if a slot's value contradicts the value inferred for it, or if an expression references a
+    *   slot that has no value
+    */
+  def infer(): StructuredAliasImpl =
+    this
+}
 
 /** Object that contains meta data about a synonym or alias including where it came from (source)
   * and its scope (narrow, broad, etc.)
@@ -115,4 +129,12 @@ abstract class StructuredAlias extends Expression, Extensible, Annotatable, Comm
     *   From schema: https://w3id.org/linkml/meta
     */
   def literalForm: String
+
+  /** Fill in the slots that have an `equals_expression`, and check the values already present
+    * against them.
+    *
+    * @throws InferenceException
+    *   if a slot's value contradicts the value inferred for it
+    */
+  def infer(): StructuredAlias
 }

--- a/metamodel/src/eu/neverblink/linkml/metamodel/StructuredAlias.scala
+++ b/metamodel/src/eu/neverblink/linkml/metamodel/StructuredAlias.scala
@@ -76,9 +76,6 @@ final case class StructuredAliasImpl(
   /** Fill in the slots that have an `equals_expression` with their computed values, and check that
     * the values already present agree with what their expressions infer.
     *
-    * Only single-valued slots with a `string` range are inferred; slots with any other range are
-    * left untouched.
-    *
     * @throws InferenceException
     *   if a slot's value contradicts the value inferred for it, or if an expression references a
     *   slot that has no value

--- a/metamodel/src/eu/neverblink/linkml/metamodel/StructuredAlias.scala
+++ b/metamodel/src/eu/neverblink/linkml/metamodel/StructuredAlias.scala
@@ -73,14 +73,7 @@ final case class StructuredAliasImpl(
     todos: Seq[String] = Seq(),
 ) extends StructuredAlias {
 
-  /** Fill in the slots that have an `equals_expression` with their computed values, and check that
-    * the values already present agree with what their expressions infer.
-    *
-    * @throws InferenceException
-    *   if a slot's value contradicts the value inferred for it, or if an expression references a
-    *   slot that has no value
-    */
-  def infer(): StructuredAliasImpl =
+  override def infer(): StructuredAliasImpl =
     this
 }
 
@@ -127,11 +120,12 @@ abstract class StructuredAlias extends Expression, Extensible, Annotatable, Comm
     */
   def literalForm: String
 
-  /** Fill in the slots that have an `equals_expression`, and check the values already present
-    * against them.
+  /** Fill in the slots that have an `equals_expression` with their computed values, and check that
+    * the values already present agree with what their expressions infer.
     *
-    * @throws InferenceException
-    *   if a slot's value contradicts the value inferred for it
+    * @throws eu.neverblink.linkml.runtime.InferenceException
+    *   if a slot's value contradicts the value inferred for it, or if an expression references a
+    *   slot that has no value
     */
   def infer(): StructuredAlias
 }

--- a/metamodel/src/eu/neverblink/linkml/metamodel/SubsetDefinition.scala
+++ b/metamodel/src/eu/neverblink/linkml/metamodel/SubsetDefinition.scala
@@ -85,9 +85,6 @@ final case class SubsetDefinitionImpl(
   /** Fill in the slots that have an `equals_expression` with their computed values, and check that
     * the values already present agree with what their expressions infer.
     *
-    * Only single-valued slots with a `string` range are inferred; slots with any other range are
-    * left untouched.
-    *
     * @throws InferenceException
     *   if a slot's value contradicts the value inferred for it, or if an expression references a
     *   slot that has no value

--- a/metamodel/src/eu/neverblink/linkml/metamodel/SubsetDefinition.scala
+++ b/metamodel/src/eu/neverblink/linkml/metamodel/SubsetDefinition.scala
@@ -80,11 +80,34 @@ final case class SubsetDefinitionImpl(
     @named("structured_aliases")
     structuredAliases: Seq[StructuredAliasImpl] = Seq(),
     todos: Seq[String] = Seq(),
-) extends SubsetDefinition
+) extends SubsetDefinition {
+
+  /** Fill in the slots that have an `equals_expression` with their computed values, and check that
+    * the values already present agree with what their expressions infer.
+    *
+    * Only single-valued slots with a `string` range are inferred; slots with any other range are
+    * left untouched.
+    *
+    * @throws InferenceException
+    *   if a slot's value contradicts the value inferred for it, or if an expression references a
+    *   slot that has no value
+    */
+  def infer(): SubsetDefinitionImpl =
+    this
+}
 
 /** An element that can be used to group other metamodel elements
   *
   * @see
   *   From schema: https://w3id.org/linkml/meta
   */
-abstract class SubsetDefinition extends Element {}
+abstract class SubsetDefinition extends Element {
+
+  /** Fill in the slots that have an `equals_expression`, and check the values already present
+    * against them.
+    *
+    * @throws InferenceException
+    *   if a slot's value contradicts the value inferred for it
+    */
+  def infer(): SubsetDefinition
+}

--- a/metamodel/src/eu/neverblink/linkml/metamodel/SubsetDefinition.scala
+++ b/metamodel/src/eu/neverblink/linkml/metamodel/SubsetDefinition.scala
@@ -82,14 +82,7 @@ final case class SubsetDefinitionImpl(
     todos: Seq[String] = Seq(),
 ) extends SubsetDefinition {
 
-  /** Fill in the slots that have an `equals_expression` with their computed values, and check that
-    * the values already present agree with what their expressions infer.
-    *
-    * @throws InferenceException
-    *   if a slot's value contradicts the value inferred for it, or if an expression references a
-    *   slot that has no value
-    */
-  def infer(): SubsetDefinitionImpl =
+  override def infer(): SubsetDefinitionImpl =
     this
 }
 
@@ -100,11 +93,12 @@ final case class SubsetDefinitionImpl(
   */
 abstract class SubsetDefinition extends Element {
 
-  /** Fill in the slots that have an `equals_expression`, and check the values already present
-    * against them.
+  /** Fill in the slots that have an `equals_expression` with their computed values, and check that
+    * the values already present agree with what their expressions infer.
     *
-    * @throws InferenceException
-    *   if a slot's value contradicts the value inferred for it
+    * @throws eu.neverblink.linkml.runtime.InferenceException
+    *   if a slot's value contradicts the value inferred for it, or if an expression references a
+    *   slot that has no value
     */
   def infer(): SubsetDefinition
 }

--- a/metamodel/src/eu/neverblink/linkml/metamodel/TypeDefinition.scala
+++ b/metamodel/src/eu/neverblink/linkml/metamodel/TypeDefinition.scala
@@ -111,7 +111,21 @@ final case class TypeDefinitionImpl(
     @named("union_of")
     unionOf: Seq[Reference[TypeDefinition]] = Seq(),
     unit: Option[UnitOfMeasureImpl] = None,
-) extends TypeDefinition
+) extends TypeDefinition {
+
+  /** Fill in the slots that have an `equals_expression` with their computed values, and check that
+    * the values already present agree with what their expressions infer.
+    *
+    * Only single-valued slots with a `string` range are inferred; slots with any other range are
+    * left untouched.
+    *
+    * @throws InferenceException
+    *   if a slot's value contradicts the value inferred for it, or if an expression references a
+    *   slot that has no value
+    */
+  def infer(): TypeDefinitionImpl =
+    this
+}
 
 /** An element that whose instances are atomic scalar values that can be mapped to primitive types
   *
@@ -172,4 +186,12 @@ abstract class TypeDefinition extends Element, TypeExpression {
     *   This only applies in the OWL generation
     */
   def unionOf: Seq[Reference[TypeDefinition]]
+
+  /** Fill in the slots that have an `equals_expression`, and check the values already present
+    * against them.
+    *
+    * @throws InferenceException
+    *   if a slot's value contradicts the value inferred for it
+    */
+  def infer(): TypeDefinition
 }

--- a/metamodel/src/eu/neverblink/linkml/metamodel/TypeDefinition.scala
+++ b/metamodel/src/eu/neverblink/linkml/metamodel/TypeDefinition.scala
@@ -116,9 +116,6 @@ final case class TypeDefinitionImpl(
   /** Fill in the slots that have an `equals_expression` with their computed values, and check that
     * the values already present agree with what their expressions infer.
     *
-    * Only single-valued slots with a `string` range are inferred; slots with any other range are
-    * left untouched.
-    *
     * @throws InferenceException
     *   if a slot's value contradicts the value inferred for it, or if an expression references a
     *   slot that has no value

--- a/metamodel/src/eu/neverblink/linkml/metamodel/TypeDefinition.scala
+++ b/metamodel/src/eu/neverblink/linkml/metamodel/TypeDefinition.scala
@@ -113,14 +113,7 @@ final case class TypeDefinitionImpl(
     unit: Option[UnitOfMeasureImpl] = None,
 ) extends TypeDefinition {
 
-  /** Fill in the slots that have an `equals_expression` with their computed values, and check that
-    * the values already present agree with what their expressions infer.
-    *
-    * @throws InferenceException
-    *   if a slot's value contradicts the value inferred for it, or if an expression references a
-    *   slot that has no value
-    */
-  def infer(): TypeDefinitionImpl =
+  override def infer(): TypeDefinitionImpl =
     this
 }
 
@@ -184,11 +177,12 @@ abstract class TypeDefinition extends Element, TypeExpression {
     */
   def unionOf: Seq[Reference[TypeDefinition]]
 
-  /** Fill in the slots that have an `equals_expression`, and check the values already present
-    * against them.
+  /** Fill in the slots that have an `equals_expression` with their computed values, and check that
+    * the values already present agree with what their expressions infer.
     *
-    * @throws InferenceException
-    *   if a slot's value contradicts the value inferred for it
+    * @throws eu.neverblink.linkml.runtime.InferenceException
+    *   if a slot's value contradicts the value inferred for it, or if an expression references a
+    *   slot that has no value
     */
   def infer(): TypeDefinition
 }

--- a/metamodel/src/eu/neverblink/linkml/metamodel/TypeExpression.scala
+++ b/metamodel/src/eu/neverblink/linkml/metamodel/TypeExpression.scala
@@ -120,4 +120,12 @@ trait TypeExpression extends Expression {
     *   From schema: https://w3id.org/linkml/units
     */
   def unit: Option[UnitOfMeasureImpl]
+
+  /** Fill in the slots that have an `equals_expression`, and check the values already present
+    * against them.
+    *
+    * @throws InferenceException
+    *   if a slot's value contradicts the value inferred for it
+    */
+  def infer(): TypeExpression
 }

--- a/metamodel/src/eu/neverblink/linkml/metamodel/TypeExpression.scala
+++ b/metamodel/src/eu/neverblink/linkml/metamodel/TypeExpression.scala
@@ -121,11 +121,12 @@ trait TypeExpression extends Expression {
     */
   def unit: Option[UnitOfMeasureImpl]
 
-  /** Fill in the slots that have an `equals_expression`, and check the values already present
-    * against them.
+  /** Fill in the slots that have an `equals_expression` with their computed values, and check that
+    * the values already present agree with what their expressions infer.
     *
-    * @throws InferenceException
-    *   if a slot's value contradicts the value inferred for it
+    * @throws eu.neverblink.linkml.runtime.InferenceException
+    *   if a slot's value contradicts the value inferred for it, or if an expression references a
+    *   slot that has no value
     */
   def infer(): TypeExpression
 }

--- a/metamodel/src/eu/neverblink/linkml/metamodel/TypeMapping.scala
+++ b/metamodel/src/eu/neverblink/linkml/metamodel/TypeMapping.scala
@@ -74,14 +74,7 @@ final case class TypeMappingImpl(
     todos: Seq[String] = Seq(),
 ) extends TypeMapping {
 
-  /** Fill in the slots that have an `equals_expression` with their computed values, and check that
-    * the values already present agree with what their expressions infer.
-    *
-    * @throws InferenceException
-    *   if a slot's value contradicts the value inferred for it, or if an expression references a
-    *   slot that has no value
-    */
-  def infer(): TypeMappingImpl =
+  override def infer(): TypeMappingImpl =
     this
 }
 
@@ -125,11 +118,12 @@ abstract class TypeMapping extends Extensible, Annotatable, CommonMetadata {
     */
   def stringSerialization: Option[String]
 
-  /** Fill in the slots that have an `equals_expression`, and check the values already present
-    * against them.
+  /** Fill in the slots that have an `equals_expression` with their computed values, and check that
+    * the values already present agree with what their expressions infer.
     *
-    * @throws InferenceException
-    *   if a slot's value contradicts the value inferred for it
+    * @throws eu.neverblink.linkml.runtime.InferenceException
+    *   if a slot's value contradicts the value inferred for it, or if an expression references a
+    *   slot that has no value
     */
   def infer(): TypeMapping
 }

--- a/metamodel/src/eu/neverblink/linkml/metamodel/TypeMapping.scala
+++ b/metamodel/src/eu/neverblink/linkml/metamodel/TypeMapping.scala
@@ -77,9 +77,6 @@ final case class TypeMappingImpl(
   /** Fill in the slots that have an `equals_expression` with their computed values, and check that
     * the values already present agree with what their expressions infer.
     *
-    * Only single-valued slots with a `string` range are inferred; slots with any other range are
-    * left untouched.
-    *
     * @throws InferenceException
     *   if a slot's value contradicts the value inferred for it, or if an expression references a
     *   slot that has no value

--- a/metamodel/src/eu/neverblink/linkml/metamodel/TypeMapping.scala
+++ b/metamodel/src/eu/neverblink/linkml/metamodel/TypeMapping.scala
@@ -72,7 +72,21 @@ final case class TypeMappingImpl(
     @named("structured_aliases")
     structuredAliases: Seq[StructuredAliasImpl] = Seq(),
     todos: Seq[String] = Seq(),
-) extends TypeMapping
+) extends TypeMapping {
+
+  /** Fill in the slots that have an `equals_expression` with their computed values, and check that
+    * the values already present agree with what their expressions infer.
+    *
+    * Only single-valued slots with a `string` range are inferred; slots with any other range are
+    * left untouched.
+    *
+    * @throws InferenceException
+    *   if a slot's value contradicts the value inferred for it, or if an expression references a
+    *   slot that has no value
+    */
+  def infer(): TypeMappingImpl =
+    this
+}
 
 /** Represents how a slot or type can be serialized to a format.
   *
@@ -113,4 +127,12 @@ abstract class TypeMapping extends Extensible, Annotatable, CommonMetadata {
     *   From schema: https://w3id.org/linkml/meta
     */
   def stringSerialization: Option[String]
+
+  /** Fill in the slots that have an `equals_expression`, and check the values already present
+    * against them.
+    *
+    * @throws InferenceException
+    *   if a slot's value contradicts the value inferred for it
+    */
+  def infer(): TypeMapping
 }

--- a/metamodel/src/eu/neverblink/linkml/metamodel/UniqueKey.scala
+++ b/metamodel/src/eu/neverblink/linkml/metamodel/UniqueKey.scala
@@ -78,9 +78,6 @@ final case class UniqueKeyImpl(
   /** Fill in the slots that have an `equals_expression` with their computed values, and check that
     * the values already present agree with what their expressions infer.
     *
-    * Only single-valued slots with a `string` range are inferred; slots with any other range are
-    * left untouched.
-    *
     * @throws InferenceException
     *   if a slot's value contradicts the value inferred for it, or if an expression references a
     *   slot that has no value

--- a/metamodel/src/eu/neverblink/linkml/metamodel/UniqueKey.scala
+++ b/metamodel/src/eu/neverblink/linkml/metamodel/UniqueKey.scala
@@ -75,14 +75,7 @@ final case class UniqueKeyImpl(
     todos: Seq[String] = Seq(),
 ) extends UniqueKey {
 
-  /** Fill in the slots that have an `equals_expression` with their computed values, and check that
-    * the values already present agree with what their expressions infer.
-    *
-    * @throws InferenceException
-    *   if a slot's value contradicts the value inferred for it, or if an expression references a
-    *   slot that has no value
-    */
-  def infer(): UniqueKeyImpl =
+  override def infer(): UniqueKeyImpl =
     this
 }
 
@@ -117,11 +110,12 @@ abstract class UniqueKey extends Extensible, Annotatable, CommonMetadata {
     */
   def considerNullsInequal: Boolean
 
-  /** Fill in the slots that have an `equals_expression`, and check the values already present
-    * against them.
+  /** Fill in the slots that have an `equals_expression` with their computed values, and check that
+    * the values already present agree with what their expressions infer.
     *
-    * @throws InferenceException
-    *   if a slot's value contradicts the value inferred for it
+    * @throws eu.neverblink.linkml.runtime.InferenceException
+    *   if a slot's value contradicts the value inferred for it, or if an expression references a
+    *   slot that has no value
     */
   def infer(): UniqueKey
 }

--- a/metamodel/src/eu/neverblink/linkml/metamodel/UniqueKey.scala
+++ b/metamodel/src/eu/neverblink/linkml/metamodel/UniqueKey.scala
@@ -73,7 +73,21 @@ final case class UniqueKeyImpl(
     @named("structured_aliases")
     structuredAliases: Seq[StructuredAliasImpl] = Seq(),
     todos: Seq[String] = Seq(),
-) extends UniqueKey
+) extends UniqueKey {
+
+  /** Fill in the slots that have an `equals_expression` with their computed values, and check that
+    * the values already present agree with what their expressions infer.
+    *
+    * Only single-valued slots with a `string` range are inferred; slots with any other range are
+    * left untouched.
+    *
+    * @throws InferenceException
+    *   if a slot's value contradicts the value inferred for it, or if an expression references a
+    *   slot that has no value
+    */
+  def infer(): UniqueKeyImpl =
+    this
+}
 
 /** A collection of slots whose values uniquely identify an instance of a class
   *
@@ -105,4 +119,12 @@ abstract class UniqueKey extends Extensible, Annotatable, CommonMetadata {
     *   From schema: https://w3id.org/linkml/meta
     */
   def considerNullsInequal: Boolean
+
+  /** Fill in the slots that have an `equals_expression`, and check the values already present
+    * against them.
+    *
+    * @throws InferenceException
+    *   if a slot's value contradicts the value inferred for it
+    */
+  def infer(): UniqueKey
 }

--- a/metamodel/src/eu/neverblink/linkml/metamodel/UnitOfMeasure.scala
+++ b/metamodel/src/eu/neverblink/linkml/metamodel/UnitOfMeasure.scala
@@ -21,7 +21,21 @@ final case class UnitOfMeasureImpl(
     symbol: Option[String] = None,
     @named("ucum_code")
     ucumCode: Option[String] = None,
-) extends UnitOfMeasure
+) extends UnitOfMeasure {
+
+  /** Fill in the slots that have an `equals_expression` with their computed values, and check that
+    * the values already present agree with what their expressions infer.
+    *
+    * Only single-valued slots with a `string` range are inferred; slots with any other range are
+    * left untouched.
+    *
+    * @throws InferenceException
+    *   if a slot's value contradicts the value inferred for it, or if an expression references a
+    *   slot that has no value
+    */
+  def infer(): UnitOfMeasureImpl =
+    this
+}
 
 /** A unit of measure, or unit, is a particular quantity value that has been chosen as a scale for
   * measuring other quantities the same kind (more generally of equivalent dimension).
@@ -92,4 +106,12 @@ abstract class UnitOfMeasure {
     *   From schema: https://w3id.org/linkml/units
     */
   def ucumCode: Option[String]
+
+  /** Fill in the slots that have an `equals_expression`, and check the values already present
+    * against them.
+    *
+    * @throws InferenceException
+    *   if a slot's value contradicts the value inferred for it
+    */
+  def infer(): UnitOfMeasure
 }

--- a/metamodel/src/eu/neverblink/linkml/metamodel/UnitOfMeasure.scala
+++ b/metamodel/src/eu/neverblink/linkml/metamodel/UnitOfMeasure.scala
@@ -26,9 +26,6 @@ final case class UnitOfMeasureImpl(
   /** Fill in the slots that have an `equals_expression` with their computed values, and check that
     * the values already present agree with what their expressions infer.
     *
-    * Only single-valued slots with a `string` range are inferred; slots with any other range are
-    * left untouched.
-    *
     * @throws InferenceException
     *   if a slot's value contradicts the value inferred for it, or if an expression references a
     *   slot that has no value

--- a/metamodel/src/eu/neverblink/linkml/metamodel/UnitOfMeasure.scala
+++ b/metamodel/src/eu/neverblink/linkml/metamodel/UnitOfMeasure.scala
@@ -23,14 +23,7 @@ final case class UnitOfMeasureImpl(
     ucumCode: Option[String] = None,
 ) extends UnitOfMeasure {
 
-  /** Fill in the slots that have an `equals_expression` with their computed values, and check that
-    * the values already present agree with what their expressions infer.
-    *
-    * @throws InferenceException
-    *   if a slot's value contradicts the value inferred for it, or if an expression references a
-    *   slot that has no value
-    */
-  def infer(): UnitOfMeasureImpl =
+  override def infer(): UnitOfMeasureImpl =
     this
 }
 
@@ -104,11 +97,12 @@ abstract class UnitOfMeasure {
     */
   def ucumCode: Option[String]
 
-  /** Fill in the slots that have an `equals_expression`, and check the values already present
-    * against them.
+  /** Fill in the slots that have an `equals_expression` with their computed values, and check that
+    * the values already present agree with what their expressions infer.
     *
-    * @throws InferenceException
-    *   if a slot's value contradicts the value inferred for it
+    * @throws eu.neverblink.linkml.runtime.InferenceException
+    *   if a slot's value contradicts the value inferred for it, or if an expression references a
+    *   slot that has no value
     */
   def infer(): UnitOfMeasure
 }

--- a/runtime/src/eu/neverblink/linkml/runtime/Inference.scala
+++ b/runtime/src/eu/neverblink/linkml/runtime/Inference.scala
@@ -1,0 +1,62 @@
+package eu.neverblink.linkml.runtime
+
+/** Thrown when a slot's value contradicts the value inferred from its `equals_expression`, or when
+  * an expression references a slot that has no value.
+  */
+final class InferenceException(message: String) extends RuntimeException(message)
+
+/** Fill in an optional slot from its `equals_expression`, or check that the value already there
+  * agrees with the inferred one.
+  *
+  * @param slotName
+  *   Name of the slot being inferred, for error messages
+  * @param current
+  *   The slot's current value
+  * @param inferred
+  *   The value computed from the slot's `equals_expression`
+  * @return
+  *   The inferred value if the slot was empty, otherwise its current value
+  */
+def inferOptional[T](slotName: String, current: Option[T], inferred: T): Option[T] =
+  current match {
+    case None => Some(inferred)
+    case Some(value) if value == inferred => current
+    case Some(value) =>
+      throw InferenceException(
+        s"Slot '$slotName' is set to '$value', but its expression infers '$inferred'",
+      )
+  }
+
+/** Check that a required slot's value agrees with its `equals_expression`. A required slot is never
+  * empty, so there is nothing to fill in.
+  *
+  * @param slotName
+  *   Name of the slot being checked, for error messages
+  * @param current
+  *   The slot's current value
+  * @param inferred
+  *   The value computed from the slot's `equals_expression`
+  * @return
+  *   The slot's current value
+  */
+def inferRequired[T](slotName: String, current: T, inferred: T): T =
+  if current == inferred then current
+  else
+    throw InferenceException(
+      s"Slot '$slotName' is set to '$current', but its expression infers '$inferred'",
+    )
+
+/** Read the value of a slot referenced by an `equals_expression`. The referenced slot must have a
+  * value, as there is no sensible way to interpolate an absent one.
+  *
+  * @param slotName
+  *   Name of the referenced slot, for error messages
+  * @param value
+  *   The referenced slot's current value
+  */
+def inferenceInput[T](slotName: String, value: Option[T]): T =
+  value.getOrElse(
+    throw InferenceException(
+      s"Slot '$slotName' is referenced by an expression, but has no value",
+    ),
+  )

--- a/runtime/src/eu/neverblink/linkml/runtime/Stringify.scala
+++ b/runtime/src/eu/neverblink/linkml/runtime/Stringify.scala
@@ -1,0 +1,81 @@
+package eu.neverblink.linkml.runtime
+
+import scala.annotation.implicitNotFound
+import scala.quoted.*
+
+/** How a slot's value is rendered when an `equals_expression` substitutes it into a string.
+  *
+  * Instances are resolved by the compiler against the range's Scala type, so a range with no
+  * instance in scope is a compile error in the generated code. To support a type this module does
+  * not know about, define your own `given` for it.
+  */
+@implicitNotFound(
+  "A value of type ${T} cannot be substituted into an equals_expression, because there is no " +
+    "Stringify[${T}] in scope. Define a `given Stringify[${T}]` to say how it should render.",
+)
+trait Stringify[-T]:
+  def stringify(value: T): String
+
+object Stringify:
+
+  /** What the elements of a multivalued slot are joined with. */
+  val separator: String = ", "
+
+  given Stringify[String] = value => value
+  given Stringify[Boolean] = _.toString
+  given Stringify[Int] = _.toString
+  given Stringify[Float] = _.toString
+  given Stringify[Double] = _.toString
+  given Stringify[BigDecimal] = _.toString
+
+  given Stringify[LinkmlDate] = _.value
+  given Stringify[LinkmlTime] = _.value
+  given Stringify[LinkmlDateTime] = _.value
+
+  /** Covers [[Uri]] and [[Curie]] too – the trait is contravariant. */
+  given Stringify[UriOrCurie] = _.original
+
+  /** Also covers `Unknown`, the fallback for a LinkML type with no `base`. */
+  given Stringify[LinkmlAny] = _.value
+
+  /** A reference renders as the identifier it holds. */
+  given referenceStringify[T]: Stringify[Reference[T]] = _.value
+
+  /** A multivalued slot renders as its elements joined with [[separator]], in document order. */
+  given seqStringify[T](using element: Stringify[T]): Stringify[Seq[T]] =
+    _.map(element.stringify).mkString(separator)
+
+  /** Derive an instance for a LinkML enum, rendering each case as the text it was declared with in
+    * the schema. The text is read from the `@named` annotation the Scala generator emits.
+    *
+    * `T` must be a sealed hierarchy of case objects, which is what the generator emits for a static
+    * enum. Generated enums carry a `derives Stringify` clause, so there is normally no need to call
+    * this by hand.
+    */
+  // `make[T]` is applied explicitly: `Expr` is covariant and `Stringify` contravariant, so
+  // leaving it to inference widens the derived type all the way to `Any`.
+  inline def derived[T]: Stringify[T] = ${ StringifyImpl.make[T] }
+
+  /** Build an instance from the case-to-text mapping recovered by [[derived]]. Public only because
+    * the derived code has to call it.
+    */
+  def fromMapping[T](mapping: Seq[(T, String)]): Stringify[T] =
+    val texts = mapping.toMap
+    value => texts(value)
+
+/** Render `value` as a string, for substitution into an `equals_expression`. */
+def stringify[T](value: T)(using s: Stringify[T]): String = s.stringify(value)
+
+private object StringifyImpl:
+  def make[T: Type](using Quotes): Expr[Stringify[T]] = new StringifyImpl().make[T]
+
+private class StringifyImpl(using Quotes) extends MacroUtils:
+  import quotes.reflect.*
+
+  def make[T: Type]: Expr[Stringify[T]] =
+    val pairs = adtLeafObjects(TypeRepr.of[T].dealias).map { leafTpe =>
+      val text = Expr(enumValueName(leafTpe))
+      val value = enumOrModuleValueRef(leafTpe).asExpr.asInstanceOf[Expr[T]]
+      '{ ($value, $text) }
+    }.toList
+    '{ Stringify.fromMapping(${ Expr.ofList(pairs) }) }

--- a/runtime/test/src/eu/neverblink/linkml/runtime/InferenceSpec.scala
+++ b/runtime/test/src/eu/neverblink/linkml/runtime/InferenceSpec.scala
@@ -1,0 +1,54 @@
+package eu.neverblink.linkml.runtime
+
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
+
+class InferenceSpec extends AnyWordSpec, Matchers {
+
+  "inferOptional" should {
+    "fill in an empty slot" in {
+      inferOptional("slot", None, "inferred") shouldBe Some("inferred")
+    }
+
+    "keep a value that agrees with the inferred one" in {
+      inferOptional("slot", Some("same"), "same") shouldBe Some("same")
+    }
+
+    "throw when the value contradicts the inferred one" in {
+      val error = intercept[InferenceException] {
+        inferOptional("slot", Some("actual"), "inferred")
+      }
+      error.getMessage should include("slot")
+      error.getMessage should include("actual")
+      error.getMessage should include("inferred")
+    }
+  }
+
+  "inferRequired" should {
+    "keep a value that agrees with the inferred one" in {
+      inferRequired("slot", "same", "same") shouldBe "same"
+    }
+
+    "throw when the value contradicts the inferred one" in {
+      val error = intercept[InferenceException] {
+        inferRequired("slot", "actual", "inferred")
+      }
+      error.getMessage should include("slot")
+      error.getMessage should include("actual")
+      error.getMessage should include("inferred")
+    }
+  }
+
+  "inferenceInput" should {
+    "unwrap a present value" in {
+      inferenceInput("slot", Some("value")) shouldBe "value"
+    }
+
+    "throw when the referenced slot has no value" in {
+      val error = intercept[InferenceException] {
+        inferenceInput("slot", None)
+      }
+      error.getMessage should include("slot")
+    }
+  }
+}

--- a/runtime/test/src/eu/neverblink/linkml/runtime/StringifySpec.scala
+++ b/runtime/test/src/eu/neverblink/linkml/runtime/StringifySpec.scala
@@ -1,0 +1,100 @@
+package eu.neverblink.linkml.runtime
+
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
+
+class StringifySpec extends AnyWordSpec, Matchers {
+
+  "stringify" should {
+    "render a string as itself" in {
+      stringify("hello") shouldBe "hello"
+    }
+
+    "render numbers and booleans" in {
+      stringify(42) shouldBe "42"
+      stringify(1.5f) shouldBe "1.5"
+      stringify(1.5d) shouldBe "1.5"
+      stringify(BigDecimal("1.50")) shouldBe "1.50"
+      stringify(true) shouldBe "true"
+    }
+
+    "render dates and times as written" in {
+      stringify(LinkmlDate("2026-08-06")) shouldBe "2026-08-06"
+      stringify(LinkmlTime("12:34:56")) shouldBe "12:34:56"
+      stringify(LinkmlDateTime("2026-08-06T12:34:56")) shouldBe "2026-08-06T12:34:56"
+    }
+
+    "render URIs and CURIEs without resolving prefixes" in {
+      stringify(Uri("https://example.org/thing")) shouldBe "https://example.org/thing"
+      stringify(Curie("ex:thing")) shouldBe "ex:thing"
+    }
+
+    "render a UriOrCurie through the sealed trait" in {
+      val either: UriOrCurie = UriOrCurie("ex:thing")
+      stringify(either) shouldBe "ex:thing"
+    }
+
+    "render a LinkmlAny as its encoded content" in {
+      stringify(LinkmlAny("{a: 1}")) shouldBe "{a: 1}"
+    }
+
+    "render a reference as the identifier it holds" in {
+      stringify(Reference[String]("some-id")) shouldBe "some-id"
+    }
+
+    "join a multivalued slot with ', '" in {
+      stringify(Seq("a", "b", "c")) shouldBe "a, b, c"
+    }
+
+    "render an empty multivalued slot as an empty string" in {
+      stringify(Seq.empty[String]) shouldBe ""
+    }
+
+    "join a multivalued slot of non-strings" in {
+      stringify(Seq(Curie("ex:a"), Curie("ex:b"))) shouldBe "ex:a, ex:b"
+      stringify(Seq(Reference[String]("1"), Reference[String]("2"))) shouldBe "1, 2"
+      stringify(Seq(1, 2, 3)) shouldBe "1, 2, 3"
+    }
+
+    "use a user-supplied instance for an unknown type" in {
+      final case class External(parts: Seq[String])
+      given Stringify[External] = _.parts.mkString("/")
+
+      stringify(External(Seq("a", "b"))) shouldBe "a/b"
+      stringify(Seq(External(Seq("a")), External(Seq("b")))) shouldBe "a, b"
+    }
+
+    "cover subtypes through one instance, since Stringify is contravariant" in {
+      // A `Uri` is served by the `UriOrCurie` instance, with no instance of its own
+      stringify(Uri("urn:x")) shouldBe "urn:x"
+      stringify(Seq(Uri("urn:x"), Curie("ex:y"))) shouldBe "urn:x, ex:y"
+    }
+  }
+
+  "Stringify.derived" should {
+    "read the LinkML text from @named, not the case name" in {
+      stringify(Sealed.Renamed) shouldBe "renamed in the schema"
+      Sealed.Renamed.toString shouldBe "Renamed"
+    }
+
+    "fall back to the case name when there is no @named" in {
+      stringify(Sealed.Plain) shouldBe "Plain"
+    }
+
+    "apply to a singleton case type, and to a sequence of cases" in {
+      // `Sealed.Plain.type`, not `Sealed` – contravariance makes this resolve
+      val one: Sealed.Plain.type = Sealed.Plain
+      stringify(one) shouldBe "Plain"
+      stringify(Seq[Sealed](Sealed.Plain, Sealed.Renamed)) shouldBe
+        "Plain, renamed in the schema"
+    }
+  }
+}
+
+/** Shaped like the enums [[eu.neverblink.linkml.generator.scala.ScalaGenerator]] emits. */
+sealed abstract class Sealed derives Stringify
+
+object Sealed {
+  case object Plain extends Sealed
+  @named("renamed in the schema") case object Renamed extends Sealed
+}

--- a/schemaview/src/eu/neverblink/linkml/schemaview/AttributeView.scala
+++ b/schemaview/src/eu/neverblink/linkml/schemaview/AttributeView.scala
@@ -3,6 +3,8 @@ package eu.neverblink.linkml.schemaview
 import eu.neverblink.linkml.metamodel.*
 import eu.neverblink.linkml.runtime.*
 import eu.neverblink.linkml.schemaview.SubjectType.implicitPrefix
+import eu.neverblink.linkml.schemaview.expression.StringInterpolationExpression
+import fastparse.Parsed
 
 /** ADT bundling a slot with its resolved range, handling different edge cases. Generators should
   * match on the subtypes of this trait when handling a slot.
@@ -12,10 +14,26 @@ sealed trait AttributeView:
     */
   def slotView: SlotView
 
+  /** The class that defines this derived attribute.
+    */
+  def definingClassView: ClassView
+
+  /** Returns the parsed abstract syntax tree of the slot's `equals_expression`, if any. This is
+    * used to generate code that computes the value of this slot from other slots in the same class.
+    *
+    * Currently, only string interpolation expressions are supported. If the slot's
+    * `equals_expression` is not a string interpolation expression, this method will return a
+    * parsing failure.
+    */
+  final def equalsExpression: Option[Parsed[StringInterpolationExpression]] =
+    slotView.slot.equalsExpression.map { expr =>
+      StringInterpolationExpression.parse(expr)(using this)
+    }
+
 /** Slot's range is `linkml:Any` - validator generators should emit an "accept all" schema if
   * possible.
   */
-case class AnyView(slotView: SlotView) extends AttributeView
+final case class AnyView(slotView: SlotView, definingClassView: ClassView) extends AttributeView
 
 /** Slot's range is an inlined class or a reference to a class. Generators for formats without
   * inlining should match on this instead of its subtypes.
@@ -33,8 +51,9 @@ sealed trait ClassAttributeView:
   * @param inlineType
   *   The inline type of this slot/class combination
   */
-case class ClassInlineAttributeView(
+final case class ClassInlineAttributeView(
     slotView: SlotView,
+    definingClassView: ClassView,
     classView: ClassView,
     inlineType: InlineType,
 ) extends AttributeView,
@@ -45,8 +64,9 @@ case class ClassInlineAttributeView(
   * @param identifierView
   *   The [[TypeAttributeView]] slot/type bundle for the class' identifier slot.
   */
-case class ClassReferenceAttributeView(
+final case class ClassReferenceAttributeView(
     slotView: SlotView,
+    definingClassView: ClassView,
     classView: ClassView,
     identifierView: TypeAttributeView,
 ) extends AttributeView,
@@ -55,8 +75,9 @@ case class ClassReferenceAttributeView(
 /** Slot's range is a type. Provides shorthand methods for merging shared slot/type metaslots, such
   * as [[pattern]], [[unit]], and [[implicitPrefix]], as well as [[SubjectType]] computation.
   */
-case class TypeAttributeView(
+final case class TypeAttributeView(
     slotView: SlotView,
+    definingClassView: ClassView,
     typeView: TypeView,
 ) extends AttributeView:
   private val slot: SlotDefinition = slotView.slot
@@ -124,7 +145,8 @@ case class TypeAttributeView(
 
 /** Slot's range is an enum.
   */
-case class EnumAttributeView(
+final case class EnumAttributeView(
     slotView: SlotView,
+    definingClassView: ClassView,
     enumView: EnumView,
 ) extends AttributeView

--- a/schemaview/src/eu/neverblink/linkml/schemaview/ElementView.scala
+++ b/schemaview/src/eu/neverblink/linkml/schemaview/ElementView.scala
@@ -132,7 +132,7 @@ final case class ClassView(cls: ClassDefinition, definingSchema: SchemaDefinitio
   /** The slot/type bundle for the identifier of this class, if it exists */
   lazy val identifierView: Option[TypeAttributeView] = identifier.map(idSlot => {
     idSlot.derivedRange.resolve.get match {
-      case tv: TypeView => TypeAttributeView(idSlot, tv)
+      case tv: TypeView => TypeAttributeView(idSlot, this, tv)
       case x =>
         throw RuntimeException(s"Invalid identifier slot: ${cls.name}.${idSlot.name} -> ${x.name}")
     }
@@ -145,16 +145,17 @@ final case class ClassView(cls: ClassDefinition, definingSchema: SchemaDefinitio
     derivedAttributes.map((k, slot) =>
       k -> (slot.derivedRange.resolve.get match {
         case classView: ClassView =>
-          if classView.isAny then AnyView(slot)
+          if classView.isAny then AnyView(slot, this)
           else if !slot.derivedInlined then
             ClassReferenceAttributeView(
               slot,
+              this,
               classView,
               classView.identifierView.get,
             )
-          else ClassInlineAttributeView(slot, classView, InlineType(slot))
-        case tv: TypeView => TypeAttributeView(slot, tv)
-        case ev: EnumView => EnumAttributeView(slot, ev)
+          else ClassInlineAttributeView(slot, this, classView, InlineType(slot))
+        case tv: TypeView => TypeAttributeView(slot, this, tv)
+        case ev: EnumView => EnumAttributeView(slot, this, ev)
         case x => throw RuntimeException(s"Invalid range: ${cls.name}.${slot.name} -> ${x.name}")
       }),
     )

--- a/schemaview/src/eu/neverblink/linkml/schemaview/expression/StringInterpolationExpression.scala
+++ b/schemaview/src/eu/neverblink/linkml/schemaview/expression/StringInterpolationExpression.scala
@@ -36,7 +36,7 @@ object StringInterpolationExpression:
 
     private def element[$: P]: P[Element] = P(escapedBrace | substitution | literal)
 
-    /** `{{` and `}}` — an escaped single brace. */
+    /** `{{` and `}}` – an escaped single brace. */
     private def escapedBrace[$: P]: P[Literal] =
       P(("{{" | "}}").!).map(s => Literal(s.take(1)))
 

--- a/schemaview/src/eu/neverblink/linkml/schemaview/expression/StringInterpolationExpression.scala
+++ b/schemaview/src/eu/neverblink/linkml/schemaview/expression/StringInterpolationExpression.scala
@@ -1,0 +1,66 @@
+package eu.neverblink.linkml.schemaview.expression
+
+import eu.neverblink.linkml.schemaview.{AttributeView, ClassView, SlotView}
+import fastparse.*
+import fastparse.NoWhitespace.given
+
+/** A parsed Python-style interpolation string, as used by LinkML's `equals_expression`.
+  *
+  * Example: `"Unknown reference to element '{reference_value}'"`
+  *
+  * As in Python, `{{` and `}}` are escapes for literal `{` and `}`.
+  *
+  * TODO LNK-170: when we implement other expression types, we probably should make this extend some
+  * common Expression trait.
+  */
+final case class StringInterpolationExpression(
+    elements: Seq[StringInterpolationExpression.Element],
+)
+
+object StringInterpolationExpression:
+  sealed trait Element
+
+  /** Expands to: literal string `value`. */
+  final case class Literal(value: String) extends Element
+
+  /** Expands to: the value of the slot named `slotName` in the current context. */
+  final case class Substitution(slot: AttributeView) extends Element
+
+  /** Parse an interpolation string into literals and `{slot}` substitutions. */
+  def parse(input: String)(using context: AttributeView): Parsed[StringInterpolationExpression] =
+    fastparse.parse(input, Parser().expression(using _))
+
+  private final class Parser(using context: AttributeView):
+    def expression[$: P]: P[StringInterpolationExpression] =
+      P(element.rep ~ End).map(es => StringInterpolationExpression(mergeLiterals(es)))
+
+    private def element[$: P]: P[Element] = P(escapedBrace | substitution | literal)
+
+    /** `{{` and `}}` — an escaped single brace. */
+    private def escapedBrace[$: P]: P[Literal] =
+      P(("{{" | "}}").!).map(s => Literal(s.take(1)))
+
+    private def substitution[$: P]: P[Substitution] =
+      P("{" ~/ slotName ~ "}").flatMap { name =>
+        context.definingClassView.attributeViews.get(name) match {
+          case Some(value) => Pass(Substitution(value))
+          case None =>
+            Fail(
+              s"Unknown slot name '$name' in context of class " +
+                s"'${context.definingClassView.name}'",
+            )
+        }
+      }
+
+    private def slotName[$: P]: P[String] =
+      P(CharsWhile(_ != '}').!).opaque("a slot name")
+
+    private def literal[$: P]: P[Literal] =
+      P(CharsWhile(c => c != '{' && c != '}').!).map(Literal.apply)
+
+    /** Fold runs of adjacent literals into one, so escapes don't split the surrounding text. */
+    private def mergeLiterals(elements: Seq[Element]): Seq[Element] =
+      elements.foldLeft(Vector.empty[Element]) {
+        case (acc :+ Literal(prev), Literal(next)) => acc :+ Literal(prev + next)
+        case (acc, e) => acc :+ e
+      }

--- a/schemaview/src/eu/neverblink/linkml/schemaview/expression/StringInterpolationExpression.scala
+++ b/schemaview/src/eu/neverblink/linkml/schemaview/expression/StringInterpolationExpression.scala
@@ -1,6 +1,6 @@
 package eu.neverblink.linkml.schemaview.expression
 
-import eu.neverblink.linkml.schemaview.{AttributeView, ClassView, SlotView}
+import eu.neverblink.linkml.schemaview.AttributeView
 import fastparse.*
 import fastparse.NoWhitespace.given
 

--- a/schemaview/src/eu/neverblink/linkml/schemaview/expression/StringInterpolationExpression.scala
+++ b/schemaview/src/eu/neverblink/linkml/schemaview/expression/StringInterpolationExpression.scala
@@ -1,12 +1,21 @@
 package eu.neverblink.linkml.schemaview.expression
 
-import eu.neverblink.linkml.schemaview.AttributeView
+import eu.neverblink.linkml.schemaview.{
+  AttributeView,
+  ClassInlineAttributeView,
+  ClassView,
+  InlineType,
+}
 import fastparse.*
 import fastparse.NoWhitespace.given
+import scala.annotation.tailrec
 
 /** A parsed Python-style interpolation string, as used by LinkML's `equals_expression`.
   *
   * Example: `"Unknown reference to element '{reference_value}'"`
+  *
+  * A substitution may reach into inlined classes with dot notation, as in
+  * `"{address.city}, {address.country.name}"`.
   *
   * As in Python, `{{` and `}}` are escapes for literal `{` and `}`.
   *
@@ -23,10 +32,19 @@ object StringInterpolationExpression:
   /** Expands to: literal string `value`. */
   final case class Literal(value: String) extends Element
 
-  /** Expands to: the value of the slot named `slotName` in the current context. */
-  final case class Substitution(slot: AttributeView) extends Element
+  /** Expands to: the value found by following `path` from the current context's class.
+    *
+    * `path` is never empty. Every element but the last is a single-valued inlined class, which the
+    * path descends into; the last element is the attribute holding the substituted value.
+    */
+  final case class Substitution(path: Seq[AttributeView]) extends Element:
+    /** The attribute holding the substituted value. */
+    def target: AttributeView = path.last
 
-  /** Parse an interpolation string into literals and `{slot}` substitutions. */
+    /** The path as written in the schema, e.g. `address.city`. */
+    def pathString: String = path.map(_.slotView.slot.name).mkString(".")
+
+  /** Parse an interpolation string into literals and `{slot}` / `{slot.path}` substitutions. */
   def parse(input: String)(using context: AttributeView): Parsed[StringInterpolationExpression] =
     fastparse.parse(input, Parser().expression(using _))
 
@@ -41,19 +59,66 @@ object StringInterpolationExpression:
       P(("{{" | "}}").!).map(s => Literal(s.take(1)))
 
     private def substitution[$: P]: P[Substitution] =
-      P("{" ~/ slotName ~ "}").flatMap { name =>
-        context.definingClassView.attributeViews.get(name) match {
-          case Some(value) => Pass(Substitution(value))
-          case None =>
-            Fail(
-              s"Unknown slot name '$name' in context of class " +
-                s"'${context.definingClassView.name}'",
-            )
+      P("{" ~/ slotPath ~ "}").flatMap { path =>
+        resolve(path) match {
+          case Right(views) => Pass(Substitution(views))
+          case Left(error) => Fail(error)
         }
       }
 
-    private def slotName[$: P]: P[String] =
+    /** The raw text between the braces. Segments are split off in [[resolve]] rather than in the
+      * grammar, so that a malformed path is reported as one readable message instead of a character
+      * offset.
+      */
+    private def slotPath[$: P]: P[String] =
       P(CharsWhile(_ != '}').!).opaque("a slot name")
+
+    /** Follow a dotted path from the context's class, descending into inlined classes.
+      *
+      * @return
+      *   the attribute for each segment, or a message explaining where the path went wrong
+      */
+    private def resolve(path: String): Either[String, Seq[AttributeView]] = {
+      val segments = path.split("\\.", -1).toIndexedSeq
+
+      @tailrec
+      def go(
+          name: String,
+          rest: Seq[String],
+          cls: ClassView,
+          acc: Vector[AttributeView],
+      ): Either[String, Seq[AttributeView]] =
+        cls.attributeViews.get(name) match {
+          case None => Left(s"Unknown slot name '$name' in context of class '${cls.name}'")
+          case Some(attribute) if rest.isEmpty => Right(acc :+ attribute)
+          case Some(attribute) =>
+            descend(attribute) match {
+              case Left(error) => Left(error)
+              case Right(next) => go(rest.head, rest.tail, next, acc :+ attribute)
+            }
+        }
+
+      if segments.exists(_.isEmpty) then Left(s"Empty slot name in path '$path'")
+      else go(segments.head, segments.tail, context.definingClassView, Vector.empty)
+    }
+
+    /** The class a path continues into after `attribute`, if it can continue at all. Only a
+      * single-valued inlined class holds exactly one nested object to read a slot from.
+      */
+    private def descend(attribute: AttributeView): Either[String, ClassView] = {
+      val name = attribute.slotView.slot.name
+      attribute match {
+        case ClassInlineAttributeView(_, _, classView, InlineType.plain | InlineType.optional) =>
+          Right(classView)
+        case _: ClassInlineAttributeView =>
+          Left(s"Slot '$name' is a multivalued inlined class, so a path cannot descend into it")
+        case _ =>
+          Left(
+            s"Slot '$name' is not a single-valued inlined class, " +
+              "so a path cannot descend into it",
+          )
+      }
+    }
 
     private def literal[$: P]: P[Literal] =
       P(CharsWhile(c => c != '{' && c != '}').!).map(Literal.apply)

--- a/schemaview/src/eu/neverblink/linkml/schemaview/expression/StringInterpolationExpression.scala
+++ b/schemaview/src/eu/neverblink/linkml/schemaview/expression/StringInterpolationExpression.scala
@@ -21,6 +21,9 @@ import scala.annotation.tailrec
   *
   * TODO LNK-170: when we implement other expression types, we probably should make this extend some
   * common Expression trait.
+  *
+  * TODO LNK-170: consider decoupling this from SchemaView, so that we can parse expressions without
+  * needing a context.
   */
 final case class StringInterpolationExpression(
     elements: Seq[StringInterpolationExpression.Element],

--- a/schemaview/test/src/eu/neverblink/linkml/schemaview/AttributeViewSpec.scala
+++ b/schemaview/test/src/eu/neverblink/linkml/schemaview/AttributeViewSpec.scala
@@ -3,6 +3,7 @@ package eu.neverblink.linkml.schemaview
 import eu.neverblink.linkml.runtime.{Curie, Uri}
 import eu.neverblink.linkml.schemaview.InlineType.plain
 import eu.neverblink.linkml.schemaview.SubjectType.{base, implicitPrefix}
+import eu.neverblink.linkml.schemaview.expression.StringInterpolationExpression.{Literal, Substitution}
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
 
@@ -162,6 +163,47 @@ class AttributeViewSpec extends AnyWordSpec, Matchers {
       c3.attributeViews("united")
         .shouldBeA[TypeAttributeView]
         .equalsString shouldBe Some("blep")
+    }
+
+    val equalsExpressionSchema =
+      """id: urn:test
+        |name: test
+        |imports:
+        |  - linkml:types
+        |classes:
+        |  C4:
+        |    attributes:
+        |      a:
+        |        range: string
+        |        equals_expression: "Hello {b} and {c}. Here are some braces: {{ and }}."
+        |      b:
+        |        range: string
+        |      c:
+        |        range: string
+        |""".stripMargin
+
+    lazy val sv3 = SchemaView.loadSchemaViewFromString(equalsExpressionSchema)
+    lazy val c4 = sv3.classes("C4")
+
+    "parse equals_expression into StringInterpolationExpression" in {
+      val a = c4.attributeViews("a")
+        .shouldBeA[TypeAttributeView]
+      val expr = a.equalsExpression
+        .getOrElse(fail("Expected equals_expression to be defined"))
+      expr.isSuccess shouldBe true
+      expr.get.value.elements shouldBe Seq(
+        Literal("Hello "),
+        Substitution(c4.attributeViews("b")),
+        Literal(" and "),
+        Substitution(c4.attributeViews("c")),
+        Literal(". Here are some braces: { and }."),
+      )
+    }
+
+    "provide None for equals_expression when not defined" in {
+      val b = c4.attributeViews("b")
+        .shouldBeA[TypeAttributeView]
+      b.equalsExpression shouldBe None
     }
   }
 }

--- a/schemaview/test/src/eu/neverblink/linkml/schemaview/AttributeViewSpec.scala
+++ b/schemaview/test/src/eu/neverblink/linkml/schemaview/AttributeViewSpec.scala
@@ -196,9 +196,9 @@ class AttributeViewSpec extends AnyWordSpec, Matchers {
       expr.isSuccess shouldBe true
       expr.get.value.elements shouldBe Seq(
         Literal("Hello "),
-        Substitution(c4.attributeViews("b")),
+        Substitution(Seq(c4.attributeViews("b"))),
         Literal(" and "),
-        Substitution(c4.attributeViews("c")),
+        Substitution(Seq(c4.attributeViews("c"))),
         Literal(". Here are some braces: { and }."),
       )
     }

--- a/schemaview/test/src/eu/neverblink/linkml/schemaview/AttributeViewSpec.scala
+++ b/schemaview/test/src/eu/neverblink/linkml/schemaview/AttributeViewSpec.scala
@@ -3,7 +3,10 @@ package eu.neverblink.linkml.schemaview
 import eu.neverblink.linkml.runtime.{Curie, Uri}
 import eu.neverblink.linkml.schemaview.InlineType.plain
 import eu.neverblink.linkml.schemaview.SubjectType.{base, implicitPrefix}
-import eu.neverblink.linkml.schemaview.expression.StringInterpolationExpression.{Literal, Substitution}
+import eu.neverblink.linkml.schemaview.expression.StringInterpolationExpression.{
+  Literal,
+  Substitution,
+}
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
 

--- a/schemaview/test/src/eu/neverblink/linkml/schemaview/expression/StringInterpolationExpressionSpec.scala
+++ b/schemaview/test/src/eu/neverblink/linkml/schemaview/expression/StringInterpolationExpressionSpec.scala
@@ -1,0 +1,161 @@
+package eu.neverblink.linkml.schemaview.expression
+
+import fastparse.Parsed
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
+import StringInterpolationExpression.{Literal, Substitution}
+import eu.neverblink.linkml.schemaview.{AttributeView, SchemaView}
+
+class StringInterpolationExpressionSpec extends AnyWordSpec, Matchers {
+
+  private val schema = """
+    |id: urn:test
+    |name: test
+    |imports:
+    | - linkml:types
+    |classes:
+    |  C1:
+    |    attributes:
+    |      reference_value:
+    |        range: string
+    |      class:
+    |        range: string
+    |      other:
+    |        range: string
+    |  C2:
+    |    attributes:
+    |      only_in_c2:
+    |        range: string
+  """.stripMargin
+
+  private def parse(
+      input: String,
+  )(using AttributeView): Seq[StringInterpolationExpression.Element] =
+    StringInterpolationExpression.parse(input) match {
+      case Parsed.Success(expr, _) => expr.elements
+      case f: Parsed.Failure => fail(s"Failed to parse '$input': ${f.trace().longAggregateMsg}")
+    }
+
+  private def parseError(input: String)(using AttributeView): String =
+    StringInterpolationExpression.parse(input) match {
+      case Parsed.Success(expr, _) => fail(s"Expected '$input' to fail, but got ${expr.elements}")
+      case f: Parsed.Failure => f.trace().longAggregateMsg
+    }
+
+  "StringInterpolationExpression" should {
+    given sv: SchemaView = SchemaView.loadSchemaViewFromString(schema)
+    given context: AttributeView = sv.classes("C1").attributeViews("reference_value")
+    val attrReferenceValue = sv.classes("C1").attributeViews("reference_value")
+    val attrClass = sv.classes("C1").attributeViews("class")
+    val attrOther = sv.classes("C1").attributeViews("other")
+
+    "parse a string with no substitutions" in {
+      parse("No 'default_range' is defined in the schema") shouldBe
+        Seq(Literal("No 'default_range' is defined in the schema"))
+    }
+
+    "parse a substitution in the middle of a string" in {
+      parse("Unknown reference to element '{reference_value}'") shouldBe Seq(
+        Literal("Unknown reference to element '"),
+        Substitution(attrReferenceValue),
+        Literal("'"),
+      )
+    }
+
+    "parse a substitution at the start of a string" in {
+      parse("{other} is missing from the schema.") shouldBe Seq(
+        Substitution(attrOther),
+        Literal(" is missing from the schema."),
+      )
+    }
+
+    "parse multiple substitutions" in {
+      parse("{reference_value}-{other}") shouldBe Seq(
+        Substitution(attrReferenceValue),
+        Literal("-"),
+        Substitution(attrOther),
+      )
+    }
+
+    "parse adjacent substitutions" in {
+      parse("{reference_value}{other}{other}") shouldBe Seq(
+        Substitution(attrReferenceValue),
+        Substitution(attrOther),
+        Substitution(attrOther),
+      )
+    }
+
+    "parse an empty string" in {
+      parse("") shouldBe Seq()
+    }
+
+    "unescape doubled braces" in {
+      parse("{{a}}") shouldBe Seq(Literal("{a}"))
+    }
+
+    "merge escapes into the surrounding literal" in {
+      parse("a {{b}} {class} d") shouldBe Seq(
+        Literal("a {b} "),
+        Substitution(attrClass),
+        Literal(" d"),
+      )
+    }
+
+    "parse a string that is only a substitution" in {
+      parse("{reference_value}") shouldBe Seq(Substitution(attrReferenceValue))
+    }
+
+    "unescape braces around a substitution" in {
+      parse("{{{reference_value}}}") shouldBe Seq(
+        Literal("{"),
+        Substitution(attrReferenceValue),
+        Literal("}"),
+      )
+    }
+
+    "unescape a brace on its own" in {
+      parse("{{") shouldBe Seq(Literal("{"))
+      parse("}}") shouldBe Seq(Literal("}"))
+    }
+
+    "resolve slots against the defining class of the context" in {
+      given c2: AttributeView = sv.classes("C2").attributeViews("only_in_c2")
+      parse("{only_in_c2}") shouldBe Seq(Substitution(c2))
+    }
+
+    "reject a slot that belongs to a different class" in {
+      given c2: AttributeView = sv.classes("C2").attributeViews("only_in_c2")
+      parseError("{reference_value}") should include("reference_value")
+    }
+
+    "reject an unknown slot name, naming the slot and the class" in {
+      val error = parseError("Hello {nope}")
+      error should include("nope")
+      error should include("C1")
+    }
+
+    "report the first unknown slot when there are several" in {
+      parseError("{nope1} and {nope2}") should include("nope1")
+    }
+
+    "reject a slot name that is not trimmed" in {
+      parseError("{ reference_value }") should include("reference_value")
+    }
+
+    "reject a lone closing brace" in {
+      val error = parseError("Hello }")
+      error should include("end-of-input")
+      error should include("found \"}\"")
+    }
+
+    "reject an unclosed substitution" in {
+      // The cut in `substitution` keeps the error inside it, rather than reporting it as
+      // "expected end-of-input" at the opening brace.
+      parseError("Hello {name") should include("substitution:1:7 / \"}\":1:12")
+    }
+
+    "reject an empty substitution" in {
+      parseError("Hello {}") should include("substitution:1:7 / a slot name:1:8")
+    }
+  }
+}

--- a/schemaview/test/src/eu/neverblink/linkml/schemaview/expression/StringInterpolationExpressionSpec.scala
+++ b/schemaview/test/src/eu/neverblink/linkml/schemaview/expression/StringInterpolationExpressionSpec.scala
@@ -22,10 +22,35 @@ class StringInterpolationExpressionSpec extends AnyWordSpec, Matchers {
     |        range: string
     |      other:
     |        range: string
+    |      nested:
+    |        range: Nested
+    |        inlined: true
+    |      nested_many:
+    |        range: Nested
+    |        inlined: true
+    |        multivalued: true
+    |      nested_ref:
+    |        range: Identified
     |  C2:
     |    attributes:
     |      only_in_c2:
     |        range: string
+    |  Nested:
+    |    attributes:
+    |      leaf:
+    |        range: string
+    |      deeper:
+    |        range: Deeper
+    |        inlined: true
+    |  Deeper:
+    |    attributes:
+    |      bottom:
+    |        range: string
+    |  Identified:
+    |    attributes:
+    |      id:
+    |        range: string
+    |        identifier: true
   """.stripMargin
 
   private def parse(
@@ -48,6 +73,10 @@ class StringInterpolationExpressionSpec extends AnyWordSpec, Matchers {
     val attrReferenceValue = sv.classes("C1").attributeViews("reference_value")
     val attrClass = sv.classes("C1").attributeViews("class")
     val attrOther = sv.classes("C1").attributeViews("other")
+    val attrNested = sv.classes("C1").attributeViews("nested")
+    val attrLeaf = sv.classes("Nested").attributeViews("leaf")
+    val attrDeeper = sv.classes("Nested").attributeViews("deeper")
+    val attrBottom = sv.classes("Deeper").attributeViews("bottom")
 
     "parse a string with no substitutions" in {
       parse("No 'default_range' is defined in the schema") shouldBe
@@ -57,31 +86,31 @@ class StringInterpolationExpressionSpec extends AnyWordSpec, Matchers {
     "parse a substitution in the middle of a string" in {
       parse("Unknown reference to element '{reference_value}'") shouldBe Seq(
         Literal("Unknown reference to element '"),
-        Substitution(attrReferenceValue),
+        Substitution(Seq(attrReferenceValue)),
         Literal("'"),
       )
     }
 
     "parse a substitution at the start of a string" in {
       parse("{other} is missing from the schema.") shouldBe Seq(
-        Substitution(attrOther),
+        Substitution(Seq(attrOther)),
         Literal(" is missing from the schema."),
       )
     }
 
     "parse multiple substitutions" in {
       parse("{reference_value}-{other}") shouldBe Seq(
-        Substitution(attrReferenceValue),
+        Substitution(Seq(attrReferenceValue)),
         Literal("-"),
-        Substitution(attrOther),
+        Substitution(Seq(attrOther)),
       )
     }
 
     "parse adjacent substitutions" in {
       parse("{reference_value}{other}{other}") shouldBe Seq(
-        Substitution(attrReferenceValue),
-        Substitution(attrOther),
-        Substitution(attrOther),
+        Substitution(Seq(attrReferenceValue)),
+        Substitution(Seq(attrOther)),
+        Substitution(Seq(attrOther)),
       )
     }
 
@@ -96,19 +125,19 @@ class StringInterpolationExpressionSpec extends AnyWordSpec, Matchers {
     "merge escapes into the surrounding literal" in {
       parse("a {{b}} {class} d") shouldBe Seq(
         Literal("a {b} "),
-        Substitution(attrClass),
+        Substitution(Seq(attrClass)),
         Literal(" d"),
       )
     }
 
     "parse a string that is only a substitution" in {
-      parse("{reference_value}") shouldBe Seq(Substitution(attrReferenceValue))
+      parse("{reference_value}") shouldBe Seq(Substitution(Seq(attrReferenceValue)))
     }
 
     "unescape braces around a substitution" in {
       parse("{{{reference_value}}}") shouldBe Seq(
         Literal("{"),
-        Substitution(attrReferenceValue),
+        Substitution(Seq(attrReferenceValue)),
         Literal("}"),
       )
     }
@@ -120,7 +149,7 @@ class StringInterpolationExpressionSpec extends AnyWordSpec, Matchers {
 
     "resolve slots against the defining class of the context" in {
       given c2: AttributeView = sv.classes("C2").attributeViews("only_in_c2")
-      parse("{only_in_c2}") shouldBe Seq(Substitution(c2))
+      parse("{only_in_c2}") shouldBe Seq(Substitution(Seq(c2)))
     }
 
     "reject a slot that belongs to a different class" in {
@@ -156,6 +185,49 @@ class StringInterpolationExpressionSpec extends AnyWordSpec, Matchers {
 
     "reject an empty substitution" in {
       parseError("Hello {}") should include("substitution:1:7 / a slot name:1:8")
+    }
+
+    "resolve a path into an inlined class" in {
+      parse("{nested.leaf}") shouldBe Seq(Substitution(Seq(attrNested, attrLeaf)))
+    }
+
+    "resolve a path several levels deep" in {
+      parse("in {nested.deeper.bottom}!") shouldBe Seq(
+        Literal("in "),
+        Substitution(Seq(attrNested, attrDeeper, attrBottom)),
+        Literal("!"),
+      )
+    }
+
+    "expose the path as written in the schema" in {
+      parse("{nested.deeper.bottom}").head
+        .asInstanceOf[Substitution].pathString shouldBe "nested.deeper.bottom"
+    }
+
+    "reject an unknown slot in a nested class, naming the nested class" in {
+      val error = parseError("{nested.nope}")
+      error should include("nope")
+      error should include("Nested")
+    }
+
+    "reject descending into a multivalued inlined class" in {
+      val error = parseError("{nested_many.leaf}")
+      error should include("nested_many")
+      error should include("multivalued")
+    }
+
+    "reject descending into a class reference" in {
+      parseError("{nested_ref.id}") should include("nested_ref")
+    }
+
+    "reject descending into a plain type" in {
+      parseError("{reference_value.leaf}") should include("reference_value")
+    }
+
+    "reject a path with an empty segment" in {
+      parseError("{nested..leaf}") should include("nested..leaf")
+      parseError("{.leaf}") should include(".leaf")
+      parseError("{nested.}") should include("nested.")
     }
   }
 }

--- a/tests/resources/models/equalsExpression/model.yaml
+++ b/tests/resources/models/equalsExpression/model.yaml
@@ -1,0 +1,41 @@
+id: https://neverblink.eu/linkml/tests/equalsExpression/
+name: equals_expression
+
+imports:
+  - linkml:types
+
+classes:
+  SomeClass:
+    tree_root: true
+    attributes:
+      reference_value:
+        range: string
+      optional_message:
+        range: string
+        equals_expression: "Unknown reference to element '{reference_value}'"
+      required_message:
+        range: string
+        required: true
+        equals_expression: "ref is {reference_value}"
+      required_source:
+        range: string
+        required: true
+      from_required:
+        range: string
+        equals_expression: "{required_source} / {required_source}"
+      literal_only:
+        range: string
+        equals_expression: "no substitutions here"
+      with_escapes:
+        range: string
+        equals_expression: "braces {{like this}} and a \"quote\""
+      no_expression:
+        range: string
+      # Out of scope: not a single-valued string, so the expression must be ignored
+      multivalued_ignored:
+        range: string
+        multivalued: true
+        equals_expression: "{reference_value}"
+      integer_ignored:
+        range: integer
+        equals_expression: "{reference_value}"

--- a/tests/resources/models/equalsExpression/model.yaml
+++ b/tests/resources/models/equalsExpression/model.yaml
@@ -4,6 +4,12 @@ name: equals_expression
 imports:
   - linkml:types
 
+enums:
+  StatusEnum:
+    permissible_values:
+      in progress:
+      done:
+
 classes:
   SomeClass:
     tree_root: true
@@ -45,6 +51,57 @@ classes:
       from_required_nested:
         range: string
         equals_expression: "{required_nested.required_leaf} at {required_nested.deeper.bottom}"
+      # Non-string ranges are stringified automatically
+      count:
+        range: integer
+      ratio:
+        range: double
+      flag:
+        range: boolean
+      created:
+        range: date
+      from_numbers:
+        range: string
+        equals_expression: "{count} items, ratio {ratio}, flag {flag}, on {created}"
+      # URIs and CURIEs stringify to the value as written, with no prefix resolution
+      homepage:
+        range: uri
+        required: true
+      term:
+        range: curie
+      either:
+        range: uriorcurie
+      from_uris:
+        range: string
+        equals_expression: "{homepage} | {term} | {either}"
+      # Multivalued slots are joined with ", "
+      tags:
+        range: string
+        multivalued: true
+      codes:
+        range: curie
+        multivalued: true
+      from_multivalued:
+        range: string
+        equals_expression: "tags: [{tags}], codes: [{codes}]"
+      # A reference stringifies to the identifier it holds
+      target:
+        range: Identified
+      targets:
+        range: Identified
+        multivalued: true
+      from_references:
+        range: string
+        equals_expression: "{target} <- {targets}"
+      # Enums stringify to their LinkML text, which is not the generated case name
+      status:
+        range: StatusEnum
+      statuses:
+        range: StatusEnum
+        multivalued: true
+      from_enum:
+        range: string
+        equals_expression: "{status} of ({statuses})"
       # Out of scope: not a single-valued string, so the expression must be ignored
       multivalued_ignored:
         range: string
@@ -70,3 +127,11 @@ classes:
       bottom:
         range: string
         required: true
+
+  Identified:
+    attributes:
+      id:
+        range: string
+        identifier: true
+      label:
+        range: string

--- a/tests/resources/models/equalsExpression/model.yaml
+++ b/tests/resources/models/equalsExpression/model.yaml
@@ -31,6 +31,20 @@ classes:
         equals_expression: "braces {{like this}} and a \"quote\""
       no_expression:
         range: string
+      # Reaching into inlined classes with dot notation
+      optional_nested:
+        range: Nested
+        inlined: true
+      required_nested:
+        range: Nested
+        inlined: true
+        required: true
+      from_optional_nested:
+        range: string
+        equals_expression: "{optional_nested.leaf}"
+      from_required_nested:
+        range: string
+        equals_expression: "{required_nested.required_leaf} at {required_nested.deeper.bottom}"
       # Out of scope: not a single-valued string, so the expression must be ignored
       multivalued_ignored:
         range: string
@@ -39,3 +53,20 @@ classes:
       integer_ignored:
         range: integer
         equals_expression: "{reference_value}"
+
+  Nested:
+    attributes:
+      leaf:
+        range: string
+      required_leaf:
+        range: string
+        required: true
+      deeper:
+        range: Deeper
+        inlined: true
+
+  Deeper:
+    attributes:
+      bottom:
+        range: string
+        required: true

--- a/tests/resources/models/inlines/inlineAbstract/model.yaml
+++ b/tests/resources/models/inlines/inlineAbstract/model.yaml
@@ -1,0 +1,40 @@
+id: https://neverblink.eu/linkml/tests/inlines/inlineAbstract/
+name: inline_abstract
+
+imports:
+  - linkml:types
+
+classes:
+  AbstractRange:
+    abstract: true
+    attributes:
+      some_slot:
+        range: string
+
+  MixinRange:
+    mixin: true
+    attributes:
+      other_slot:
+        range: string
+
+  ConcreteRange:
+    attributes:
+      third_slot:
+        range: string
+
+  Container:
+    tree_root: true
+    attributes:
+      to_abstract:
+        range: AbstractRange
+        inlined: true
+      to_mixin:
+        range: MixinRange
+        inlined: true
+      to_concrete:
+        range: ConcreteRange
+        inlined: true
+      many_abstract:
+        range: AbstractRange
+        inlined: true
+        multivalued: true

--- a/tests/src/eu/neverblink/linkml/tests/ModelCatalogue.scala
+++ b/tests/src/eu/neverblink/linkml/tests/ModelCatalogue.scala
@@ -136,6 +136,7 @@ object ModelCatalogue {
   val curie: Entry = Entry("/models/curie/")
   val emitPrefixes: Entry = Entry("/models/emitPrefixes/")
   val emptyClass: Entry = Entry("/models/emptyClass/")
+  val equalsExpression: Entry = Entry("/models/equalsExpression/")
   val `enum`: Entry = Entry("/models/enum/")
   val externalType: Entry = Entry("/models/externalType/")
   val implicitPrefix: Entry = Entry("/models/implicitPrefix/")

--- a/tests/src/eu/neverblink/linkml/tests/ModelCatalogue.scala
+++ b/tests/src/eu/neverblink/linkml/tests/ModelCatalogue.scala
@@ -173,6 +173,7 @@ object ModelCatalogue {
     val explicitInlineImplicitlyAsSimpleDict: Entry =
       Entry("/models/inlines/explicitInlineImplicitlyAsSimpleDict/")
     val explicitInlineList: Entry = Entry("/models/inlines/explicitInlineList/")
+    val inlineAbstract: Entry = Entry("/models/inlines/inlineAbstract/")
 
     val selfSimple2: Entry = Entry("/models/inlines/selfSimple2/")
     val selfSimple2Required: Entry = Entry("/models/inlines/selfSimple2Required/")

--- a/yaml/src/eu/neverblink/linkml/yaml/LinkmlYamlCodec.scala
+++ b/yaml/src/eu/neverblink/linkml/yaml/LinkmlYamlCodec.scala
@@ -34,7 +34,7 @@ object LinkmlYamlCodec {
       case n => decodeError("URI or CURIE string value", n)
     }
 
-    override def encode(x: UriOrCurie, skipId: Boolean): Node = Node.ScalarNode(x.original)
+    override def encode(x: UriOrCurie, skipId: Boolean): Node = StringNode(x.original)
   }
 
   inline def derived[T]: LinkmlYamlCodec[T] = ${ LinkmlYamlCodecImpl.make }
@@ -174,7 +174,7 @@ private class LinkmlYamlCodecImpl(using Quotes) extends MacroUtils {
     if (implCodec.isDefined) {
       '{ ${ implCodec.get.asInstanceOf[Expr[LinkmlYamlCodec[T]]] }.encode($x, $skipId) }
     } else if (tpe =:= stringTpe) withEncoderFor(tpe, x, skipId) { (x, _) =>
-      '{ Node.ScalarNode(${ x.asInstanceOf[Expr[String]] }) }
+      '{ StringNode(${ x.asInstanceOf[Expr[String]] }) }
     }
     else if (tpe =:= intTpe || tpe =:= booleanTpe) withEncoderFor(tpe, x, skipId) { (x, _) =>
       '{ Node.ScalarNode($x.toString) }
@@ -213,7 +213,7 @@ private class LinkmlYamlCodecImpl(using Quotes) extends MacroUtils {
     }
     else if (isAbstractClassOrTraitOrEnum(tpe)) withEncoderFor(tpe, x, skipId) { (x, _) =>
       val m = withReverseEnumMapFor[T](tpe)
-      '{ Node.ScalarNode($m.get($x)) }
+      '{ StringNode($m.get($x)) }
     }
     else
       withEncoderFor(tpe, x, skipId) { (x, skipId) =>

--- a/yaml/src/org/virtuslab/yaml/StringNode.scala
+++ b/yaml/src/org/virtuslab/yaml/StringNode.scala
@@ -1,0 +1,15 @@
+package org.virtuslab.yaml
+
+/** Builds scalar nodes that are always tagged as YAML strings.
+  *
+  * The public [[Node.ScalarNode]] factory infers the tag from the value, so `"123"`, `"true"` and
+  * `"null"` come back tagged `int`/`bool`/`null` even when they are string values. Serializers use
+  * that tag, and would emit them as unquoted literals. The needed constructor is `private[yaml]`,
+  * so this helper lives in scala-yaml's own package.
+  */
+object StringNode {
+  def apply(value: String): Node.ScalarNode =
+    // Keep null as a null-tagged node: absent values are encoded that way.
+    if (value eq null) Node.ScalarNode(null)
+    else new Node.ScalarNode(value, Tag.str)
+}

--- a/yaml/test/src/eu/neverblink/linkml/yaml/LinkmlYamlCodecSpec.scala
+++ b/yaml/test/src/eu/neverblink/linkml/yaml/LinkmlYamlCodecSpec.scala
@@ -15,12 +15,21 @@ class LinkmlYamlCodecSpec extends AnyWordSpec, Matchers, ScalaCheckPropertyCheck
     "decode and encode strings" in {
       implicit val codec: LinkmlYamlCodec[String] = LinkmlYamlCodec.derived
       roundTrip("abc", "abc\n")
-      roundTrip("true", "true\n")
-      roundTrip("false", "false\n")
-      roundTrip("123", "123\n")
-      roundTrip("123.456", "123.456\n")
       roundTrip("Привіт", "Привіт\n")
       roundTrip("★🎸🎧⋆｡°⋆", "★🎸🎧⋆｡°⋆\n")
+      // Strings that look like other scalar types must be quoted on encode, otherwise they
+      // re-parse (and serialize to JSON) as a number/boolean/null rather than a string.
+      roundTrip("true", "\"true\"\n")
+      roundTrip("false", "\"false\"\n")
+      roundTrip("null", "\"null\"\n")
+      roundTrip("~", "\"~\"\n")
+      roundTrip("123", "\"123\"\n")
+      roundTrip("123.456", "\"123.456\"\n")
+      roundTrip("", "\"\"\n")
+      // Unquoted scalars still decode as strings.
+      decode[String]("true\n", "true")
+      decode[String]("123\n", "123")
+      decode[String]("123.456\n", "123.456")
       decodeError[String](
         "a: abc\n",
         """Expected string value at 0:0 but got:
@@ -642,6 +651,9 @@ class LinkmlYamlCodecSpec extends AnyWordSpec, Matchers, ScalaCheckPropertyCheck
     parseYaml(yaml).map(x => codec.decode(x)) shouldEqual Right(value)
     codec.encode(value).asYaml shouldEqual yaml
   }
+
+  private def decode[T](yaml: String, value: T)(implicit codec: LinkmlYamlCodec[T]): Unit =
+    parseYaml(yaml).map(x => codec.decode(x)) shouldEqual Right(value)
 
   private def decodeError[T](yaml: String, error: String)(implicit
       codec: LinkmlYamlCodec[T],


### PR DESCRIPTION
- Only string interpolation is supported
- The expression is parsed with fastparse (which already gives a BNF basis to put in spec later!) in SchemaView. The parser uses AttributeView to resolve the referenced slots.
- Only Scala generator is supported
- Case classes are not modified. Inferred fields and populated and checked when the user calls infer() on a case class – then we create a new instance of the class.