### PR TITLE
Serialize non-string-looking strings as strings

### DIFF
--- a/generator/test/src/eu/neverblink/linkml/generator/linkml/LinkMlGeneratorSpec.scala
+++ b/generator/test/src/eu/neverblink/linkml/generator/linkml/LinkMlGeneratorSpec.scala
@@ -288,6 +288,42 @@ class LinkMlGeneratorSpec extends AnyWordSpec, Matchers {
         |}""".stripMargin
     }
 
+    "serialize string values that look like numbers, booleans or nulls as strings" in {
+      val sv = SchemaView.loadSchemaViewFromString("""name: numeric_strings
+          |id: https://example.org/numeric-strings
+          |title: "123"
+          |description: "true"
+          |license: "null"
+          |classes:
+          |  SomeClass:
+          |    description: "3.14"
+          |""".stripMargin)
+
+      LinkMlGenerator(using sv).serialize(outputFormat = LinkMlGenerator.OutputFormat.json) shouldBe
+        """{
+        |  "name": "numeric_strings",
+        |  "id": "https://example.org/numeric-strings",
+        |  "classes": {
+        |    "SomeClass": {
+        |      "class_uri": "https://example.org/numeric-strings/SomeClass",
+        |      "description": "3.14",
+        |      "from_schema": "https://example.org/numeric-strings"
+        |    }
+        |  },
+        |  "title": "123",
+        |  "description": "true",
+        |  "license": "null"
+        |}""".stripMargin
+
+      // The same nodes feed the YAML output, which must quote them for the same reason.
+      val yaml =
+        LinkMlGenerator(using sv).serialize(outputFormat = LinkMlGenerator.OutputFormat.yaml)
+      yaml should include("""title: "123"""")
+      yaml should include("""description: "true"""")
+      yaml should include("""license: "null"""")
+      yaml should include("""description: "3.14"""")
+    }
+
     "generate all catalogue models without errors" when {
       for entry <- ModelCatalogue.all.filter(m => !skipModels.contains(m.model.root.name)) do
         s"model '${entry.model.root.name}'" in {

--- a/yaml/src/eu/neverblink/linkml/yaml/LinkmlYamlCodec.scala
+++ b/yaml/src/eu/neverblink/linkml/yaml/LinkmlYamlCodec.scala
@@ -34,7 +34,7 @@ object LinkmlYamlCodec {
       case n => decodeError("URI or CURIE string value", n)
     }
 
-    override def encode(x: UriOrCurie, skipId: Boolean): Node = Node.ScalarNode(x.original)
+    override def encode(x: UriOrCurie, skipId: Boolean): Node = StringNode(x.original)
   }
 
   inline def derived[T]: LinkmlYamlCodec[T] = ${ LinkmlYamlCodecImpl.make }
@@ -174,7 +174,7 @@ private class LinkmlYamlCodecImpl(using Quotes) extends MacroUtils {
     if (implCodec.isDefined) {
       '{ ${ implCodec.get.asInstanceOf[Expr[LinkmlYamlCodec[T]]] }.encode($x, $skipId) }
     } else if (tpe =:= stringTpe) withEncoderFor(tpe, x, skipId) { (x, _) =>
-      '{ Node.ScalarNode(${ x.asInstanceOf[Expr[String]] }) }
+      '{ StringNode(${ x.asInstanceOf[Expr[String]] }) }
     }
     else if (tpe =:= intTpe || tpe =:= booleanTpe) withEncoderFor(tpe, x, skipId) { (x, _) =>
       '{ Node.ScalarNode($x.toString) }
@@ -213,7 +213,7 @@ private class LinkmlYamlCodecImpl(using Quotes) extends MacroUtils {
     }
     else if (isAbstractClassOrTraitOrEnum(tpe)) withEncoderFor(tpe, x, skipId) { (x, _) =>
       val m = withReverseEnumMapFor[T](tpe)
-      '{ Node.ScalarNode($m.get($x)) }
+      '{ StringNode($m.get($x)) }
     }
     else
       withEncoderFor(tpe, x, skipId) { (x, skipId) =>

--- a/yaml/src/org/virtuslab/yaml/StringNode.scala
+++ b/yaml/src/org/virtuslab/yaml/StringNode.scala
@@ -1,0 +1,15 @@
+package org.virtuslab.yaml
+
+/** Builds scalar nodes that are always tagged as YAML strings.
+  *
+  * The public [[Node.ScalarNode]] factory infers the tag from the value, so `"123"`, `"true"` and
+  * `"null"` come back tagged `int`/`bool`/`null` even when they are string values. Serializers use
+  * that tag, and would emit them as unquoted literals. The needed constructor is `private[yaml]`,
+  * so this helper lives in scala-yaml's own package.
+  */
+object StringNode {
+  def apply(value: String): Node.ScalarNode =
+    // Keep null as a null-tagged node: absent values are encoded that way.
+    if (value eq null) Node.ScalarNode(null)
+    else new Node.ScalarNode(value, Tag.str)
+}

--- a/yaml/test/src/eu/neverblink/linkml/yaml/LinkmlYamlCodecSpec.scala
+++ b/yaml/test/src/eu/neverblink/linkml/yaml/LinkmlYamlCodecSpec.scala
@@ -15,12 +15,21 @@ class LinkmlYamlCodecSpec extends AnyWordSpec, Matchers, ScalaCheckPropertyCheck
     "decode and encode strings" in {
       implicit val codec: LinkmlYamlCodec[String] = LinkmlYamlCodec.derived
       roundTrip("abc", "abc\n")
-      roundTrip("true", "true\n")
-      roundTrip("false", "false\n")
-      roundTrip("123", "123\n")
-      roundTrip("123.456", "123.456\n")
       roundTrip("Привіт", "Привіт\n")
       roundTrip("★🎸🎧⋆｡°⋆", "★🎸🎧⋆｡°⋆\n")
+      // Strings that look like other scalar types must be quoted on encode, otherwise they
+      // re-parse (and serialize to JSON) as a number/boolean/null rather than a string.
+      roundTrip("true", "\"true\"\n")
+      roundTrip("false", "\"false\"\n")
+      roundTrip("null", "\"null\"\n")
+      roundTrip("~", "\"~\"\n")
+      roundTrip("123", "\"123\"\n")
+      roundTrip("123.456", "\"123.456\"\n")
+      roundTrip("", "\"\"\n")
+      // Unquoted scalars still decode as strings.
+      decode[String]("true\n", "true")
+      decode[String]("123\n", "123")
+      decode[String]("123.456\n", "123.456")
       decodeError[String](
         "a: abc\n",
         """Expected string value at 0:0 but got:
@@ -642,6 +651,9 @@ class LinkmlYamlCodecSpec extends AnyWordSpec, Matchers, ScalaCheckPropertyCheck
     parseYaml(yaml).map(x => codec.decode(x)) shouldEqual Right(value)
     codec.encode(value).asYaml shouldEqual yaml
   }
+
+  private def decode[T](yaml: String, value: T)(implicit codec: LinkmlYamlCodec[T]): Unit =
+    parseYaml(yaml).map(x => codec.decode(x)) shouldEqual Right(value)
 
   private def decodeError[T](yaml: String, error: String)(implicit
       codec: LinkmlYamlCodec[T],


### PR DESCRIPTION
Only YAML can provide so much fun.

Basically, strings like "123" would be serialized as numbers, no matter what, also in JSON. Ugh.