### PR TITLE
Serialize ifabsent fields

### DIFF
--- a/generator/src/eu/neverblink/linkml/generator/scala/ScalaGenerator.scala
+++ b/generator/src/eu/neverblink/linkml/generator/scala/ScalaGenerator.scala
@@ -254,8 +254,13 @@ final class ScalaGenerator(using sv: SchemaView) {
     val range = slot.derivedRange
     val inlined = slot.derivedInlined
     val (scalaType, defaultValue) = baseRange(slot, range, inlined)
+    // Defaults coming from 'ifabsent' are meaningful and must survive serialization, unlike the
+    // implicit "empty" defaults (None / Seq() / Map()) that codecs are free to omit.
+    val ifAbsentAnnotation =
+      if defaultValue.isDefined then Seq("@serializeDefault") else Seq()
     InlineType(slot) match {
-      case InlineType.plain => TypedDefault(scalaType, defaultValue)
+      case InlineType.plain =>
+        TypedDefault(scalaType, defaultValue, annotations = ifAbsentAnnotation)
       case InlineType.optional if scalaType == "Boolean" =>
         TypedDefault(
           scalaType,
@@ -266,6 +271,7 @@ final class ScalaGenerator(using sv: SchemaView) {
         TypedDefault(
           s"Option[$scalaType]",
           default = Some(defaultValue.map(v => s"Some($v)").getOrElse("None")),
+          annotations = ifAbsentAnnotation,
           combineFunc = combineOption(combineFallback),
         )
       case InlineType.list =>
@@ -282,7 +288,7 @@ final class ScalaGenerator(using sv: SchemaView) {
         TypedDefault(
           s"Map[String, $scalaType]",
           default = if slot.slot.required then None else Some("Map()"),
-          annotation = Some(annotation),
+          annotations = Seq(annotation),
           combineFunc = combineMap,
         )
     }
@@ -336,7 +342,7 @@ final class ScalaGenerator(using sv: SchemaView) {
       name,
       typedDefault.typeName,
       typedDefault.default,
-      Seq() ++ thisAnnotation ++ aliasAnnotation ++ typedDefault.annotation,
+      Seq() ++ thisAnnotation ++ aliasAnnotation ++ typedDefault.annotations,
       remapMetamodelCombineFunctions(v, typedDefault.combineFunc),
       order,
       // TODO LNK-124: remove when resolved in linkml-model
@@ -684,16 +690,16 @@ object ScalaGenerator {
     * @param default
     *   The default value to provide for the field, or None if the field should be required. Must be
     *   compatible with [[typeName]]
-    * @param annotation
-    *   The range inlining annotation specifying which dict inline style should be used. None if not
-    *   applicable.
+    * @param annotations
+    *   Annotations implied by the type-level information, e.g. the dict inline style to use, or
+    *   whether the default value must be serialized. Empty if none apply.
     * @param combineFunc
     *   The combining function appropriate for the [[typeName]].
     */
   case class TypedDefault(
       typeName: String,
       default: Option[String] = None,
-      annotation: Option[String] = None,
+      annotations: Seq[String] = Seq(),
       combineFunc: CombineFunction = CombineFunction.combineFallback,
   )
 }

--- a/generator/test/src/eu/neverblink/linkml/generator/scala/ScalaGeneratorSpec.scala
+++ b/generator/test/src/eu/neverblink/linkml/generator/scala/ScalaGeneratorSpec.scala
@@ -753,6 +753,23 @@ class ScalaGeneratorSpec extends AnyWordSpec, Matchers {
       }
     }
 
+    "mark ifabsent default values with @serializeDefault" in {
+      val files = ScalaGenerator(using ModelCatalogue.ifabsent.enums.model).generate(testPkg).toMap
+      // Drop the indentation, so that the snippets below can be written without it.
+      // Done without a regex, as Scala.js has no MULTILINE support below ES2018.
+      val code = files("SomeClass.scala").linesIterator.map(_.stripLeading()).mkString("\n")
+      Seq(
+        "@serializeDefault\nsomeSlot: Option[SomeEnum] = Some(SomeEnum.SomeOption)",
+        "@serializeDefault\nsomeOtherSlot: Option[SomeEnum] = Some(SomeEnum.SomeOtherOption)",
+        "@serializeDefault\nyetAnotherSlot: Option[SomeEnum] = Some(SomeEnum.YetAnotherOption)",
+        "@serializeDefault\nwithSpaces: Option[SomeEnum] = Some(SomeEnum.OptionWithSpaces)",
+      ).foreach { snippet =>
+        code should include(snippet)
+      }
+      // Slots without an ifabsent default must not be annotated -- their default is just "empty"
+      code should not include "@serializeDefault\nnoIfabsent"
+    }
+
     "generate an emit_prefixes object" in {
       val files = ScalaGenerator(using ModelCatalogue.emitPrefixes.model)
         .generate(testPkg).toMap

--- a/runtime/src/eu/neverblink/linkml/runtime/Annotations.scala
+++ b/runtime/src/eu/neverblink/linkml/runtime/Annotations.scala
@@ -14,3 +14,11 @@ import scala.annotation.meta.field
 @field final class compactDict extends StaticAnnotation
 
 @field final class expandedDict extends StaticAnnotation
+
+/** Marks a field whose default value is meaningful and must always be serialized, even when the
+  * field is set to the default value. Used for defaults derived from the LinkML `ifabsent`
+  * metaslot.
+  *
+  * Only valid on fields that actually declare a default value.
+  */
+@field final class serializeDefault extends StaticAnnotation

--- a/runtime/src/eu/neverblink/linkml/runtime/MacroUtils.scala
+++ b/runtime/src/eu/neverblink/linkml/runtime/MacroUtils.scala
@@ -82,6 +82,8 @@ trait MacroUtils(using val quotes: Quotes) {
     *   The fully resolved type representation (`TypeRepr`) of the field.
     * @param kind
     *   The structural role of this field in LinkML mappings (e.g., ID, Value, Dictionary).
+    * @param serializeDefault
+    *   Whether the default value must be serialized instead of omitted (`@serializeDefault`).
     */
   class FieldInfo(
       val symbol: Symbol,
@@ -90,6 +92,7 @@ trait MacroUtils(using val quotes: Quotes) {
       val defaultValue: Option[Term],
       val resolvedTpe: TypeRepr,
       val kind: FieldKind,
+      val serializeDefault: Boolean,
   )
 
   /** Defines the specific mapping behavior or structural role a field has within a LinkML schema.
@@ -316,11 +319,20 @@ trait MacroUtils(using val quotes: Quotes) {
             }
             var named: Option[Term] = None
             var kind: FieldKind = FieldKind.Regular
+            var serializeDefault = false
             getterOrField.annotations.foreach { annotation =>
               val aTpe = annotation.tpe
               if (aTpe =:= namedTpe) {
                 if (named eq None) named = new Some(annotation)
                 else fail(s"Duplicated '${namedTpe.show}' defined for '$name' of '${tpe.show}'.")
+              } else if (aTpe =:= serializeDefaultTpe) {
+                if (defaultValue.isEmpty) {
+                  fail(
+                    s"'${serializeDefaultTpe.show}' is defined for '$name' of '${tpe.show}', which has no " +
+                      "default value. The annotation is only valid on fields with a default value.",
+                  )
+                }
+                serializeDefault = true
               } else {
                 if (kind != FieldKind.Regular) {
                   fail(
@@ -337,7 +349,15 @@ trait MacroUtils(using val quotes: Quotes) {
             val mappedName = namedValueOpt(named, tpe) match
               case Some(name1) => name1
               case _ => name
-            new FieldInfo(symbol, mappedName, getterOrField, defaultValue, fieldTpe, kind)
+            new FieldInfo(
+              symbol,
+              mappedName,
+              getterOrField,
+              defaultValue,
+              fieldTpe,
+              kind,
+              serializeDefault,
+            )
         }
 
       new ClassInfo(
@@ -526,4 +546,6 @@ trait MacroUtils(using val quotes: Quotes) {
     Symbol.requiredClass("eu.neverblink.linkml.runtime.compactDict").typeRef
   private val expandedDictTpe =
     Symbol.requiredClass("eu.neverblink.linkml.runtime.expandedDict").typeRef
+  private val serializeDefaultTpe =
+    Symbol.requiredClass("eu.neverblink.linkml.runtime.serializeDefault").typeRef
 }

--- a/yaml/src/eu/neverblink/linkml/yaml/LinkmlYamlCodec.scala
+++ b/yaml/src/eu/neverblink/linkml/yaml/LinkmlYamlCodec.scala
@@ -422,13 +422,15 @@ private class LinkmlYamlCodecImpl(using Quotes) extends MacroUtils {
             case '[ft] =>
               val encodeVal = genEncode[ft](fTpe, getter.asInstanceOf[Expr[ft]], fSkipId)
               fieldInfo.defaultValue match {
-                case Some(d) =>
+                // '@serializeDefault' fields carry a meaningful default (e.g. from 'ifabsent'),
+                // so they are written out even when they still hold it.
+                case Some(d) if !fieldInfo.serializeDefault =>
                   '{
                     if (${ getter } != ${ d.asExpr }) {
                       $kvs.addOne((Node.ScalarNode($name), $encodeVal))
                     }
                   }
-                case None =>
+                case _ =>
                   if (fieldInfo.kind == FieldKind.Id) '{
                     if (! $skipId) $kvs.addOne((Node.ScalarNode($name), $encodeVal))
                   }
@@ -451,8 +453,11 @@ private class LinkmlYamlCodecImpl(using Quotes) extends MacroUtils {
       }
     } else if (
       fields.exists(_.kind == FieldKind.Id) && fields.exists(_.kind == FieldKind.Value) &&
+      // A '@serializeDefault' field must always be written, so the class cannot collapse to the
+      // compact (bare value) form. Decoding of that form stays supported either way.
       fields.forall(x =>
-        x.kind == FieldKind.Id || x.kind == FieldKind.Value || x.defaultValue.isDefined,
+        x.kind == FieldKind.Id || x.kind == FieldKind.Value ||
+          (x.defaultValue.isDefined && !x.serializeDefault),
       )
     ) {
       val fieldInfo = fields.find(_.kind == FieldKind.Value).get

--- a/yaml/test/src/eu/neverblink/linkml/yaml/LinkmlYamlCodecSpec.scala
+++ b/yaml/test/src/eu/neverblink/linkml/yaml/LinkmlYamlCodecSpec.scala
@@ -278,6 +278,68 @@ class LinkmlYamlCodecSpec extends AnyWordSpec, Matchers, ScalaCheckPropertyCheck
           |   ^""".stripMargin,
       )
     }
+    "encode default values of fields annotated with @serializeDefault" in {
+      case class MyClass(
+          a: Option[String] = Some("ifabsent"),
+          @serializeDefault b: Option[String] = Some("ifabsent"),
+          @serializeDefault c: Int = 42,
+          @named("dd") @serializeDefault d: Boolean = true,
+      ) derives LinkmlYamlCodec
+
+      // Untouched defaults: 'a' is omitted, the annotated fields are still written out
+      roundTrip(
+        MyClass(),
+        """b: ifabsent
+          |c: 42
+          |dd: true
+          |""".stripMargin,
+      )
+      roundTrip(
+        MyClass(Some("x"), Some("y"), 1, false),
+        """a: x
+          |b: y
+          |c: 1
+          |dd: false
+          |""".stripMargin,
+      )
+      // Annotated fields remain optional on decode, falling back to their defaults
+      decode[MyClass]("a: x", MyClass(a = Some("x")))
+      // An explicitly serialized default round-trips to the same value
+      decode[MyClass](
+        """b: ifabsent
+          |c: 42
+          |dd: true
+          |""".stripMargin,
+        MyClass(),
+      )
+    }
+    "not use the compact form for classes with a @serializeDefault field" in {
+      case class DictEntry(
+          @id k: String,
+          @value v: Int,
+          @serializeDefault e: Boolean = true,
+      )
+
+      case class MyClass(@simpleDict d: Map[String, DictEntry], x: Option[Int] = None)
+          derives LinkmlYamlCodec
+
+      // Without '@serializeDefault' on 'e' this would collapse to the compact form below
+      roundTrip(
+        MyClass(Map("a" -> DictEntry("a", 1))),
+        """d:
+          |  a:
+          |    v: 1
+          |    e: true
+          |""".stripMargin,
+      )
+      // The compact form is still accepted on decode
+      decode[MyClass](
+        """d:
+          |  a: 1
+          |""".stripMargin,
+        MyClass(Map("a" -> DictEntry("a", 1))),
+      )
+    }
     "decode and encode recursive case classes" in {
       case class MyClass(v: Int, n: Option[MyClass] = None) derives LinkmlYamlCodec
 
@@ -643,6 +705,11 @@ class LinkmlYamlCodecSpec extends AnyWordSpec, Matchers, ScalaCheckPropertyCheck
         """case class MyClass(@id a: String, @value b: Int, @value c: Boolean) derives LinkmlYamlCodec"""
       }).getMessage.contains {
         """More than one field is defined with '@value' annotation in 'MyClass'."""
+      })
+      assert(intercept[TestFailedException](assertCompiles {
+        """case class MyClass(a: String, @serializeDefault b: Int) derives LinkmlYamlCodec"""
+      }).getMessage.contains {
+        """'eu.neverblink.linkml.runtime.serializeDefault' is defined for 'b' of 'MyClass', which has no default value."""
       })
     }
   }


### PR DESCRIPTION
Encoder ignores fields set to the default value. IMO we should still serialize these fields, but @niegrzybkowski I'm open to any alternative suggestions here.

The use case is that in validation reports we have the severity which is set by ifabsent. Without this, the value never gets serialized. Theoretically it's possible to retrieve it by re-parsing this... but yeah, it's not very easy for consumers.