### PR TITLE
LNK-142 More efficient decoding of LinkML input and generation of JSON Schema, LinkML, and SHACL schemas

### DIFF
--- a/benchmark/src/eu/neverblink/linkml/benchmark/GeneratorBench.scala
+++ b/benchmark/src/eu/neverblink/linkml/benchmark/GeneratorBench.scala
@@ -39,7 +39,11 @@ class GeneratorBench extends CommonParams {
 
   @Benchmark
   def jsonSchemaFromYaml(bh: Blackhole): Unit =
-    bh.consume(JsonSchemaGenerator(using SchemaIssues.orThrow(SchemaView.loadSchemaViewFromString(yaml))).serialize())
+    bh.consume(
+      JsonSchemaGenerator(using
+        SchemaIssues.orThrow(SchemaView.loadSchemaViewFromString(yaml)),
+      ).serialize(),
+    )
 
   def jsonSchemaFromYaml(bh: Blackhole): Unit =
     bh.consume(JsonSchemaGenerator(using SchemaView.loadSchemaViewFromString(yaml)).serialize())
@@ -77,7 +81,11 @@ class GeneratorBench extends CommonParams {
 
   @Benchmark
   def linkmlFromYaml(bh: Blackhole): Unit =
-    bh.consume(LinkMlGenerator(using SchemaIssues.orThrow(SchemaView.loadSchemaViewFromString(yaml))).serialize())
+    bh.consume(
+      LinkMlGenerator(using
+        SchemaIssues.orThrow(SchemaView.loadSchemaViewFromString(yaml)),
+      ).serialize(),
+    )
 
   /** Same setup for RDF sinks as in the CLI.
     */

--- a/benchmark/src/eu/neverblink/linkml/benchmark/GeneratorBench.scala
+++ b/benchmark/src/eu/neverblink/linkml/benchmark/GeneratorBench.scala
@@ -45,9 +45,6 @@ class GeneratorBench extends CommonParams {
       ).serialize(),
     )
 
-  def jsonSchemaFromYaml(bh: Blackhole): Unit =
-    bh.consume(JsonSchemaGenerator(using SchemaView.loadSchemaViewFromString(yaml)).serialize())
-
   @Benchmark
   def jsonSchemaFromSchemas(bh: Blackhole): Unit =
     bh.consume(JsonSchemaGenerator(using SchemaView(schemaView.schemas)).serialize())
@@ -59,9 +56,6 @@ class GeneratorBench extends CommonParams {
   @Benchmark
   def shaclFromYaml(bh: Blackhole): Unit =
     writeShacl(bh)(using SchemaIssues.orThrow(SchemaView.loadSchemaViewFromString(yaml)))
-
-  def shaclFromYaml(bh: Blackhole): Unit =
-    writeShacl(bh)(using SchemaView.loadSchemaViewFromString(yaml))
 
   @Benchmark
   def shaclFromSchemas(bh: Blackhole): Unit =

--- a/benchmark/src/eu/neverblink/linkml/benchmark/GeneratorBench.scala
+++ b/benchmark/src/eu/neverblink/linkml/benchmark/GeneratorBench.scala
@@ -38,58 +38,46 @@ class GeneratorBench extends CommonParams {
   }
 
   @Benchmark
-  def jsonSchemaFromYaml(bh: Blackhole): Unit = {
-    given sv: SchemaView = SchemaIssues.orThrow(SchemaView.loadSchemaViewFromString(yaml))
-    bh.consume(JsonSchemaGenerator().serialize())
-  }
+  def jsonSchemaFromYaml(bh: Blackhole): Unit =
+    bh.consume(JsonSchemaGenerator(using SchemaIssues.orThrow(SchemaView.loadSchemaViewFromString(yaml))).serialize())
+
+  def jsonSchemaFromYaml(bh: Blackhole): Unit =
+    bh.consume(JsonSchemaGenerator(using SchemaView.loadSchemaViewFromString(yaml)).serialize())
 
   @Benchmark
-  def jsonSchemaFromSchemas(bh: Blackhole): Unit = {
-    given sv: SchemaView = SchemaView(schemaView.schemas)
-    bh.consume(JsonSchemaGenerator().serialize())
-  }
+  def jsonSchemaFromSchemas(bh: Blackhole): Unit =
+    bh.consume(JsonSchemaGenerator(using SchemaView(schemaView.schemas)).serialize())
 
   @Benchmark
-  def jsonSchemaFromSchemaView(bh: Blackhole): Unit = {
-    given sv: SchemaView = schemaView
-    bh.consume(JsonSchemaGenerator().serialize())
-  }
+  def jsonSchemaFromSchemaView(bh: Blackhole): Unit =
+    bh.consume(JsonSchemaGenerator(using schemaView).serialize())
 
   @Benchmark
-  def shaclFromYaml(bh: Blackhole): Unit = {
-    given sv: SchemaView = SchemaIssues.orThrow(SchemaView.loadSchemaViewFromString(yaml))
-    writeShacl(bh)
-  }
+  def shaclFromYaml(bh: Blackhole): Unit =
+    writeShacl(bh)(using SchemaIssues.orThrow(SchemaView.loadSchemaViewFromString(yaml)))
+
+  def shaclFromYaml(bh: Blackhole): Unit =
+    writeShacl(bh)(using SchemaView.loadSchemaViewFromString(yaml))
 
   @Benchmark
-  def shaclFromSchemas(bh: Blackhole): Unit = {
-    given sv: SchemaView = SchemaView(schemaView.schemas)
-    writeShacl(bh)
-  }
+  def shaclFromSchemas(bh: Blackhole): Unit =
+    writeShacl(bh)(using SchemaView(schemaView.schemas))
 
   @Benchmark
-  def shaclFromSchemaView(bh: Blackhole): Unit = {
-    given sv: SchemaView = schemaView
-    writeShacl(bh)
-  }
+  def shaclFromSchemaView(bh: Blackhole): Unit =
+    writeShacl(bh)(using schemaView)
 
   @Benchmark
-  def linkmlFromSchemas(bh: Blackhole): Unit = {
-    given sv: SchemaView = SchemaView(schemaView.schemas)
-    bh.consume(LinkMlGenerator().serialize())
-  }
+  def linkmlFromSchemas(bh: Blackhole): Unit =
+    bh.consume(LinkMlGenerator(using SchemaView(schemaView.schemas)).serialize())
 
   @Benchmark
-  def linkmlFromSchemaView(bh: Blackhole): Unit = {
-    given sv: SchemaView = schemaView
-    bh.consume(LinkMlGenerator().serialize())
-  }
+  def linkmlFromSchemaView(bh: Blackhole): Unit =
+    bh.consume(LinkMlGenerator(using schemaView).serialize())
 
   @Benchmark
-  def linkmlFromYaml(bh: Blackhole): Unit = {
-    given sv: SchemaView = SchemaIssues.orThrow(SchemaView.loadSchemaViewFromString(yaml))
-    bh.consume(LinkMlGenerator().serialize())
-  }
+  def linkmlFromYaml(bh: Blackhole): Unit =
+    bh.consume(LinkMlGenerator(using SchemaIssues.orThrow(SchemaView.loadSchemaViewFromString(yaml))).serialize())
 
   /** Same setup for RDF sinks as in the CLI.
     */

--- a/benchmark/src/eu/neverblink/linkml/benchmark/NTriplesSerializationBench.scala
+++ b/benchmark/src/eu/neverblink/linkml/benchmark/NTriplesSerializationBench.scala
@@ -47,9 +47,8 @@ class NTriplesSerializationBench extends CommonParams {
     val yaml = Using.resource(getClass.getResourceAsStream(s"/schemas/$schema")) { in =>
       Source.fromInputStream(in, "UTF-8").mkString
     }
-    given sv: SchemaView = SchemaIssues.orThrow(SchemaView.loadSchemaViewFromString(yaml))
     val collector = new CollectingRdfSink
-    ShaclGenerator().generate(collector)
+    ShaclGenerator(using SchemaIssues.orThrow(SchemaView.loadSchemaViewFromString(yaml))).generate(collector)
     val triples = collector.triples
 
     linkmlTriples = triples.toArray

--- a/benchmark/src/eu/neverblink/linkml/benchmark/NTriplesSerializationBench.scala
+++ b/benchmark/src/eu/neverblink/linkml/benchmark/NTriplesSerializationBench.scala
@@ -48,7 +48,9 @@ class NTriplesSerializationBench extends CommonParams {
       Source.fromInputStream(in, "UTF-8").mkString
     }
     val collector = new CollectingRdfSink
-    ShaclGenerator(using SchemaIssues.orThrow(SchemaView.loadSchemaViewFromString(yaml))).generate(collector)
+    ShaclGenerator(using SchemaIssues.orThrow(SchemaView.loadSchemaViewFromString(yaml))).generate(
+      collector,
+    )
     val triples = collector.triples
 
     linkmlTriples = triples.toArray

--- a/benchmark/src/eu/neverblink/linkml/benchmark/WarmBench.scala
+++ b/benchmark/src/eu/neverblink/linkml/benchmark/WarmBench.scala
@@ -58,15 +58,13 @@ class WarmBench extends CommonParams {
   @Benchmark
   def jsonSchema(bh: Blackhole): Unit = {
     // create SchemaView in the benchmark to not use the class cache
-    given SchemaView = SchemaView(schemaDefs)
-    bh.consume(JsonSchemaGenerator().serialize())
+    bh.consume(JsonSchemaGenerator(using SchemaView(schemaDefs)).serialize())
   }
 
   @Benchmark
   def shacl(bh: Blackhole): Unit = {
     // create SchemaView in the benchmark to not use the class cache
-    given SchemaView = SchemaView(schemaDefs)
-
-    ShaclGenerator().generate(NTriplesRdfSink(BufferedByteSink(BlackholeOutputStream(bh))))
+    ShaclGenerator(using SchemaView(schemaDefs))
+      .generate(NTriplesRdfSink(BufferedByteSink(BlackholeOutputStream(bh))))
   }
 }

--- a/cli/src/eu/neverblink/linkml/cli/BaseCommand.scala
+++ b/cli/src/eu/neverblink/linkml/cli/BaseCommand.scala
@@ -30,7 +30,6 @@ abstract class BaseCommand[T: {Parser, Help}] extends Command[T] {
   def loadSchema(inFile: Option[String]): SchemaView =
     inFile.foldFast {
       err("Input file is required.")
-      null
     } { inputName =>
       SchemaView.loadSchemaViewFromUri(inputName) match {
         case Right(sv) => sv
@@ -41,7 +40,7 @@ abstract class BaseCommand[T: {Parser, Help}] extends Command[T] {
             verbose = true,
             showLevel = false,
           )
-          err("Cannot load schema: " + formatted); null
+          err("Cannot load schema: " + formatted)
       }
     }
 

--- a/cli/src/eu/neverblink/linkml/cli/BaseCommand.scala
+++ b/cli/src/eu/neverblink/linkml/cli/BaseCommand.scala
@@ -2,6 +2,7 @@ package eu.neverblink.linkml.cli
 
 import caseapp.*
 import eu.neverblink.linkml.schemaview.{SchemaIssues, SchemaView}
+import eu.neverblink.linkml.runtime.FastUtils.*
 
 import java.io.{ByteArrayOutputStream, PrintStream}
 
@@ -27,20 +28,21 @@ abstract class BaseCommand[T: {Parser, Help}] extends Command[T] {
     exit(1)
 
   def loadSchema(inFile: Option[String]): SchemaView =
-    inFile match {
-      case None => err("Input file is required."); null
-      case Some(inputName) =>
-        SchemaView.loadSchemaViewFromUri(inputName) match {
-          case Right(sv) => sv
-          case Left(problems) =>
-            val formatted = SchemaIssues.format(
-              problems.map(_.infer()),
-              maxProblems = 5,
-              verbose = true,
-              showLevel = false,
-            )
-            err("Cannot load schema: " + formatted); null
-        }
+    inFile.foldFast {
+      err("Input file is required.")
+      null
+    } { inputName =>
+      SchemaView.loadSchemaViewFromUri(inputName) match {
+        case Right(sv) => sv
+        case Left(problems) =>
+          val formatted = SchemaIssues.format(
+            problems.map(_.infer()),
+            maxProblems = 5,
+            verbose = true,
+            showLevel = false,
+          )
+          err("Cannot load schema: " + formatted); null
+      }
     }
 
   /** Runs the whole CLI (via [[App]]) with the given args, capturing stdout and stderr. For tests

--- a/cli/src/eu/neverblink/linkml/cli/Generate.scala
+++ b/cli/src/eu/neverblink/linkml/cli/Generate.scala
@@ -2,6 +2,7 @@ package eu.neverblink.linkml.cli
 
 import caseapp.*
 import eu.neverblink.linkml.schemaview.SchemaView
+import eu.neverblink.linkml.runtime.FastUtils.*
 
 import java.io.OutputStream
 
@@ -52,34 +53,31 @@ sealed abstract class Generate[T <: HasGenerateOptions: {Parser, Help}] extends 
     }
 
   private def writeToFileOrStdout(file: Option[String], write: OutputStream => Unit): Unit =
-    file match {
-      case Some(value) =>
-        val stream = os.write.outputStream(os.Path(value, os.pwd))
-        try write(stream)
-        finally stream.close()
-      case None =>
-        // `out` is the command's stdout (redirected in tests). Flush but never close it.
-        write(outStream)
-        outStream.flush()
+    file.foldFast {
+      // `out` is the command's stdout (redirected in tests). Flush but never close it.
+      write(outStream)
+      outStream.flush()
+    } { value =>
+      val stream = os.write.outputStream(os.Path(value, os.pwd))
+      try write(stream)
+      finally stream.close()
     }
 
   private def writeToFileOrStdout(file: Option[String], content: String): Unit =
-    file match {
-      case Some(value) => os.write(os.Path(value, os.pwd), content)
-      case None => printLine(content)
+    file.foldFast(printLine(content)) { value =>
+      os.write(os.Path(value, os.pwd), content)
     }
 
   private def writeManyFiles(to: Option[String], files: Iterable[(String, String)]): Unit =
-    to match {
-      case Some(dir) =>
-        val path = os.Path(dir, os.pwd)
-        os.makeDir.all(path)
-        files.foreach((k, v) => os.write.over(path / k, v))
-      case None =>
-        files.foreach((k, v) => {
-          printLine(s"//\n// FILE $k\n//")
-          printLine(v)
-        })
+    to.foldFast {
+      files.foreach((k, v) => {
+        printLine(s"//\n// FILE $k\n//")
+        printLine(v)
+      })
+    } { dir =>
+      val path = os.Path(dir, os.pwd)
+      os.makeDir.all(path)
+      files.foreach((k, v) => os.write.over(path / k, v))
     }
 }
 

--- a/cli/src/eu/neverblink/linkml/cli/Validate.scala
+++ b/cli/src/eu/neverblink/linkml/cli/Validate.scala
@@ -66,12 +66,13 @@ object Validate extends BaseCommand[ValidateOptions] {
     catch
       // Only unexpected failures land here - a custom importer throwing, say. Reported as an import
       // failure so that every issue, including this one, is structured.
-      case NonFatal(ex) =>
+      case ex if NonFatal(ex) =>
+        val msg = ex.getMessage
         Seq(
-          SchemaImportErrorImpl(
+          new SchemaImportErrorImpl(
             location = IssueLocationImpl(),
             importUri = inputName,
-            reason = Option(ex.getMessage).getOrElse(ex.toString),
+            reason = if (msg ne null) msg else ex.toString,
           ),
         )
 }

--- a/cli/src/eu/neverblink/linkml/cli/ValidationReport.scala
+++ b/cli/src/eu/neverblink/linkml/cli/ValidationReport.scala
@@ -3,6 +3,7 @@ package eu.neverblink.linkml.cli
 import eu.neverblink.linkml.generator.util.JsonUtil
 import org.virtuslab.yaml.Node
 import eu.neverblink.linkml.schemaview.SchemaIssues
+import eu.neverblink.linkml.runtime.FastUtils.*
 import eu.neverblink.linkml.validation.{
   Codec,
   IssueSeverity,
@@ -136,23 +137,23 @@ object ValidationReport {
       case Format.Json => text
       case Format.Plain => s"# $text"
       case Format.Terminal =>
-        val (color, icon) = all.headOption match
-          case None => (green, "✔") // ✔
-          case Some(_) =>
-            val s = summarySeverity(all)
-            (s.color, s.icon)
+        val (color, icon) = all.headOption.foldFast((green, "✔")) { _ =>
+          val s = summarySeverity(all)
+          (s.color, s.icon)
+        }
         s"  $color$bold$icon $text$reset"
       case Format.Json => throw UnsupportedOperationException()
 
   private def renderPlain(issues: Seq[Issue]): String =
     if issues.isEmpty then "Schema is valid."
-    else
-      val lines = sorted(issues).map(i => s"${i.severity.label}: ${i.message}")
-      (lines :+ "" :+ summaryText(issues)).mkString("\n")
+    else {
+      sorted(issues).map(i => s"${i.severity.label}: ${i.message}")
+        .mkString("", "\n", "\n".concat(summaryText(issues)))
+    }
 
   private def renderTerminal(schemaName: String, issues: Seq[Issue]): String =
     import Ansi.*
-    val sb = new StringBuilder
+    val sb = new java.lang.StringBuilder
     sb.append(s"${dim}Validating $schemaName$reset\n\n")
     if issues.isEmpty then sb.append(s"$green$bold✔ Schema is valid.$reset") // ✔
     else

--- a/cli/src/eu/neverblink/linkml/cli/ValidationReport.scala
+++ b/cli/src/eu/neverblink/linkml/cli/ValidationReport.scala
@@ -119,6 +119,7 @@ object ValidationReport {
 
   private def renderBlock(schemaName: String, issues: Seq[Issue], format: Format): String =
     format match
+      case Format.Json => renderPlain(issues)
       case Format.Plain => s"# $schemaName\n${renderPlain(issues)}"
       case Format.Terminal => renderTerminal(schemaName, issues)
       case Format.Json => throw UnsupportedOperationException()
@@ -132,6 +133,7 @@ object ValidationReport {
         val withIssues = reports.count(_._2.nonEmpty)
         s"${reports.size} schemas checked, $withIssues with issues: ${summaryText(all)}"
     format match
+      case Format.Json => text
       case Format.Plain => s"# $text"
       case Format.Terminal =>
         val (color, icon) = all.headOption match

--- a/cli/src/eu/neverblink/linkml/cli/ValidationReport.scala
+++ b/cli/src/eu/neverblink/linkml/cli/ValidationReport.scala
@@ -120,7 +120,6 @@ object ValidationReport {
 
   private def renderBlock(schemaName: String, issues: Seq[Issue], format: Format): String =
     format match
-      case Format.Json => renderPlain(issues)
       case Format.Plain => s"# $schemaName\n${renderPlain(issues)}"
       case Format.Terminal => renderTerminal(schemaName, issues)
       case Format.Json => throw UnsupportedOperationException()
@@ -134,7 +133,6 @@ object ValidationReport {
         val withIssues = reports.count(_._2.nonEmpty)
         s"${reports.size} schemas checked, $withIssues with issues: ${summaryText(all)}"
     format match
-      case Format.Json => text
       case Format.Plain => s"# $text"
       case Format.Terminal =>
         val (color, icon) = all.headOption.foldFast((green, "✔")) { _ =>

--- a/generator/src/eu/neverblink/linkml/generator/graphql/GraphQlGenerator.scala
+++ b/generator/src/eu/neverblink/linkml/generator/graphql/GraphQlGenerator.scala
@@ -99,9 +99,9 @@ class GraphQlGenerator(using sv: SchemaView) {
           cls.aliasedName,
           cls.uriStr,
           fields,
-          cls.parents
-            .filter(cv => cv.cls.`abstract` || cv.cls.mixin)
-            .map(_.aliasedName).toSeq,
+          cls.parents.collect {
+            case cv if cv.cls.`abstract` || cv.cls.mixin => cv.aliasedName
+          },
           cls.cls.description,
         ),
       )
@@ -111,11 +111,11 @@ class GraphQlGenerator(using sv: SchemaView) {
           cls.aliasedName,
           cls.uriStr,
           fields,
-          cls.parents
-            // Break the inheritance chain on concrete -> concrete inheritance
-            // We still need to use the derived slots and interfaces and types anyway
-            .filter(cv => cv.cls.`abstract` || cv.cls.mixin)
-            .map(_.aliasedName).toSeq,
+          // Break the inheritance chain on concrete -> concrete inheritance
+          // We still need to use the derived slots and interfaces and types anyway
+          cls.parents.collect {
+            case cv if cv.cls.`abstract` || cv.cls.mixin => cv.aliasedName
+          },
           cls.cls.description,
         ),
       )

--- a/generator/src/eu/neverblink/linkml/generator/jsonschema/JsonSchemaGenerator.scala
+++ b/generator/src/eu/neverblink/linkml/generator/jsonschema/JsonSchemaGenerator.scala
@@ -92,28 +92,23 @@ class JsonSchemaGenerator(using sv: SchemaView) {
         case _: AnyView => Schema.Empty
         case ClassInlineAttributeView(_, _, classView, inlineType) =>
           val mappedClassName = className(classView)
+          val $ref = "#/$defs/".concat(mappedClassName)
           inlineType match {
             case InlineType.plain =>
-              new Schema(
-                $ref = new Some("#/$defs/".concat(mappedClassName)),
-              )
+              new Schema($ref = new Some($ref))
             case InlineType.optional =>
-              new Schema(
-                $ref = new Some("#/$defs/".concat(mappedClassName)),
-              ) // TODO LNK-34: or null
+              new Schema($ref = new Some($ref)) // TODO LNK-34: or null
             case InlineType.list =>
-              new Schema(
-                $ref = new Some("#/$defs/".concat(mappedClassName)),
-              ).arrayOf // TODO LNK-34: or null
+              new Schema($ref = new Some($ref)).arrayOf // TODO LNK-34: or null
             case InlineType.dict(CollectionForm.CompactDict(key)) =>
               needKeyless.add((mappedClassName, slotName(classView.derivedAttributes(key))))
               new Schema(
-                $ref = new Some("#/$defs/" + mappedClassName + "__identifier_optional"),
+                $ref = new Some($ref.concat("__identifier_optional")),
               ).dictOf // TODO LNK-34: or null
             case InlineType.dict(CollectionForm.SimpleDict(key, value)) =>
               needValue.add((mappedClassName, slotName(classView.derivedAttributes(value))))
-              new Schema(
-                $ref = new Some("#/$defs/" + mappedClassName + "__simple_dict_value"),
+              new Schema($ref =
+                new Some($ref.concat("__simple_dict_value")),
               ).dictOf // TODO LNK-34: or null
           }
         case ClassReferenceAttributeView(slotView, _, classView, identifierView) =>

--- a/generator/src/eu/neverblink/linkml/generator/jsonschema/JsonSchemaGenerator.scala
+++ b/generator/src/eu/neverblink/linkml/generator/jsonschema/JsonSchemaGenerator.scala
@@ -6,6 +6,7 @@ import eu.neverblink.linkml
 import eu.neverblink.linkml.metamodel.Anything
 import eu.neverblink.linkml.schemaview
 import eu.neverblink.linkml.schemaview.*
+import eu.neverblink.linkml.runtime.FastUtils.*
 import sttp.apispec.{
   AnySchema,
   ExampleMultipleValue,
@@ -30,27 +31,18 @@ class JsonSchemaGenerator(using sv: SchemaView) {
   /** Translate a class name into a JSON Schema form, respecting aliases and LinkML casing rules
     */
   protected def className(cls: ClassView): MappedClassName =
-    cls.cls.alias match {
-      case Some(a) => a
-      case _ => Case.PascalCase(cls.cls.name)
-    }
+    cls.cls.alias.getOrElseFast(Case.PascalCase(cls.cls.name))
 
   /** Translate a slot name into a JSON Schema form, respecting aliases and LinkML casing rules
     */
   protected def slotName(slot: SlotView): MappedSlotName =
-    slot.slot.alias match {
-      case Some(a) => a
-      case _ => Case.deSpaceCase(slot.slot.name)
-    }
+    slot.slot.alias.getOrElseFast(Case.deSpaceCase(slot.slot.name))
 
-  private def toBigDecimalOpt(x: Option[Anything]): Option[BigDecimal] = x match {
-    case Some(v) =>
-      try new Some(BigDecimal(v.value.trim))
-      catch {
-        case ex if NonFatal(ex) => None
-      }
-    case _ => None
-  }
+  private def toBigDecimalOpt(x: Option[Anything]): Option[BigDecimal] =
+    try x.mapFast(v => BigDecimal(v.value.trim))
+    catch {
+      case ex if NonFatal(ex) => None
+    }
 
   /** Generate the JSON Schema, but keep it in the [[Schema]] model
     *
@@ -75,9 +67,8 @@ class JsonSchemaGenerator(using sv: SchemaView) {
     }
     // If a tree root is defined, only include classes reachable from the tree root (pruning).
     // Otherwise, include all classes in the schema view.
-    val query = maybeTreeRoot match {
-      case Some(root) => sv.derivedReachabilityQuery(Seq(root), true, false)
-      case _ => IncludeAllReachabilityQuery()
+    val query = maybeTreeRoot.foldFast(IncludeAllReachabilityQuery()) { root =>
+      sv.derivedReachabilityQuery(Seq(root), true, false)
     }
     // Mutable set this method will add to if it requires a keyless class to be defined in `$defs`
     // for CompactDict form inlining. The slot will be the key to omit from required fields.
@@ -117,7 +108,7 @@ class JsonSchemaGenerator(using sv: SchemaView) {
               $comment = Some(s"Reference to ${classView.name} class"),
               minimum = toBigDecimalOpt(identifierView.minimumValue),
               maximum = toBigDecimalOpt(identifierView.maximumValue),
-              pattern = identifierView.pattern.map(Pattern(_)),
+              pattern = identifierView.pattern.mapFast(new Pattern(_)),
             )
             .arrayOfIf(slotView.slot.multivalued)
         case typeAttribute: TypeAttributeView =>
@@ -125,7 +116,7 @@ class JsonSchemaGenerator(using sv: SchemaView) {
             .copy(
               minimum = toBigDecimalOpt(typeAttribute.minimumValue),
               maximum = toBigDecimalOpt(typeAttribute.maximumValue),
-              pattern = typeAttribute.pattern.map(Pattern(_)),
+              pattern = typeAttribute.pattern.mapFast(new Pattern(_)),
             )
             .arrayOfIf(typeAttribute.slotView.slot.multivalued)
         case EnumAttributeView(slotView, _, enumView) =>
@@ -170,33 +161,31 @@ class JsonSchemaGenerator(using sv: SchemaView) {
         ),
       )
     }
-    val baseSchema = maybeTreeRoot match {
-      case Some(treeRoot) =>
-        val classSchema =
+    val baseSchema = maybeTreeRoot.foldFast(Schema.Empty) { treeRoot =>
+      val classSchema =
+        new Schema(
+          $ref = new Some("#/$defs/".concat(className(treeRoot))),
+        )
+      val inlineType = treeRoot.treeRootInlineType(treeRootInlineTypeOverride)
+      inlineType match {
+        case InlineType.plain => classSchema // object (mandatory)
+        case InlineType.optional =>
+          Schema.oneOf(List(classSchema, Schema.Null), discriminator = None) // object or null
+        case InlineType.list =>
+          arraySchema.copy(items = Some(classSchema)) // array of objects
+        case InlineType.dict(CollectionForm.CompactDict(key)) =>
+          val mappedClassName = className(treeRoot)
+          needKeyless.add((mappedClassName, slotName(treeRoot.derivedAttributes(key))))
           new Schema(
-            $ref = new Some("#/$defs/".concat(className(treeRoot))),
-          )
-        val inlineType = treeRoot.treeRootInlineType(treeRootInlineTypeOverride)
-        inlineType match {
-          case InlineType.plain => classSchema // object (mandatory)
-          case InlineType.optional =>
-            Schema.oneOf(List(classSchema, Schema.Null), discriminator = None) // object or null
-          case InlineType.list =>
-            arraySchema.copy(items = Some(classSchema)) // array of objects
-          case InlineType.dict(CollectionForm.CompactDict(key)) =>
-            val mappedClassName = className(treeRoot)
-            needKeyless.add((mappedClassName, slotName(treeRoot.derivedAttributes(key))))
-            new Schema(
-              $ref = new Some("#/$defs/" + mappedClassName + "__identifier_optional"),
-            ).dictOf
-          case InlineType.dict(CollectionForm.SimpleDict(key, value)) =>
-            val mappedClassName = className(treeRoot)
-            needValue.add((mappedClassName, slotName(treeRoot.derivedAttributes(value))))
-            new Schema(
-              $ref = new Some("#/$defs/" + mappedClassName + "__simple_dict_value"),
-            ).dictOf
-        }
-      case _ => Schema.Empty
+            $ref = new Some("#/$defs/" + mappedClassName + "__identifier_optional"),
+          ).dictOf
+        case InlineType.dict(CollectionForm.SimpleDict(key, value)) =>
+          val mappedClassName = className(treeRoot)
+          needValue.add((mappedClassName, slotName(treeRoot.derivedAttributes(value))))
+          new Schema(
+            $ref = new Some("#/$defs/" + mappedClassName + "__simple_dict_value"),
+          ).dictOf
+      }
     }
     // Generate the needed keyless/value refs
     for (className, idField) <- needKeyless do {

--- a/generator/src/eu/neverblink/linkml/generator/jsonschema/JsonSchemaGenerator.scala
+++ b/generator/src/eu/neverblink/linkml/generator/jsonschema/JsonSchemaGenerator.scala
@@ -94,7 +94,7 @@ class JsonSchemaGenerator(using sv: SchemaView) {
     for cls <- classes if query.reachable(cls) do {
       // Generate a Schema for a specific slot, which maps to a JSON Schema property
       val attributes = cls.attributeViews.values // The slot to define a JSON Schema property for
-      val properties = new mutable.LinkedHashMap[MappedClassName, Schema]
+      val properties = new mutable.LinkedHashMap[MappedSlotName, Schema]
       properties.sizeHint(attributes.size)
       for attribute <- attributes do {
         val slot = attribute.slotView
@@ -157,7 +157,7 @@ class JsonSchemaGenerator(using sv: SchemaView) {
         )
       }
       val requiredSlots = attributes.foldLeft(new mutable.ListBuffer[String]) { (acc, s) =>
-        if (s.slotView.slot.required) acc.addOne(s.slotView.name)
+        if (s.slotView.slot.required) acc.addOne(slotName(s.slotView))
         else acc
       }.toList
       defs.update(

--- a/generator/src/eu/neverblink/linkml/generator/jsonschema/JsonSchemaGenerator.scala
+++ b/generator/src/eu/neverblink/linkml/generator/jsonschema/JsonSchemaGenerator.scala
@@ -79,21 +79,24 @@ class JsonSchemaGenerator(using sv: SchemaView) {
       case Some(root) => sv.derivedReachabilityQuery(Seq(root), true, false)
       case _ => IncludeAllReachabilityQuery()
     }
-    // Accumulator of all schema definitions, reused to search definition for
-    // keyless classes and value feds
-    val defs = new mutable.LinkedHashMap[String, Schema]
     // Mutable set this method will add to if it requires a keyless class to be defined in `$defs`
     // for CompactDict form inlining. The slot will be the key to omit from required fields.
     val needKeyless = mutable.Set.empty[(MappedClassName, MappedSlotName)]
     // Mutable set this method will add to if it requires a value def to be defined in `$defs` for
     // SimpleDict form inlining. The slot will be the value to omit from required fields.
     val needValue = mutable.Set.empty[(MappedClassName, MappedSlotName)]
-    for cls <- sv.classes.values if query.reachable(cls) do {
+    // Accumulator of all schema definitions, reused to search definition for
+    // keyless classes and value feds
+    val defs = new mutable.LinkedHashMap[String, Schema]
+    val enums = sv.enums.values
+    val classes = sv.classes.values
+    defs.sizeHint(classes.size + enums.size << 1)
+    for cls <- classes if query.reachable(cls) do {
       // Generate a Schema for a specific slot, which maps to a JSON Schema property
-      val attributes = cls.attributeViews // The slot to define a JSON Schema property for
+      val attributes = cls.attributeViews.values // The slot to define a JSON Schema property for
       val properties = new mutable.LinkedHashMap[MappedClassName, Schema]
-      properties.sizeHint(attributes.values.size)
-      for attribute <- attributes.values do {
+      properties.sizeHint(attributes.size)
+      for attribute <- attributes do {
         val slot = attribute.slotView
         val slotSchema = attribute match {
           case _: AnyView => Schema.Empty
@@ -153,15 +156,16 @@ class JsonSchemaGenerator(using sv: SchemaView) {
           ),
         )
       }
-      val requiredSlots = attributes.values.foldLeft(new mutable.ListBuffer[String]) { (acc, s) =>
+      val requiredSlots = attributes.foldLeft(new mutable.ListBuffer[String]) { (acc, s) =>
         if (s.slotView.slot.required) acc.addOne(s.slotView.name)
         else acc
-      }.toList // avoids O(n^2) complexity
+      }.toList
       defs.update(
         className(cls),
         objectSchema.copy(
           required = requiredSlots,
-          properties = immutable.ListMap.newBuilder.addAll(properties).result(),
+          properties =
+            immutable.ListMap.newBuilder.addAll(properties).result(), // avoids O(n^2) complexity
           additionalProperties = new Some(if (open) AnySchema.Anything else AnySchema.Nothing),
           title = cls.cls.title,
           description = cls.cls.description,
@@ -211,7 +215,7 @@ class JsonSchemaGenerator(using sv: SchemaView) {
         simpleDict.properties(valueField).asInstanceOf[Schema],
       )
     }
-    for ev <- sv.enums.values do {
+    for ev <- enums do {
       val enum_ = ev._enum
       val enumValues = enum_.permissibleValues.keys.foldLeft(new mutable.ListBuffer[ExampleValue]) {
         (acc, v) => acc.addOne(ExampleSingleValue(v))
@@ -231,9 +235,11 @@ class JsonSchemaGenerator(using sv: SchemaView) {
       $id = new Some(sv.root.id.uri(using sv.rootPrefixResolver)),
       title = sv.root.title.orElse(new Some(sv.root.name)),
       description = sv.root.description,
-      $defs = new Some(immutable.ListMap.newBuilder[String, SchemaLike].addAll(
-        defs,
-      ).result()), // avoids O(n^2) complexity
+      $defs = new Some(
+        immutable.ListMap.newBuilder[String, SchemaLike].addAll(
+          defs,
+        ).result(), // avoids O(n^2) complexity
+      ),
     )
   }
 

--- a/generator/src/eu/neverblink/linkml/generator/jsonschema/JsonSchemaGenerator.scala
+++ b/generator/src/eu/neverblink/linkml/generator/jsonschema/JsonSchemaGenerator.scala
@@ -86,7 +86,7 @@ class JsonSchemaGenerator(using sv: SchemaView) {
     // SimpleDict form inlining. The slot will be the value to omit from required fields.
     val needValue = mutable.Set.empty[(MappedClassName, MappedSlotName)]
     // Accumulator of all schema definitions, reused to search definition for
-    // keyless classes and value feds
+    // keyless classes and value definitions
     val defs = new mutable.LinkedHashMap[String, Schema]
     val enums = sv.enums.values
     val classes = sv.classes.values
@@ -218,7 +218,7 @@ class JsonSchemaGenerator(using sv: SchemaView) {
     for ev <- enums do {
       val enum_ = ev._enum
       val enumValues = enum_.permissibleValues.keys.foldLeft(new mutable.ListBuffer[ExampleValue]) {
-        (acc, v) => acc.addOne(ExampleSingleValue(v))
+        (acc, v) => acc.addOne(new ExampleSingleValue(v))
       }.toList
       defs.update(
         enum_.name,
@@ -271,28 +271,22 @@ object JsonSchemaGenerator {
   /** Translate the [[RuntimeType]] of the provided type view into the appropriate JSON Schema.
     * Provides formats for date-times and URI/CURIE.
     */
-  def typeToRuntime(tv: TypeView): Schema = tv.runtimeType match {
-    case StringType => stringSchema
-    case IntegerType => integerSchema
-    case FloatType => numberSchema
-    case DoubleType => numberSchema
-    case BooleanType => booleanSchema
-    case DecimalType => numberSchema
-    case AnyType => Schema.Empty
-    case DateType => stringSchema.copy(format = new Some(SchemaFormat.Date))
-    case DateTimeType => stringSchema.copy(format = new Some(SchemaFormat.DateTime))
-    case TimeType => stringSchema.copy(format = new Some("time"))
-    case UriOrCurieType =>
-      Schema.Empty.copy(anyOf =
-        List(
-          stringSchema.copy(format = new Some("uri")),
-          stringSchema.copy(format = new Some("curie")),
-        ),
-      )
-    case UriType => stringSchema.copy(format = new Some("uri"))
-    case CurieType => stringSchema.copy(format = new Some("curie"))
-    case NcNameType => stringSchema.copy(format = new Some("ncname"))
-    case UnknownType => Schema.Empty
+  def typeToRuntime(tv: TypeView): Schema = {
+    val rt = tv.runtimeType
+    if (rt eq StringType) stringSchema
+    else if (rt eq IntegerType) integerSchema
+    else if (rt eq FloatType) numberSchema
+    else if (rt eq DoubleType) numberSchema
+    else if (rt eq BooleanType) booleanSchema
+    else if (rt eq DecimalType) numberSchema
+    else if (rt eq DateType) dateSchema
+    else if (rt eq DateTimeType) datetimeSchema
+    else if (rt eq TimeType) timeSchema
+    else if (rt eq UriOrCurieType) uriOrCurieSchema
+    else if (rt eq UriType) uriSchema
+    else if (rt eq CurieType) curieSchema
+    else if (rt eq NcNameType) ncNameSchema
+    else Schema.Empty
   }
 
   type MappedClassName = String
@@ -359,4 +353,16 @@ object JsonSchemaGenerator {
   private val numberSchema: Schema = Schema(SchemaType.Number)
   private val objectSchema: Schema = Schema(SchemaType.Object)
   private val stringSchema: Schema = Schema(SchemaType.String)
+  private val dateSchema: Schema = stringSchema.copy(format = new Some(SchemaFormat.Date))
+  private val datetimeSchema: Schema = stringSchema.copy(format = new Some(SchemaFormat.DateTime))
+  private val timeSchema: Schema = stringSchema.copy(format = new Some("time"))
+  private val ncNameSchema: Schema = stringSchema.copy(format = new Some("ncname"))
+  private val uriSchema: Schema = stringSchema.copy(format = new Some("uri"))
+  private val curieSchema: Schema = stringSchema.copy(format = new Some("curie"))
+  private val uriOrCurieSchema: Schema = new Schema(anyOf =
+    List(
+      stringSchema.copy(format = new Some("uri")),
+      stringSchema.copy(format = new Some("curie")),
+    ),
+  )
 }

--- a/generator/src/eu/neverblink/linkml/generator/jsonschema/JsonSchemaGenerator.scala
+++ b/generator/src/eu/neverblink/linkml/generator/jsonschema/JsonSchemaGenerator.scala
@@ -85,6 +85,66 @@ class JsonSchemaGenerator(using sv: SchemaView) {
     // Mutable set this method will add to if it requires a value def to be defined in `$defs` for
     // SimpleDict form inlining. The slot will be the value to omit from required fields.
     val needValue = mutable.Set.empty[(MappedClassName, MappedSlotName)]
+
+    // Generate a Schema for a specific attribute, which maps to a JSON Schema property
+    def generateSlotSchema(attribute: AttributeView): Schema = {
+      val slotSchema = attribute match {
+        case _: AnyView => Schema.Empty
+        case ClassInlineAttributeView(_, _, classView, inlineType) =>
+          val mappedClassName = className(classView)
+          inlineType match {
+            case InlineType.plain =>
+              new Schema(
+                $ref = new Some("#/$defs/".concat(mappedClassName)),
+              )
+            case InlineType.optional =>
+              new Schema(
+                $ref = new Some("#/$defs/".concat(mappedClassName)),
+              ) // TODO LNK-34: or null
+            case InlineType.list =>
+              new Schema(
+                $ref = new Some("#/$defs/".concat(mappedClassName)),
+              ).arrayOf // TODO LNK-34: or null
+            case InlineType.dict(CollectionForm.CompactDict(key)) =>
+              needKeyless.add((mappedClassName, slotName(classView.derivedAttributes(key))))
+              new Schema(
+                $ref = new Some("#/$defs/" + mappedClassName + "__identifier_optional"),
+              ).dictOf // TODO LNK-34: or null
+            case InlineType.dict(CollectionForm.SimpleDict(key, value)) =>
+              needValue.add((mappedClassName, slotName(classView.derivedAttributes(value))))
+              new Schema(
+                $ref = new Some("#/$defs/" + mappedClassName + "__simple_dict_value"),
+              ).dictOf // TODO LNK-34: or null
+          }
+        case ClassReferenceAttributeView(slotView, _, classView, identifierView) =>
+          typeToRuntime(identifierView.typeView)
+            .copy(
+              $comment = Some(s"Reference to ${classView.name} class"),
+              minimum = toBigDecimalOpt(identifierView.minimumValue),
+              maximum = toBigDecimalOpt(identifierView.maximumValue),
+              pattern = identifierView.pattern.map(Pattern(_)),
+            )
+            .arrayOfIf(slotView.slot.multivalued)
+        case typeAttribute: TypeAttributeView =>
+          typeToRuntime(typeAttribute.typeView)
+            .copy(
+              minimum = toBigDecimalOpt(typeAttribute.minimumValue),
+              maximum = toBigDecimalOpt(typeAttribute.maximumValue),
+              pattern = typeAttribute.pattern.map(Pattern(_)),
+            )
+            .arrayOfIf(typeAttribute.slotView.slot.multivalued)
+        case EnumAttributeView(slotView, _, enumView) =>
+          new Schema(
+            $ref = new Some("#/$defs/".concat(enumView._enum.name)),
+          ).arrayOfIf(slotView.slot.multivalued)
+      }
+      val sv = attribute.slotView
+      slotSchema.copy(
+        title = sv.slot.title,
+        description = sv.slot.description,
+      )
+    }
+
     // Accumulator of all schema definitions, reused to search definition for
     // keyless classes and value definitions
     val defs = new mutable.LinkedHashMap[String, Schema]
@@ -92,78 +152,21 @@ class JsonSchemaGenerator(using sv: SchemaView) {
     val classes = sv.classes.values
     defs.sizeHint(classes.size + enums.size << 1)
     for cls <- classes if query.reachable(cls) do {
-      // Generate a Schema for a specific slot, which maps to a JSON Schema property
-      val attributes = cls.attributeViews.values // The slot to define a JSON Schema property for
+      val attributes = cls.attributeViews.values
       val properties = new mutable.LinkedHashMap[MappedSlotName, Schema]
-      properties.sizeHint(attributes.size)
-      for attribute <- attributes do {
-        val slot = attribute.slotView
-        val slotSchema = attribute match {
-          case _: AnyView => Schema.Empty
-          case ClassInlineAttributeView(_, _, classView, inlineType) =>
-            val mappedClassName = className(classView)
-            inlineType match {
-              case InlineType.plain =>
-                new Schema(
-                  $ref = new Some("#/$defs/".concat(mappedClassName)),
-                )
-              case InlineType.optional =>
-                new Schema(
-                  $ref = new Some("#/$defs/".concat(mappedClassName)),
-                ) // TODO LNK-34: or null
-              case InlineType.list =>
-                new Schema(
-                  $ref = new Some("#/$defs/".concat(mappedClassName)),
-                ).arrayOf // TODO LNK-34: or null
-              case InlineType.dict(CollectionForm.CompactDict(key)) =>
-                needKeyless.add((mappedClassName, slotName(classView.derivedAttributes(key))))
-                new Schema(
-                  $ref = new Some("#/$defs/" + mappedClassName + "__identifier_optional"),
-                ).dictOf // TODO LNK-34: or null
-              case InlineType.dict(CollectionForm.SimpleDict(key, value)) =>
-                needValue.add((mappedClassName, slotName(classView.derivedAttributes(value))))
-                new Schema(
-                  $ref = new Some("#/$defs/" + mappedClassName + "__simple_dict_value"),
-                ).dictOf // TODO LNK-34: or null
-            }
-          case ClassReferenceAttributeView(slotView, _, classView, identifierView) =>
-            typeToRuntime(identifierView.typeView)
-              .copy(
-                $comment = Some(s"Reference to ${classView.name} class"),
-                minimum = toBigDecimalOpt(identifierView.minimumValue),
-                maximum = toBigDecimalOpt(identifierView.maximumValue),
-                pattern = identifierView.pattern.map(Pattern(_)),
-              )
-              .arrayOfIf(slotView.slot.multivalued)
-          case typeAttribute: TypeAttributeView =>
-            typeToRuntime(typeAttribute.typeView)
-              .copy(
-                minimum = toBigDecimalOpt(typeAttribute.minimumValue),
-                maximum = toBigDecimalOpt(typeAttribute.maximumValue),
-                pattern = typeAttribute.pattern.map(Pattern(_)),
-              )
-              .arrayOfIf(typeAttribute.slotView.slot.multivalued)
-          case EnumAttributeView(slotView, _, enumView) =>
-            new Schema(
-              $ref = new Some("#/$defs/".concat(enumView._enum.name)),
-            ).arrayOfIf(slotView.slot.multivalued)
-        }
-        properties.update(
-          slotName(slot),
-          slotSchema.copy(
-            title = slot.slot.title,
-            description = slot.slot.description,
-          ),
-        )
+      properties.sizeHint(attributes.knownSize) // to avoid hashmap growing
+      val requiredSlots = new mutable.ListBuffer[String]
+      attributes.foreach { a =>
+        val slotSchema = generateSlotSchema(a)
+        val sv = a.slotView
+        val name = slotName(sv)
+        properties.update(name, slotSchema)
+        if (sv.slot.required) requiredSlots.addOne(name)
       }
-      val requiredSlots = attributes.foldLeft(new mutable.ListBuffer[String]) { (acc, s) =>
-        if (s.slotView.slot.required) acc.addOne(slotName(s.slotView))
-        else acc
-      }.toList
       defs.update(
         className(cls),
         objectSchema.copy(
-          required = requiredSlots,
+          required = requiredSlots.toList,
           properties =
             immutable.ListMap.newBuilder.addAll(properties).result(), // avoids O(n^2) complexity
           additionalProperties = new Some(if (open) AnySchema.Anything else AnySchema.Nothing),

--- a/generator/src/eu/neverblink/linkml/generator/jsonschema/JsonSchemaGenerator.scala
+++ b/generator/src/eu/neverblink/linkml/generator/jsonschema/JsonSchemaGenerator.scala
@@ -43,80 +43,6 @@ class JsonSchemaGenerator(using sv: SchemaView) {
       case _ => Case.deSpaceCase(slot.slot.name)
     }
 
-  /** Generate a Schema for a specific slot, which maps to a JSON Schema property.
-    * @param attributeView
-    *   The slot to define a JSON Schema property for
-    * @param needKeyless
-    *   Mutable set this method will add to if it requires a keyless class to be defined in `$defs`
-    *   for CompactDict form inlining. The slot will be the key to omit from required fields.
-    * @param needValue
-    *   Mutable set this method will add to if it requires a value def to be defined in `$defs` for
-    *   SimpleDict form inlining. The slot will be the value to omit from required fields.
-    * @return
-    *   A tuple of the mapped slot name and the JSON [[Schema]] for the property value
-    */
-  private def generateSlotSchema(
-      attributeView: AttributeView,
-      needKeyless: mutable.Set[(MappedClassName, MappedSlotName)],
-      needValue: mutable.Set[(MappedClassName, MappedSlotName)],
-  ): (MappedSlotName, Schema) = {
-    val slot = attributeView.slotView
-    val slotSchema = attributeView match {
-      case _: AnyView => Schema.Empty
-      case ClassInlineAttributeView(_, _, classView, inlineType) =>
-        val mappedClassName = className(classView)
-        inlineType match {
-          case InlineType.plain =>
-            new Schema(
-              $ref = new Some("#/$defs/".concat(mappedClassName)),
-            )
-          case InlineType.optional =>
-            new Schema(
-              $ref = new Some("#/$defs/".concat(mappedClassName)),
-            ) // TODO LNK-34: or null
-          case InlineType.list =>
-            new Schema(
-              $ref = new Some("#/$defs/".concat(mappedClassName)),
-            ).arrayOf // TODO LNK-34: or null
-          case InlineType.dict(CollectionForm.CompactDict(key)) =>
-            needKeyless.add((mappedClassName, slotName(classView.derivedAttributes(key))))
-            new Schema(
-              $ref = new Some("#/$defs/" + mappedClassName + "__identifier_optional"),
-            ).dictOf // TODO LNK-34: or null
-          case InlineType.dict(CollectionForm.SimpleDict(key, value)) =>
-            needValue.add((mappedClassName, slotName(classView.derivedAttributes(value))))
-            new Schema(
-              $ref = new Some("#/$defs/" + mappedClassName + "__simple_dict_value"),
-            ).dictOf // TODO LNK-34: or null
-        }
-      case ClassReferenceAttributeView(slotView, _, classView, identifierView) =>
-        typeToRuntime(identifierView.typeView)
-          .copy(
-            $comment = Some(s"Reference to ${classView.name} class"),
-            minimum = toBigDecimalOpt(identifierView.minimumValue),
-            maximum = toBigDecimalOpt(identifierView.maximumValue),
-            pattern = identifierView.pattern.map(Pattern(_)),
-          )
-          .arrayOfIf(slotView.slot.multivalued)
-      case typeAttribute: TypeAttributeView =>
-        typeToRuntime(typeAttribute.typeView)
-          .copy(
-            minimum = toBigDecimalOpt(typeAttribute.minimumValue),
-            maximum = toBigDecimalOpt(typeAttribute.maximumValue),
-            pattern = typeAttribute.pattern.map(Pattern(_)),
-          )
-          .arrayOfIf(typeAttribute.slotView.slot.multivalued)
-      case EnumAttributeView(slotView, _, enumView) =>
-        new Schema(
-          $ref = new Some("#/$defs/".concat(enumView._enum.name)),
-        ).arrayOfIf(slotView.slot.multivalued)
-    }
-    slotName(slot) -> slotSchema.copy(
-      title = slot.slot.title,
-      description = slot.slot.description,
-    )
-  }
-
   private def toBigDecimalOpt(x: Option[Anything]): Option[BigDecimal] = x match {
     case Some(v) =>
       try new Some(BigDecimal(v.value.trim))
@@ -153,20 +79,85 @@ class JsonSchemaGenerator(using sv: SchemaView) {
       case Some(root) => sv.derivedReachabilityQuery(Seq(root), true, false)
       case _ => IncludeAllReachabilityQuery()
     }
+    // Accumulator of all schema definitions, reused to search definition for
+    // keyless classes and value feds
+    val defs = new mutable.LinkedHashMap[String, Schema]
+    // Mutable set this method will add to if it requires a keyless class to be defined in `$defs`
+    // for CompactDict form inlining. The slot will be the key to omit from required fields.
     val needKeyless = mutable.Set.empty[(MappedClassName, MappedSlotName)]
+    // Mutable set this method will add to if it requires a value def to be defined in `$defs` for
+    // SimpleDict form inlining. The slot will be the value to omit from required fields.
     val needValue = mutable.Set.empty[(MappedClassName, MappedSlotName)]
-    val defsClasses = for cls <- sv.classes.values if query.reachable(cls) yield {
-      val attributes = cls.attributeViews
+    for cls <- sv.classes.values if query.reachable(cls) do {
+      // Generate a Schema for a specific slot, which maps to a JSON Schema property
+      val attributes = cls.attributeViews // The slot to define a JSON Schema property for
       val properties = new mutable.LinkedHashMap[MappedClassName, Schema]
       properties.sizeHint(attributes.values.size)
       for attribute <- attributes.values do {
-        properties.addOne(generateSlotSchema(attribute, needKeyless, needValue))
+        val slot = attribute.slotView
+        val slotSchema = attribute match {
+          case _: AnyView => Schema.Empty
+          case ClassInlineAttributeView(_, _, classView, inlineType) =>
+            val mappedClassName = className(classView)
+            inlineType match {
+              case InlineType.plain =>
+                new Schema(
+                  $ref = new Some("#/$defs/".concat(mappedClassName)),
+                )
+              case InlineType.optional =>
+                new Schema(
+                  $ref = new Some("#/$defs/".concat(mappedClassName)),
+                ) // TODO LNK-34: or null
+              case InlineType.list =>
+                new Schema(
+                  $ref = new Some("#/$defs/".concat(mappedClassName)),
+                ).arrayOf // TODO LNK-34: or null
+              case InlineType.dict(CollectionForm.CompactDict(key)) =>
+                needKeyless.add((mappedClassName, slotName(classView.derivedAttributes(key))))
+                new Schema(
+                  $ref = new Some("#/$defs/" + mappedClassName + "__identifier_optional"),
+                ).dictOf // TODO LNK-34: or null
+              case InlineType.dict(CollectionForm.SimpleDict(key, value)) =>
+                needValue.add((mappedClassName, slotName(classView.derivedAttributes(value))))
+                new Schema(
+                  $ref = new Some("#/$defs/" + mappedClassName + "__simple_dict_value"),
+                ).dictOf // TODO LNK-34: or null
+            }
+          case ClassReferenceAttributeView(slotView, _, classView, identifierView) =>
+            typeToRuntime(identifierView.typeView)
+              .copy(
+                $comment = Some(s"Reference to ${classView.name} class"),
+                minimum = toBigDecimalOpt(identifierView.minimumValue),
+                maximum = toBigDecimalOpt(identifierView.maximumValue),
+                pattern = identifierView.pattern.map(Pattern(_)),
+              )
+              .arrayOfIf(slotView.slot.multivalued)
+          case typeAttribute: TypeAttributeView =>
+            typeToRuntime(typeAttribute.typeView)
+              .copy(
+                minimum = toBigDecimalOpt(typeAttribute.minimumValue),
+                maximum = toBigDecimalOpt(typeAttribute.maximumValue),
+                pattern = typeAttribute.pattern.map(Pattern(_)),
+              )
+              .arrayOfIf(typeAttribute.slotView.slot.multivalued)
+          case EnumAttributeView(slotView, _, enumView) =>
+            new Schema(
+              $ref = new Some("#/$defs/".concat(enumView._enum.name)),
+            ).arrayOfIf(slotView.slot.multivalued)
+        }
+        properties.update(
+          slotName(slot),
+          slotSchema.copy(
+            title = slot.slot.title,
+            description = slot.slot.description,
+          ),
+        )
       }
       val requiredSlots = attributes.values.foldLeft(new mutable.ListBuffer[String]) { (acc, s) =>
         if (s.slotView.slot.required) acc.addOne(s.slotView.name)
         else acc
-      }.toList
-      (
+      }.toList // avoids O(n^2) complexity
+      defs.update(
         className(cls),
         objectSchema.copy(
           required = requiredSlots,
@@ -174,21 +165,6 @@ class JsonSchemaGenerator(using sv: SchemaView) {
           additionalProperties = new Some(if (open) AnySchema.Anything else AnySchema.Nothing),
           title = cls.cls.title,
           description = cls.cls.description,
-        ),
-      )
-    }
-    val defsEnums = for ev <- sv.enums.values yield {
-      val enum_ = ev._enum
-      val enumValues = enum_.permissibleValues.keys.foldLeft(new mutable.ListBuffer[ExampleValue]) {
-        (acc, v) => acc.addOne(ExampleSingleValue(v))
-      }.toList
-      (
-        enum_.name,
-        objectSchema.copy(
-          `type` = new Some(List(SchemaType.String)),
-          `enum` = new Some(enumValues),
-          title = enum_.title,
-          description = enum_.description,
         ),
       )
     }
@@ -221,36 +197,43 @@ class JsonSchemaGenerator(using sv: SchemaView) {
       case _ => Schema.Empty
     }
     // Generate the needed keyless/value refs
-    val defMap = defsClasses.toMap
-    val defsKeyless = for (className, idField) <- needKeyless yield {
-      val classSchema = defMap(className)
-      (
+    for (className, idField) <- needKeyless do {
+      val classSchema = defs(className)
+      defs.update(
         className.concat("__identifier_optional"),
         classSchema.copy(required = classSchema.required.filter(_ != idField)),
       )
     }
-    val defsValues = for (className, valueField) <- needValue yield {
-      val simpleDict = defMap(className)
-      (
+    for (className, valueField) <- needValue do {
+      val simpleDict = defs(className)
+      defs.update(
         className.concat("__simple_dict_value"),
         simpleDict.properties(valueField).asInstanceOf[Schema],
       )
     }
-    val defs = immutable.ListMap.newBuilder[String, SchemaLike].addAll({
-      val m = new collection.mutable.LinkedHashMap[String, SchemaLike]
-      m.sizeHint(defsClasses.size + defsEnums.size + defsKeyless.size + defsValues.size)
-      defsClasses.foreach(kv => m.update(kv._1, kv._2))
-      defsEnums.foreach(kv => m.update(kv._1, kv._2))
-      defsKeyless.foreach(kv => m.update(kv._1, kv._2))
-      defsValues.foreach(kv => m.update(kv._1, kv._2))
-      m
-    }).result()
+    for ev <- sv.enums.values do {
+      val enum_ = ev._enum
+      val enumValues = enum_.permissibleValues.keys.foldLeft(new mutable.ListBuffer[ExampleValue]) {
+        (acc, v) => acc.addOne(ExampleSingleValue(v))
+      }.toList
+      defs.update(
+        enum_.name,
+        objectSchema.copy(
+          `type` = new Some(List(SchemaType.String)),
+          `enum` = new Some(enumValues),
+          title = enum_.title,
+          description = enum_.description,
+        ),
+      )
+    }
     baseSchema.copy(
       $schema = new Some("https://json-schema.org/draft/2020-12/schema"),
       $id = new Some(sv.root.id.uri(using sv.rootPrefixResolver)),
       title = sv.root.title.orElse(new Some(sv.root.name)),
       description = sv.root.description,
-      $defs = new Some(defs),
+      $defs = new Some(immutable.ListMap.newBuilder[String, SchemaLike].addAll(
+        defs,
+      ).result()), // avoids O(n^2) complexity
     )
   }
 

--- a/generator/src/eu/neverblink/linkml/generator/jsonschema/JsonSchemaGenerator.scala
+++ b/generator/src/eu/neverblink/linkml/generator/jsonschema/JsonSchemaGenerator.scala
@@ -30,12 +30,18 @@ class JsonSchemaGenerator(using sv: SchemaView) {
   /** Translate a class name into a JSON Schema form, respecting aliases and LinkML casing rules
     */
   protected def className(cls: ClassView): MappedClassName =
-    cls.cls.alias.getOrElse(Case.PascalCase(cls.cls.name))
+    cls.cls.alias match {
+      case Some(a) => a
+      case _ => Case.PascalCase(cls.cls.name)
+    }
 
   /** Translate a slot name into a JSON Schema form, respecting aliases and LinkML casing rules
     */
   protected def slotName(slot: SlotView): MappedSlotName =
-    slot.slot.alias.getOrElse(Case.deSpaceCase(slot.slot.name))
+    slot.slot.alias match {
+      case Some(a) => a
+      case _ => Case.deSpaceCase(slot.slot.name)
+    }
 
   /** Generate a Schema for a specific slot, which maps to a JSON Schema property.
     * @param attributeView
@@ -56,27 +62,31 @@ class JsonSchemaGenerator(using sv: SchemaView) {
   ): (MappedSlotName, Schema) = {
     val slot = attributeView.slotView
     val slotSchema = attributeView match {
-      case AnyView(slotView, _) => Schema.Empty
-      case ClassInlineAttributeView(slotView, _, classView, inlineType) =>
+      case _: AnyView => Schema.Empty
+      case ClassInlineAttributeView(_, _, classView, inlineType) =>
         val mappedClassName = className(classView)
         inlineType match {
           case InlineType.plain =>
-            Schema.referenceTo("#/$defs/", mappedClassName)
+            new Schema(
+              $ref = new Some("#/$defs/".concat(mappedClassName)),
+            )
           case InlineType.optional =>
-            Schema.referenceTo("#/$defs/", mappedClassName) // TODO LNK-34: or null
+            new Schema(
+              $ref = new Some("#/$defs/".concat(mappedClassName)),
+            ) // TODO LNK-34: or null
           case InlineType.list =>
-            Schema.referenceTo("#/$defs/", mappedClassName).arrayOf // TODO LNK-34: or null
+            new Schema(
+              $ref = new Some("#/$defs/".concat(mappedClassName)),
+            ).arrayOf // TODO LNK-34: or null
           case InlineType.dict(CollectionForm.CompactDict(key)) =>
-            needKeyless.add(mappedClassName -> slotName(classView.derivedAttributes(key)))
-            Schema.referenceTo(
-              "#/$defs/",
-              mappedClassName.concat("__identifier_optional"),
+            needKeyless.add((mappedClassName, slotName(classView.derivedAttributes(key))))
+            new Schema(
+              $ref = new Some("#/$defs/" + mappedClassName + "__identifier_optional"),
             ).dictOf // TODO LNK-34: or null
           case InlineType.dict(CollectionForm.SimpleDict(key, value)) =>
-            needValue.add(mappedClassName -> slotName(classView.derivedAttributes(value)))
-            Schema.referenceTo(
-              "#/$defs/",
-              mappedClassName.concat("__simple_dict_value"),
+            needValue.add((mappedClassName, slotName(classView.derivedAttributes(value))))
+            new Schema(
+              $ref = new Some("#/$defs/" + mappedClassName + "__simple_dict_value"),
             ).dictOf // TODO LNK-34: or null
         }
       case ClassReferenceAttributeView(slotView, _, classView, identifierView) =>
@@ -97,8 +107,9 @@ class JsonSchemaGenerator(using sv: SchemaView) {
           )
           .arrayOfIf(typeAttribute.slotView.slot.multivalued)
       case EnumAttributeView(slotView, _, enumView) =>
-        Schema.referenceTo("#/$defs/", enumView._enum.name)
-          .arrayOfIf(slotView.slot.multivalued)
+        new Schema(
+          $ref = new Some("#/$defs/".concat(enumView._enum.name)),
+        ).arrayOfIf(slotView.slot.multivalued)
     }
     slotName(slot) -> slotSchema.copy(
       title = slot.slot.title,
@@ -108,7 +119,7 @@ class JsonSchemaGenerator(using sv: SchemaView) {
 
   private def toBigDecimalOpt(x: Option[Anything]): Option[BigDecimal] = x match {
     case Some(v) =>
-      try Some(BigDecimal(v.value.trim))
+      try new Some(BigDecimal(v.value.trim))
       catch {
         case ex if NonFatal(ex) => None
       }
@@ -136,43 +147,57 @@ class JsonSchemaGenerator(using sv: SchemaView) {
       case Success(value) => value
       case Failure(exception) => throw exception
     }
-    val needKeyless = mutable.Set.empty[(MappedClassName, MappedSlotName)]
-    val needValue = mutable.Set.empty[(MappedClassName, MappedSlotName)]
     // If a tree root is defined, only include classes reachable from the tree root (pruning).
     // Otherwise, include all classes in the schema view.
     val query = maybeTreeRoot match {
       case Some(root) => sv.derivedReachabilityQuery(Seq(root), true, false)
-      case None => IncludeAllReachabilityQuery()
+      case _ => IncludeAllReachabilityQuery()
     }
+    val needKeyless = mutable.Set.empty[(MappedClassName, MappedSlotName)]
+    val needValue = mutable.Set.empty[(MappedClassName, MappedSlotName)]
     val defsClasses = for cls <- sv.classes.values if query.reachable(cls) yield {
       val attributes = cls.attributeViews
-      val properties = for attribute <- attributes.values yield {
-        generateSlotSchema(attribute, needKeyless, needValue)
+      val properties = new mutable.LinkedHashMap[MappedClassName, Schema]
+      properties.sizeHint(attributes.values.size)
+      for attribute <- attributes.values do {
+        properties.addOne(generateSlotSchema(attribute, needKeyless, needValue))
       }
-      val requiredSlots = attributes.values.collect {
-        case s if s.slotView.slot.required => s.slotView.name
-      }
-      className(cls) -> objectSchema.copy(
-        required = requiredSlots.toList,
-        properties = properties.to(immutable.ListMap),
-        additionalProperties = Some(if (open) AnySchema.Anything else AnySchema.Nothing),
-        title = cls.cls.title,
-        description = cls.cls.description,
+      val requiredSlots = attributes.values.foldLeft(new mutable.ListBuffer[String]) { (acc, s) =>
+        if (s.slotView.slot.required) acc.addOne(s.slotView.name)
+        else acc
+      }.toList
+      (
+        className(cls),
+        objectSchema.copy(
+          required = requiredSlots,
+          properties = immutable.ListMap.newBuilder.addAll(properties).result(),
+          additionalProperties = new Some(if (open) AnySchema.Anything else AnySchema.Nothing),
+          title = cls.cls.title,
+          description = cls.cls.description,
+        ),
       )
     }
     val defsEnums = for ev <- sv.enums.values yield {
       val enum_ = ev._enum
-      enum_.name -> objectSchema.copy(
-        `type` = Some(List(SchemaType.String)),
-        `enum` = Some(enum_.permissibleValues.keys.map(ExampleSingleValue(_)).toList),
-        title = enum_.title,
-        description = enum_.description,
+      val enumValues = enum_.permissibleValues.keys.foldLeft(new mutable.ListBuffer[ExampleValue]) {
+        (acc, v) => acc.addOne(ExampleSingleValue(v))
+      }.toList
+      (
+        enum_.name,
+        objectSchema.copy(
+          `type` = new Some(List(SchemaType.String)),
+          `enum` = new Some(enumValues),
+          title = enum_.title,
+          description = enum_.description,
+        ),
       )
     }
-
     val baseSchema = maybeTreeRoot match {
       case Some(treeRoot) =>
-        val classSchema = Schema.referenceTo("#/$defs/", className(treeRoot))
+        val classSchema =
+          new Schema(
+            $ref = new Some("#/$defs/".concat(className(treeRoot))),
+          )
         val inlineType = treeRoot.treeRootInlineType(treeRootInlineTypeOverride)
         inlineType match {
           case InlineType.plain => classSchema // object (mandatory)
@@ -182,43 +207,50 @@ class JsonSchemaGenerator(using sv: SchemaView) {
             arraySchema.copy(items = Some(classSchema)) // array of objects
           case InlineType.dict(CollectionForm.CompactDict(key)) =>
             val mappedClassName = className(treeRoot)
-            needKeyless.add(mappedClassName -> slotName(treeRoot.derivedAttributes(key)))
-            Schema.referenceTo(
-              "#/$defs/",
-              mappedClassName.concat("__identifier_optional"),
+            needKeyless.add((mappedClassName, slotName(treeRoot.derivedAttributes(key))))
+            new Schema(
+              $ref = new Some("#/$defs/" + mappedClassName + "__identifier_optional"),
             ).dictOf
           case InlineType.dict(CollectionForm.SimpleDict(key, value)) =>
             val mappedClassName = className(treeRoot)
-            needValue.add(mappedClassName -> slotName(treeRoot.derivedAttributes(value)))
-            Schema.referenceTo(
-              "#/$defs/",
-              mappedClassName.concat("__simple_dict_value"),
+            needValue.add((mappedClassName, slotName(treeRoot.derivedAttributes(value))))
+            new Schema(
+              $ref = new Some("#/$defs/" + mappedClassName + "__simple_dict_value"),
             ).dictOf
         }
       case _ => Schema.Empty
     }
-
     // Generate the needed keyless/value refs
     val defMap = defsClasses.toMap
     val defsKeyless = for (className, idField) <- needKeyless yield {
       val classSchema = defMap(className)
-      className.concat("__identifier_optional") -> classSchema.copy(required =
-        classSchema.required.filter(_ != idField),
+      (
+        className.concat("__identifier_optional"),
+        classSchema.copy(required = classSchema.required.filter(_ != idField)),
       )
     }
     val defsValues = for (className, valueField) <- needValue yield {
       val simpleDict = defMap(className)
-      className.concat("__simple_dict_value") -> simpleDict.properties(valueField).asInstanceOf[
-        Schema,
-      ]
+      (
+        className.concat("__simple_dict_value"),
+        simpleDict.properties(valueField).asInstanceOf[Schema],
+      )
     }
-
+    val defs = immutable.ListMap.newBuilder[String, SchemaLike].addAll({
+      val m = new collection.mutable.LinkedHashMap[String, SchemaLike]
+      m.sizeHint(defsClasses.size + defsEnums.size + defsKeyless.size + defsValues.size)
+      defsClasses.foreach(kv => m.update(kv._1, kv._2))
+      defsEnums.foreach(kv => m.update(kv._1, kv._2))
+      defsKeyless.foreach(kv => m.update(kv._1, kv._2))
+      defsValues.foreach(kv => m.update(kv._1, kv._2))
+      m
+    }).result()
     baseSchema.copy(
-      $schema = Some("https://json-schema.org/draft/2020-12/schema"),
-      $id = Some(sv.root.id.uri(using sv.rootPrefixResolver)),
-      title = Some(sv.root.title.getOrElse(sv.root.name)),
+      $schema = new Some("https://json-schema.org/draft/2020-12/schema"),
+      $id = new Some(sv.root.id.uri(using sv.rootPrefixResolver)),
+      title = sv.root.title.orElse(new Some(sv.root.name)),
       description = sv.root.description,
-      $defs = Some((defsClasses ++ defsEnums ++ defsKeyless ++ defsValues).to(immutable.ListMap)),
+      $defs = new Some(defs),
     )
   }
 
@@ -258,19 +290,19 @@ object JsonSchemaGenerator {
     case BooleanType => booleanSchema
     case DecimalType => numberSchema
     case AnyType => Schema.Empty
-    case DateType => stringSchema.copy(format = Some(SchemaFormat.Date))
-    case DateTimeType => stringSchema.copy(format = Some(SchemaFormat.DateTime))
-    case TimeType => stringSchema.copy(format = Some("time"))
+    case DateType => stringSchema.copy(format = new Some(SchemaFormat.Date))
+    case DateTimeType => stringSchema.copy(format = new Some(SchemaFormat.DateTime))
+    case TimeType => stringSchema.copy(format = new Some("time"))
     case UriOrCurieType =>
       Schema.Empty.copy(anyOf =
         List(
-          stringSchema.copy(format = Some("uri")),
-          stringSchema.copy(format = Some("curie")),
+          stringSchema.copy(format = new Some("uri")),
+          stringSchema.copy(format = new Some("curie")),
         ),
       )
-    case UriType => stringSchema.copy(format = Some("uri"))
-    case CurieType => stringSchema.copy(format = Some("curie"))
-    case NcNameType => stringSchema.copy(format = Some("ncname"))
+    case UriType => stringSchema.copy(format = new Some("uri"))
+    case CurieType => stringSchema.copy(format = new Some("curie"))
+    case NcNameType => stringSchema.copy(format = new Some("ncname"))
     case UnknownType => Schema.Empty
   }
 
@@ -280,7 +312,7 @@ object JsonSchemaGenerator {
   extension (schema: Schema)
     /** Wrap this Schema in an array
       */
-    def arrayOf: Schema = arraySchema.copy(items = Some(schema))
+    def arrayOf: Schema = arraySchema.copy(items = new Some(schema))
 
     /** Wrap this Schema in an array if the condition is true, return the schema unchanged otherwise
       */
@@ -288,7 +320,7 @@ object JsonSchemaGenerator {
 
     /** Wrap this Schema as a dict (object with additional properties set to this schema)
       */
-    def dictOf: Schema = objectSchema.copy(additionalProperties = Some(schema))
+    def dictOf: Schema = objectSchema.copy(additionalProperties = new Some(schema))
 
   private implicit lazy val codec: JsonValueCodec[Schema] = {
     implicit val schemaLikeCodec: JsonValueCodec[SchemaLike] = new JsonValueCodec {

--- a/generator/src/eu/neverblink/linkml/generator/jsonschema/JsonSchemaGenerator.scala
+++ b/generator/src/eu/neverblink/linkml/generator/jsonschema/JsonSchemaGenerator.scala
@@ -70,13 +70,13 @@ class JsonSchemaGenerator(using sv: SchemaView) {
             needKeyless.add(mappedClassName -> slotName(classView.derivedAttributes(key)))
             Schema.referenceTo(
               "#/$defs/",
-              mappedClassName + "__identifier_optional",
+              mappedClassName.concat("__identifier_optional"),
             ).dictOf // TODO LNK-34: or null
           case InlineType.dict(CollectionForm.SimpleDict(key, value)) =>
             needValue.add(mappedClassName -> slotName(classView.derivedAttributes(value)))
             Schema.referenceTo(
               "#/$defs/",
-              mappedClassName + "__simple_dict_value",
+              mappedClassName.concat("__simple_dict_value"),
             ).dictOf // TODO LNK-34: or null
         }
       case ClassReferenceAttributeView(slotView, _, classView, identifierView) =>
@@ -185,14 +185,14 @@ class JsonSchemaGenerator(using sv: SchemaView) {
             needKeyless.add(mappedClassName -> slotName(treeRoot.derivedAttributes(key)))
             Schema.referenceTo(
               "#/$defs/",
-              mappedClassName + "__identifier_optional",
+              mappedClassName.concat("__identifier_optional"),
             ).dictOf
           case InlineType.dict(CollectionForm.SimpleDict(key, value)) =>
             val mappedClassName = className(treeRoot)
             needValue.add(mappedClassName -> slotName(treeRoot.derivedAttributes(value)))
             Schema.referenceTo(
               "#/$defs/",
-              mappedClassName + "__simple_dict_value",
+              mappedClassName.concat("__simple_dict_value"),
             ).dictOf
         }
       case _ => Schema.Empty
@@ -202,13 +202,15 @@ class JsonSchemaGenerator(using sv: SchemaView) {
     val defMap = defsClasses.toMap
     val defsKeyless = for (className, idField) <- needKeyless yield {
       val classSchema = defMap(className)
-      className + "__identifier_optional" -> classSchema.copy(required =
+      className.concat("__identifier_optional") -> classSchema.copy(required =
         classSchema.required.filter(_ != idField),
       )
     }
     val defsValues = for (className, valueField) <- needValue yield {
       val simpleDict = defMap(className)
-      className + "__simple_dict_value" -> simpleDict.properties(valueField).asInstanceOf[Schema]
+      className.concat("__simple_dict_value") -> simpleDict.properties(valueField).asInstanceOf[
+        Schema,
+      ]
     }
 
     baseSchema.copy(

--- a/generator/src/eu/neverblink/linkml/generator/jsonschema/JsonSchemaGenerator.scala
+++ b/generator/src/eu/neverblink/linkml/generator/jsonschema/JsonSchemaGenerator.scala
@@ -274,22 +274,22 @@ object JsonSchemaGenerator {
   /** Translate the [[RuntimeType]] of the provided type view into the appropriate JSON Schema.
     * Provides formats for date-times and URI/CURIE.
     */
-  def typeToRuntime(tv: TypeView): Schema = {
-    val rt = tv.runtimeType
-    if (rt eq StringType) stringSchema
-    else if (rt eq IntegerType) integerSchema
-    else if (rt eq FloatType) numberSchema
-    else if (rt eq DoubleType) numberSchema
-    else if (rt eq BooleanType) booleanSchema
-    else if (rt eq DecimalType) numberSchema
-    else if (rt eq DateType) dateSchema
-    else if (rt eq DateTimeType) datetimeSchema
-    else if (rt eq TimeType) timeSchema
-    else if (rt eq UriOrCurieType) uriOrCurieSchema
-    else if (rt eq UriType) uriSchema
-    else if (rt eq CurieType) curieSchema
-    else if (rt eq NcNameType) ncNameSchema
-    else Schema.Empty
+  def typeToRuntime(tv: TypeView): Schema = tv.runtimeType match {
+    case _: StringType.type => stringSchema
+    case _: IntegerType.type => integerSchema
+    case _: FloatType.type => numberSchema
+    case _: DoubleType.type => numberSchema
+    case _: BooleanType.type => booleanSchema
+    case _: DecimalType.type => numberSchema
+    case _: AnyType.type => Schema.Empty
+    case _: DateType.type => dateSchema
+    case _: DateTimeType.type => datetimeSchema
+    case _: TimeType.type => timeSchema
+    case _: UriOrCurieType.type => uriOrCurieSchema
+    case _: UriType.type => uriSchema
+    case _: CurieType.type => curieSchema
+    case _: NcNameType.type => ncNameSchema
+    case _: UnknownType.type => Schema.Empty
   }
 
   type MappedClassName = String
@@ -298,15 +298,15 @@ object JsonSchemaGenerator {
   extension (schema: Schema)
     /** Wrap this Schema in an array
       */
-    def arrayOf: Schema = arraySchema.copy(items = new Some(schema))
+    inline def arrayOf: Schema = arraySchema.copy(items = new Some(schema))
 
     /** Wrap this Schema in an array if the condition is true, return the schema unchanged otherwise
       */
-    def arrayOfIf(condition: Boolean): Schema = if condition then schema.arrayOf else schema
+    inline def arrayOfIf(condition: Boolean): Schema = if condition then schema.arrayOf else schema
 
     /** Wrap this Schema as a dict (object with additional properties set to this schema)
       */
-    def dictOf: Schema = objectSchema.copy(additionalProperties = new Some(schema))
+    inline def dictOf: Schema = objectSchema.copy(additionalProperties = new Some(schema))
 
   private implicit lazy val codec: JsonValueCodec[Schema] = {
     implicit val schemaLikeCodec: JsonValueCodec[SchemaLike] = new JsonValueCodec {

--- a/generator/src/eu/neverblink/linkml/generator/linkml/LinkMlGenerator.scala
+++ b/generator/src/eu/neverblink/linkml/generator/linkml/LinkMlGenerator.scala
@@ -23,49 +23,62 @@ class LinkMlGenerator(using sv: SchemaView) {
       pruningMode: PruningMode = PruningMode.treeRoot(None),
       skipClassDerivation: Boolean = false,
   ): SchemaDefinitionImpl = {
-    val query = if skipClassDerivation then pruningMode.underivedQuery()
-    else pruningMode.derivedQuery(false, false)
-
+    val query =
+      if (skipClassDerivation) pruningMode.underivedQuery()
+      else pruningMode.derivedQuery(false, false)
     sv.root.asInstanceOf[SchemaDefinitionImpl].copy(
-      imports = Seq.empty,
-      classes = {
-        val toInclude = sv.classes.filter((_, v) => query.reachable(v))
-        if skipClassDerivation then
-          toInclude.map((k, v) =>
-            k -> v.cls.impl.copy(
-              classUri = Some(v.uriOrCurie),
-              fromSchema = Some(v.definingSchema.id),
+      imports = Nil,
+      classes =
+        if (skipClassDerivation) {
+          sv.classes.collect {
+            case (k, v) if query.reachable(v.cls) =>
+              (
+                k,
+                v.cls.impl.copy(
+                  classUri = new Some(v.uriOrCurie),
+                  fromSchema = new Some(v.definingSchema.id),
+                ),
+              )
+          }
+        } else {
+          sv.classes.collect {
+            case (k, v) if query.reachable(v.cls) =>
+              (k, v.materialize)
+          }
+        },
+      types = sv.types.collect {
+        case (k, v) if query.reachable(v._type) =>
+          (
+            k,
+            v._type.impl.copy(
+              typeUri = new Some(v.uriOrCurie),
+              fromSchema = new Some(v.definingSchema.id),
             ),
           )
-        else toInclude.map((k, v) => k -> v.materialize)
       },
-      types = sv.types
-        .collect {
-          case (k, v) if query.reachable(v.inner) =>
-            k -> v.inner.impl.copy(
-              typeUri = Some(v.uriOrCurie),
-              fromSchema = Some(v.definingSchema.id),
-            )
-        },
-      enums = sv.enums
-        .collect {
-          case (k, v) if query.reachable(v.inner) =>
-            k -> v.inner.impl.copy(
-              enumUri = Some(v.uriOrCurie),
-              fromSchema = Some(v.definingSchema.id),
-            )
-        },
+      enums = sv.enums.collect {
+        case (k, v) if query.reachable(v._enum) =>
+          (
+            k,
+            v._enum.impl.copy(
+              enumUri = new Some(v.uriOrCurie),
+              fromSchema = new Some(v.definingSchema.id),
+            ),
+          )
+      },
       slotDefinitions =
-        if skipClassDerivation then
-          sv.slotDefinitions
-            .collect {
-              case (k, v) if query.reachable(v.inner) =>
-                k -> v.inner.impl.copy(
-                  slotUri = Some(v.uriOrCurie),
-                  fromSchema = Some(v.definingSchema.id),
-                )
-            }
-        else Map.empty,
+        if (skipClassDerivation) {
+          sv.slotDefinitions.collect {
+            case (k, v) if query.reachable(v.slot) =>
+              (
+                k,
+                v.slot.impl.copy(
+                  slotUri = new Some(v.uriOrCurie),
+                  fromSchema = new Some(v.definingSchema.id),
+                ),
+              )
+          }
+        } else Map.empty,
     )
   }
 
@@ -96,11 +109,14 @@ class LinkMlGenerator(using sv: SchemaView) {
 
 object LinkMlGenerator {
   // TODO LNK-48: Don't do these horrible casts
-  extension (classDef: ClassDefinition)
-    private def impl: ClassDefinitionImpl = classDef.asInstanceOf
-  extension (typeDef: TypeDefinition) private def impl: TypeDefinitionImpl = typeDef.asInstanceOf
-  extension (slotDef: SlotDefinition) private def impl: SlotDefinitionImpl = slotDef.asInstanceOf
-  extension (enumDef: EnumDefinition) private def impl: EnumDefinitionImpl = enumDef.asInstanceOf
+  extension (inline classDef: ClassDefinition)
+    private inline def impl: ClassDefinitionImpl = classDef.asInstanceOf
+  extension (inline typeDef: TypeDefinition)
+    private inline def impl: TypeDefinitionImpl = typeDef.asInstanceOf
+  extension (inline slotDef: SlotDefinition)
+    private inline def impl: SlotDefinitionImpl = slotDef.asInstanceOf
+  extension (inline enumDef: EnumDefinition)
+    private inline def impl: EnumDefinitionImpl = enumDef.asInstanceOf
 
   /** Serialization format for LinkML models
     */

--- a/generator/src/eu/neverblink/linkml/generator/rdf/Vocabularies.scala
+++ b/generator/src/eu/neverblink/linkml/generator/rdf/Vocabularies.scala
@@ -1,7 +1,7 @@
 package eu.neverblink.linkml.generator.rdf
 
 abstract class Vocabulary(val prefix: String) {
-  def get(suffix: String): Iri = Iri(prefix + suffix)
+  def get(suffix: String): Iri = new Iri(prefix.concat(suffix))
 }
 
 object XmlSchema extends Vocabulary("http://www.w3.org/2001/XMLSchema#") {

--- a/generator/src/eu/neverblink/linkml/generator/rdfs/RdfsGenerator.scala
+++ b/generator/src/eu/neverblink/linkml/generator/rdfs/RdfsGenerator.scala
@@ -66,12 +66,12 @@ class RdfsGenerator(using sv: SchemaView) extends RdfGenerator {
     // Emit each enum as an rdfs:Class (its URI controlled by enum_uri), and each of its
     // permissible values as an instance of that class.
     enums.values.foreach { e =>
-      given PrefixResolver = e.definingPrefixResolver
+      val prefixResolver = e.definingPrefixResolver
       val enumIri = Iri(e.uriStr)
       sink.triple(enumIri, Rdf.`type`, Rdfs.Class)
       emitCommonMetadata(sink, enumIri, e._enum)
       e.derivedValues.foreach { (pv, meaning) =>
-        val pvIri = Iri(meaning.uri)
+        val pvIri = Iri(meaning.uri(using prefixResolver))
         sink.triple(pvIri, Rdf.`type`, enumIri)
         emitCommonMetadata(sink, pvIri, pv)
       }

--- a/generator/src/eu/neverblink/linkml/generator/rdfs/RdfsGenerator.scala
+++ b/generator/src/eu/neverblink/linkml/generator/rdfs/RdfsGenerator.scala
@@ -2,7 +2,6 @@ package eu.neverblink.linkml.generator.rdfs
 
 import eu.neverblink.linkml.generator.rdf.*
 import eu.neverblink.linkml.metamodel.CommonMetadata
-import eu.neverblink.linkml.runtime.PrefixResolver
 import eu.neverblink.linkml.schemaview.SchemaView
 
 class RdfsGenerator(using sv: SchemaView) extends RdfGenerator {

--- a/generator/src/eu/neverblink/linkml/generator/rdfs/RdfsGenerator.scala
+++ b/generator/src/eu/neverblink/linkml/generator/rdfs/RdfsGenerator.scala
@@ -47,13 +47,15 @@ class RdfsGenerator(using sv: SchemaView) extends RdfGenerator {
           sink.triple(classNameIri, Rdfs.subClassOf, Iri(e.uriStr))
         }
       }
-      c.derivedAttributes.values.filter(!_.inner.identifier).foreach { s =>
-        val propertyNameIri = Iri(s.uriStr)
-        sink.triple(propertyNameIri, Rdf.`type`, Rdf.Property)
-        emitCommonMetadata(sink, propertyNameIri, s.slot)
-        sink.triple(propertyNameIri, Rdfs.domain, classNameIri)
-        s.derivedRange.resolve.foreach { e =>
-          sink.triple(propertyNameIri, Rdfs.range, Iri(e.uriStr))
+      c.derivedAttributes.values.foreach { s =>
+        if (!s.inner.identifier) {
+          val propertyNameIri = Iri(s.uriStr)
+          sink.triple(propertyNameIri, Rdf.`type`, Rdf.Property)
+          emitCommonMetadata(sink, propertyNameIri, s.slot)
+          sink.triple(propertyNameIri, Rdfs.domain, classNameIri)
+          s.derivedRange.resolve.foreach { e =>
+            sink.triple(propertyNameIri, Rdfs.range, Iri(e.uriStr))
+          }
         }
       }
     }

--- a/generator/src/eu/neverblink/linkml/generator/scala/ScalaGenerator.scala
+++ b/generator/src/eu/neverblink/linkml/generator/scala/ScalaGenerator.scala
@@ -582,8 +582,7 @@ object ScalaGenerator {
               |def combineInherited(other: ${name}Impl, $combineRange): ${name}Impl =
               |  copy(
               |    ${fields
-                  .filter(_.inherited)
-                  .map(_.generateCombiningFunctionPart)
+                  .collect { case f if f.inherited => f.generateCombiningFunctionPart }
                   .mkString(",\n")}
               |  )
               |""".stripMargin
@@ -605,8 +604,8 @@ object ScalaGenerator {
         inheritsFrom.mkString(" extends ", ", ", "")
       } else ""
       val interfaceBody = fields
-        .filter(x => interfaceFields.contains(x.name))
-        .map(_.generateInterfaceField).mkString("\n")
+        .collect { case x if interfaceFields.contains(x.name) => x.generateInterfaceField }
+        .mkString("\n")
       // Declared on the interface so callers can infer without knowing the implementation type.
       // The implementation narrows the return type to its own `${name}Impl`.
       val inferDeclaration =

--- a/generator/src/eu/neverblink/linkml/generator/scala/ScalaGenerator.scala
+++ b/generator/src/eu/neverblink/linkml/generator/scala/ScalaGenerator.scala
@@ -322,7 +322,7 @@ final class ScalaGenerator(using sv: SchemaView) {
   private def isSingleValuedString(attribute: AttributeView): Boolean =
     attribute match {
       case TypeAttributeView(slotView, _, typeView) =>
-        typeView.runtimeType == StringType && (InlineType(slotView) match {
+        (typeView.runtimeType eq StringType) && (InlineType(slotView) match {
           case InlineType.plain | InlineType.optional => true
           case _ => false
         })

--- a/generator/src/eu/neverblink/linkml/generator/scala/ScalaGenerator.scala
+++ b/generator/src/eu/neverblink/linkml/generator/scala/ScalaGenerator.scala
@@ -43,7 +43,7 @@ final class ScalaGenerator(using sv: SchemaView) {
       val className = Case.PascalCase(cls.name)
       val interfaceFields =
         (cls.slots.map(_.value) ++ cls.attributes.keys ++ cls.slotUsage.keys).map(slotName).toSet
-      className + ".scala" -> (
+      className.concat(".scala") -> (
         if classView.uriStr == "https://w3id.org/linkml/Any" then
           typeDef(
             pkg,
@@ -99,7 +99,7 @@ final class ScalaGenerator(using sv: SchemaView) {
             ScalaDoc(en, ev.definingSchema.id),
           )
             .generate()
-        Some(enumName + ".scala" -> enumInfo)
+        Some(enumName.concat(".scala") -> enumInfo)
       }
     }
 
@@ -170,8 +170,7 @@ final class ScalaGenerator(using sv: SchemaView) {
     */
   private def slotName(snakeCase: String): String = {
     val camel = Case.camelCase(snakeCase)
-    if scalaKeywords.contains(camel)
-    then "`" + camel + "`"
+    if (scalaKeywords.contains(camel)) s"`$camel`"
     else camel
   }
 
@@ -603,7 +602,7 @@ object ScalaGenerator {
         if traitInterface then "trait"
         else "abstract class"
       val inheritanceList = if inheritsFrom.nonEmpty then {
-        " extends " + inheritsFrom.mkString(", ")
+        inheritsFrom.mkString(" extends ", ", ", "")
       } else ""
       val interfaceBody = fields
         .filter(x => interfaceFields.contains(x.name))

--- a/generator/src/eu/neverblink/linkml/generator/scala/ScalaGenerator.scala
+++ b/generator/src/eu/neverblink/linkml/generator/scala/ScalaGenerator.scala
@@ -32,7 +32,6 @@ final class ScalaGenerator(using sv: SchemaView) {
     */
   private def generateClasses(pkg: String): Iterable[(String, String)] = {
     for classView <- sv.classes.values yield {
-      given PrefixResolver = classView.definingPrefixResolver
       val cls = classView.cls
       val collectionForm = CollectionForm.of(classView)
       val scalaFields = for attribute <- classView.attributeViews.values.toIndexedSeq yield {
@@ -43,13 +42,14 @@ final class ScalaGenerator(using sv: SchemaView) {
       val className = Case.PascalCase(cls.name)
       val interfaceFields =
         (cls.slots.map(_.value) ++ cls.attributes.keys ++ cls.slotUsage.keys).map(slotName).toSet
+      val prefixResolver = classView.definingPrefixResolver
       className.concat(".scala") -> (
         if classView.uriStr == "https://w3id.org/linkml/Any" then
           typeDef(
             pkg,
             Case.PascalCase(cls.name),
             "LinkmlAny",
-            ScalaDoc(cls, classView.definingSchema.id),
+            ScalaDoc(cls, classView.definingSchema.id)(using prefixResolver),
           )
         else
           ScalaClassInfo(
@@ -62,7 +62,7 @@ final class ScalaGenerator(using sv: SchemaView) {
             shouldBeTrait,
             isSlotDefinitionClass,
             makeInferredFields(classView),
-            ScalaDoc(classView.materialize, classView.definingSchema.id),
+            ScalaDoc(classView.materialize, classView.definingSchema.id)(using prefixResolver),
           ).print
       )
     }
@@ -76,17 +76,17 @@ final class ScalaGenerator(using sv: SchemaView) {
     */
   private def generateEnums(pkg: String): Iterable[(String, String)] =
     sv.enums.values.flatMap { ev =>
-      given PrefixResolver = ev.definingPrefixResolver
       val en = ev._enum
       if (en.permissibleValues.isEmpty) None
       else {
+        val prefixResolver = ev.definingPrefixResolver
         val enumName = Case.PascalCase(en.name)
         val enumCases = en.permissibleValues.values.map(v =>
           ScalaEnumCase(
             caseName = v.text,
             objectName = Case.PascalCase(v.text),
             enumName = enumName,
-            doc = ScalaDoc(v, ev.definingSchema.id),
+            doc = ScalaDoc(v, ev.definingSchema.id)(using prefixResolver),
           ),
         ).toSeq
         val enumInfo =
@@ -96,7 +96,7 @@ final class ScalaGenerator(using sv: SchemaView) {
             enumCases,
             !en.`abstract`,
             en.mixin,
-            ScalaDoc(en, ev.definingSchema.id),
+            ScalaDoc(en, ev.definingSchema.id)(using prefixResolver),
           )
             .generate()
         Some(enumName.concat(".scala") -> enumInfo)
@@ -132,12 +132,12 @@ final class ScalaGenerator(using sv: SchemaView) {
     sv.types.values.collect {
       case tv if !tv.isPrimitive =>
         val name = Case.PascalCase(tv._type.name)
-        given PrefixResolver = tv.definingPrefixResolver
+        val prefixResolver = tv.definingPrefixResolver
         s"$name.scala" -> typeDef(
           pkg,
           name,
           typeToRuntime(tv),
-          ScalaDoc(tv._type, tv.definingSchema.id),
+          ScalaDoc(tv._type, tv.definingSchema.id)(using prefixResolver),
         )
     }
   }

--- a/generator/src/eu/neverblink/linkml/generator/scala/ScalaGenerator.scala
+++ b/generator/src/eu/neverblink/linkml/generator/scala/ScalaGenerator.scala
@@ -3,6 +3,7 @@ package eu.neverblink.linkml.generator.scala
 import eu.neverblink.linkml.generator.util.*
 import eu.neverblink.linkml.metamodel.*
 import eu.neverblink.linkml.runtime.*
+import eu.neverblink.linkml.runtime.FastUtils.*
 import eu.neverblink.linkml.schemaview.*
 import eu.neverblink.linkml.schemaview.expression.StringInterpolationExpression
 import fastparse.Parsed
@@ -729,12 +730,11 @@ object ScalaGenerator {
         pr: PrefixResolver,
     ): ScalaDoc = {
       new ScalaDoc(
-        metadata.description.map(_.capitalize).getOrElse(""),
+        metadata.description.foldFast("")(_.capitalize),
         metadata.seeAlso.map(_.uri) ++
-          metadata.aliases.reduceOption(_ + ", " + _).map("Aliases: " + _) ++
-          Seq("From schema: " + fromSchema.uri),
-        metadata.notes.map(_.capitalize) ++
-          metadata.comments.map(_.capitalize),
+          metadata.aliases.reduceOption(_ + ", " + _).mapFast("Aliases: ".concat) ++
+          Seq("From schema: ".concat(fromSchema.uri)),
+        (metadata.notes ++ metadata.comments).map(_.capitalize),
         metadata.todos.map(_.capitalize),
         metadata.examples.flatMap(ex =>
           for
@@ -778,10 +778,7 @@ object ScalaGenerator {
   ):
     /** Generate code for a case class field string with annotations and default values */
     def generateCaseClassField: String = {
-      val field = default match {
-        case Some(defaultValue) => s"$name: $typeName = $defaultValue,"
-        case _ => s"$name: $typeName,"
-      }
+      val field = default.foldFast(s"$name: $typeName,")(dv => s"$name: $typeName = $dv,")
       s"""${annotations.mkString("\n")}
          |$field
          |""".stripMargin.strip()

--- a/generator/src/eu/neverblink/linkml/generator/shacl/ShaclGenerator.scala
+++ b/generator/src/eu/neverblink/linkml/generator/shacl/ShaclGenerator.scala
@@ -137,10 +137,13 @@ class ShaclGenerator(using sv: SchemaView) extends RdfGenerator {
         Seq(Rdf.`type`) ++ c.identifier.map(id => Iri(id.uriStr)),
       )
       sink.triple(classNameIri, Shacl.ignoredProperties, ignoredPropertiesListHead)
-      var order = 0
-      c.derivedAttributes.values.filter(!_.inner.identifier).foreach { x =>
-        processSlot(sink, x, order, classNameIri)
-        order += 1
+      c.derivedAttributes.values.foreach {
+        var order = 0
+        x =>
+          if (!x.inner.identifier) {
+            processSlot(sink, x, order, classNameIri)
+            order += 1
+          }
       }
       sink.triple(classNameIri, Shacl.targetClass, classNameIri)
     }

--- a/generator/src/eu/neverblink/linkml/generator/shacl/ShaclGenerator.scala
+++ b/generator/src/eu/neverblink/linkml/generator/shacl/ShaclGenerator.scala
@@ -2,6 +2,7 @@ package eu.neverblink.linkml.generator.shacl
 
 import eu.neverblink.linkml.generator.rdf.*
 import eu.neverblink.linkml.metamodel.SlotExpression
+import eu.neverblink.linkml.runtime.FastUtils.*
 import eu.neverblink.linkml.runtime.Reference
 import eu.neverblink.linkml.schemaview.*
 
@@ -24,25 +25,25 @@ class ShaclGenerator(using sv: SchemaView) extends RdfGenerator {
   ): Unit = {
     // TODO LNK-129 HACK: Skip the main range if any boolean slot is defined.
     if slotExpression.anyOf.isEmpty then
-      slotExpression.range.getOrElse(sv.getDefaultRange(slotView.definingSchema))
+      slotExpression.range.getOrElseFast(sv.getDefaultRange(slotView.definingSchema))
         .asInstanceOf[Reference[ElementView[?, ?]]].resolve.foreach {
           case typeView: TypeView =>
             val isIri = typeView.isIri || slotExpression.implicitPrefix.isDefined
             if !isIri then
-              sink.triple(subject, Shacl.datatype, Iri(typeView.uriStr))
+              sink.triple(subject, Shacl.datatype, new Iri(typeView.uriStr))
               sink.triple(subject, Shacl.nodeKind, Shacl.Literal)
             else sink.triple(subject, Shacl.nodeKind, Shacl.IRI)
           case classView: ClassView =>
             val cdUri = classView.uriStr
             val isLinkmlAny = cdUri == "https://w3id.org/linkml/Any"
             if (!isLinkmlAny) {
-              sink.triple(subject, Shacl.`class`, Iri(cdUri))
+              sink.triple(subject, Shacl.`class`, new Iri(cdUri))
               sink.triple(subject, Shacl.nodeKind, Shacl.BlankNodeOrIRI)
             }
           case enumView: EnumView =>
             val permissibleValues =
               enumView.derivedValues.map(value => {
-                Iri(value.meaning.uri(using enumView.definingPrefixResolver))
+                new Iri(value.meaning.uri(using enumView.definingPrefixResolver))
               })
             val rdfListHead = addList(sink, permissibleValues)
             sink.triple(subject, Shacl.in, rdfListHead)
@@ -77,9 +78,8 @@ class ShaclGenerator(using sv: SchemaView) extends RdfGenerator {
     val slot = s.slot
     val property = blankNode()
     sink.triple(propertyDomain, Shacl.property, property)
-    slot.description match {
-      case Some(d) => sink.triple(property, Shacl.description, Literal(d, XmlSchema.string))
-      case _ =>
+    slot.description.foreachFast { d =>
+      sink.triple(property, Shacl.description, Literal(d, XmlSchema.string))
     }
     // TODO LNK-129: N-arity has to be done on the top-level-only,
     //  as SHACL boolean operators attached to a PropertyShape have to be NodeShapes
@@ -88,7 +88,7 @@ class ShaclGenerator(using sv: SchemaView) extends RdfGenerator {
     //  leaves PropertyShapes.
     if (!slot.multivalued) sink.triple(property, Shacl.maxCount, Literal.one)
     if (slot.required) sink.triple(property, Shacl.minCount, Literal.one)
-    sink.triple(property, Shacl.path, Iri(s.uriStr))
+    sink.triple(property, Shacl.path, new Iri(s.uriStr))
     processSlotExpr(sink, s, slot, property)
     sink.triple(property, Shacl.order, Literal(order.toString, XmlSchema.integer))
   }
@@ -124,17 +124,16 @@ class ShaclGenerator(using sv: SchemaView) extends RdfGenerator {
       else sv.classes
 
     classes.values.foreach { c =>
-      val classNameIri = Iri(c.uriStr)
+      val classNameIri = new Iri(c.uriStr)
       sink.triple(classNameIri, Rdf.`type`, Shacl.NodeShape)
-      c.cls.description match {
-        case Some(d) => sink.triple(classNameIri, Rdfs.comment, Literal(d, XmlSchema.string))
-        case _ =>
+      c.cls.description.foreachFast { d =>
+        sink.triple(classNameIri, Rdfs.comment, Literal(d, XmlSchema.string))
       }
       val closed = !(enforceOpenShapes || c.cls.`abstract` || c.cls.mixin)
       sink.triple(classNameIri, Shacl.closed, Literal(closed.toString, XmlSchema.boolean))
       val ignoredPropertiesListHead = addList(
         sink,
-        Seq(Rdf.`type`) ++ c.identifier.map(id => Iri(id.uriStr)),
+        Seq(Rdf.`type`) ++ c.identifier.mapFast(id => new Iri(id.uriStr)),
       )
       sink.triple(classNameIri, Shacl.ignoredProperties, ignoredPropertiesListHead)
       c.derivedAttributes.values.foreach {

--- a/generator/src/eu/neverblink/linkml/generator/tableschema/TableSchemaGenerator.scala
+++ b/generator/src/eu/neverblink/linkml/generator/tableschema/TableSchemaGenerator.scala
@@ -4,34 +4,34 @@ import com.github.plokhotnyuk.jsoniter_scala.core.{JsonValueCodec, WriterConfig,
 import com.github.plokhotnyuk.jsoniter_scala.macros.{CodecMakerConfig, JsonCodecMaker}
 import eu.neverblink.linkml.generator.tableschema.FieldDescriptor.types
 import eu.neverblink.linkml.schemaview.*
+import eu.neverblink.linkml.runtime.FastUtils.*
 
 class TableSchemaGenerator(using sv: SchemaView) {
 
   /** Map the [[RuntimeType]] to the appropriate Table Schema (type, format) tuple
     */
-  private def remapType(rt: RuntimeType): (String, String) =
-    rt match {
-      case StringType => (types.string, "default")
-      case IntegerType => (types.integer, "default")
-      case FloatType => (types.number, "default")
-      case DoubleType => (types.number, "default")
-      case BooleanType => (types.boolean, "default")
-      case DecimalType => (types.number, "default")
-      case AnyType => (types.any, "default")
-      case DateType => (types.date, "any")
-      case DateTimeType => (types.datetime, "any")
-      case TimeType => (types.time, "any")
-      case UriOrCurieType => (types.string, "default")
-      case UriType => (types.string, "uri")
-      case CurieType => (types.string, "default")
-      case NcNameType => (types.string, "default")
-      case UnknownType => (types.any, "default")
-    }
+  private def remapType(rt: RuntimeType): (String, String) = rt match {
+    case _: StringType.type => (types.string, "default")
+    case _: IntegerType.type => (types.integer, "default")
+    case _: FloatType.type => (types.number, "default")
+    case _: DoubleType.type => (types.number, "default")
+    case _: BooleanType.type => (types.boolean, "default")
+    case _: DecimalType.type => (types.number, "default")
+    case _: AnyType.type => (types.any, "default")
+    case _: DateType.type => (types.date, "any")
+    case _: DateTimeType.type => (types.datetime, "any")
+    case _: TimeType.type => (types.time, "any")
+    case _: UriOrCurieType.type => (types.string, "default")
+    case _: UriType.type => (types.string, "uri")
+    case _: CurieType.type => (types.string, "default")
+    case _: NcNameType.type => (types.string, "default")
+    case _: UnknownType.type => (types.any, "default")
+  }
 
   /** Get the name of the slot, respecting alias, and LinkML casing rules
     */
   def slotName(slotView: SlotView): String =
-    slotView.slot.alias.getOrElse(Case.deSpaceCase(slotView.slot.name))
+    slotView.slot.alias.getOrElseFast(Case.deSpaceCase(slotView.slot.name))
 
   /** Generate the Table Schema
     *
@@ -43,7 +43,7 @@ class TableSchemaGenerator(using sv: SchemaView) {
     */
   def generate(treeRootOverride: Option[String] = None): TableDescriptor = {
     val root: ClassView = sv.treeRootWithOverride(treeRootOverride)
-      .get.getOrElse(throw RuntimeException("No tree root - can't generate table schema"))
+      .get.getOrElseFast(throw RuntimeException("No tree root - can't generate table schema"))
     val fields =
       for slotView <- root.derivedAttributes.values.toSeq.sortBy(s => (s.slot.rank, s.slot.name))
       yield {
@@ -51,7 +51,7 @@ class TableSchemaGenerator(using sv: SchemaView) {
           name = slotName(slotView),
           title = slotView.slot.title,
           description = slotView.slot.description,
-          constraints = Some(Constraints(required = Some(slotView.slot.required))),
+          constraints = new Some(new Constraints(required = new Some(slotView.slot.required))),
         )
         slotView.derivedRange.resolve.get match {
           case cls: ClassView =>
@@ -65,51 +65,51 @@ class TableSchemaGenerator(using sv: SchemaView) {
               cls.identifier.get.derivedRange.resolve.get match {
                 case tv: TypeView =>
                   val (type_, format) = remapType(tv.runtimeType)
-                  base.copy(`type` = type_, rdfType = Some(cls.uriStr), format = format)
+                  base.copy(`type` = type_, rdfType = new Some(cls.uriStr), format = format)
                 case _ => throw RuntimeException("ID slot is not type")
               }
             } else
               InlineType(slotView) match {
                 case InlineType.list =>
-                  base.copy(`type` = types.array, rdfType = Some(cls.uriStr))
+                  base.copy(`type` = types.array, rdfType = new Some(cls.uriStr))
                 // plain is JSON objects, optional is JSON object or null, dict inlines are JSON objects
                 case _ =>
-                  base.copy(`type` = types.`object`, rdfType = Some(cls.uriStr))
+                  base.copy(`type` = types.`object`, rdfType = new Some(cls.uriStr))
               }
           case tv: TypeView =>
             val (type_, format) = remapType(tv.runtimeType)
             if !slotView.slot.multivalued then
               base.copy(
                 `type` = type_,
-                rdfType = Some(tv.uriStr),
+                rdfType = new Some(tv.uriStr),
                 format = format,
-                constraints = base.constraints.map(
+                constraints = base.constraints.mapFast(
                   _.copy(
-                    pattern = slotView.slot.pattern.orElse(tv._type.pattern),
-                    maximum =
-                      slotView.slot.maximumValue.orElse(tv._type.maximumValue).map(_.value.strip()),
-                    minimum =
-                      slotView.slot.minimumValue.orElse(tv._type.minimumValue).map(_.value.strip()),
+                    pattern = slotView.slot.pattern.orElseFast(tv._type.pattern),
+                    maximum = slotView.slot.maximumValue
+                      .orElseFast(tv._type.maximumValue).mapFast(_.value.strip()),
+                    minimum = slotView.slot.minimumValue
+                      .orElseFast(tv._type.minimumValue).mapFast(_.value.strip()),
                   ),
                 ),
               )
             else
               base.copy(
                 `type` = types.array,
-                rdfType = Some(tv.uriStr),
+                rdfType = new Some(tv.uriStr),
               )
           case ev: EnumView =>
-            val values = Some(ev.toMeaning.keys.toSeq)
+            val values = new Some(ev.toMeaning.keys.toSeq)
             if !slotView.slot.multivalued then
               base.copy(
                 `type` = types.string,
-                rdfType = Some(ev.uriStr),
-                constraints = base.constraints.map(_.copy(`enum` = values)),
+                rdfType = new Some(ev.uriStr),
+                constraints = base.constraints.mapFast(_.copy(`enum` = values)),
               )
             else
               base.copy(
                 `type` = types.array,
-                rdfType = Some(ev.uriStr),
+                rdfType = new Some(ev.uriStr),
                 // no multivalued enums in table schema...
               )
           case _ => throw RuntimeException(s"Couldn't map range ${slotView.derivedRange}")

--- a/generator/src/eu/neverblink/linkml/generator/util/PruningMode.scala
+++ b/generator/src/eu/neverblink/linkml/generator/util/PruningMode.scala
@@ -2,6 +2,7 @@ package eu.neverblink.linkml.generator.util
 
 import eu.neverblink.linkml.metamodel.TypeDefinition
 import eu.neverblink.linkml.runtime.Reference
+import eu.neverblink.linkml.runtime.FastUtils.*
 import eu.neverblink.linkml.schemaview.{
   Case,
   ElementView,
@@ -34,16 +35,16 @@ enum PruningMode:
     lazy val defaultRanges = sv.schemas.map(
       _
         .defaultRange
-        .getOrElse(Reference[TypeDefinition]("string"))
+        .getOrElseFast(Reference[TypeDefinition]("string"))
         .asInstanceOf[Reference[TypeView]],
     ).flatMap(_.resolve)
 
     this match {
       case PruningMode.treeRoot(ovr) =>
-        defaultRanges ++ (sv.treeRootWithOverride(ovr).get match {
-          case Some(value) => Seq(value)
-          case None => sv.root.classes.keys.map(sv.classes.apply)
-        })
+        sv.treeRootWithOverride(ovr).get
+          .foldFast(defaultRanges ++ sv.root.classes.keys.map(sv.classes.apply)) { value =>
+            defaultRanges :+ value
+          }
       case PruningMode.schemaRoot => defaultRanges ++ sv.root.classes.keys.map(sv.classes.apply)
       case PruningMode.skip => Seq.empty
     }

--- a/runtime/src/eu/neverblink/linkml/runtime/Combining.scala
+++ b/runtime/src/eu/neverblink/linkml/runtime/Combining.scala
@@ -22,12 +22,12 @@ def combineOption[T](o1: Option[T], o2: Option[T], combineSome: (T, T) => T): Op
 
 /** Combine two [[Seq]]s if they're distinct
   */
-def combineSeq[T](v1: Seq[T], v2: Seq[T]): Seq[T] = if v1 == v2 then v1 else v1 ++ v2
+def combineSeq[T](v1: Seq[T], v2: Seq[T]): Seq[T] = if v2.isEmpty || v1 == v2 then v1 else v1.appendedAll(v2)
 
 /** Combine two [[Map]]s if they're distinct
   */
 def combineMap[T](v1: Map[String, T], v2: Map[String, T]): Map[String, T] =
-  if v1 == v2 then v1 else v1 ++ v2
+  if v2.isEmpty || v1 == v2 then v1 else v1.concat(v2)
 
 /** Combine values for the `maximum_value` metaslot
   */

--- a/runtime/src/eu/neverblink/linkml/runtime/Combining.scala
+++ b/runtime/src/eu/neverblink/linkml/runtime/Combining.scala
@@ -1,6 +1,7 @@
 package eu.neverblink.linkml.runtime
 
 import scala.annotation.unused
+import eu.neverblink.linkml.runtime.FastUtils.*
 
 /** Combine two optional values into one with a handler for combining them if both are defined and
   * are not identical
@@ -11,13 +12,11 @@ import scala.annotation.unused
   *   The combined optional value
   */
 def combineOption[T](o1: Option[T], o2: Option[T], combineSome: (T, T) => T): Option[T] =
-  o1 match {
-    case Some(v1) =>
-      o2 match {
-        case Some(v2) if v1 != v2 => new Some(combineSome(v1, v2))
-        case _ => o1
-      }
-    case _ => o2
+  o1.foldFast(o2) { v1 =>
+    o2.foldFast(o1) { v2 =>
+      if (v1 != v2) new Some(combineSome(v1, v2))
+      else o1
+    }
   }
 
 /** Combine two [[Seq]]s if they're distinct
@@ -33,22 +32,22 @@ def combineMap[T](v1: Map[String, T], v2: Map[String, T]): Map[String, T] =
 /** Combine values for the `maximum_value` metaslot
   */
 // TODO COMPAT
-def combineMax(v1: LinkmlAny, @unused v2: LinkmlAny): LinkmlAny = v1
+inline def combineMax(v1: LinkmlAny, @unused v2: LinkmlAny): LinkmlAny = v1
 
 /** Combine values for the `minimum_value` metaslot
   */
 // TODO COMPAT
-def combineMin(v1: LinkmlAny, @unused v2: LinkmlAny): LinkmlAny = v1
+inline def combineMin(v1: LinkmlAny, @unused v2: LinkmlAny): LinkmlAny = v1
 
 /** Combine values for the `pattern` metaslot
   */
 // TODO COMPAT
-def combinePattern(v1: String, @unused v2: String): String = v1
+inline def combinePattern(v1: String, @unused v2: String): String = v1
 
 /** Combine boolean values with an OR operation
   */
-def combineBoolean(v1: Boolean, v2: Boolean): Boolean = v1 || v2
+inline def combineBoolean(v1: Boolean, v2: Boolean): Boolean = v1 || v2
 
 /** Fallback combine function that simply returns the first value
   */
-def combineFallback[T](v1: T, @unused v2: T): T = v1
+inline def combineFallback[T](v1: T, @unused v2: T): T = v1

--- a/runtime/src/eu/neverblink/linkml/runtime/Combining.scala
+++ b/runtime/src/eu/neverblink/linkml/runtime/Combining.scala
@@ -22,7 +22,8 @@ def combineOption[T](o1: Option[T], o2: Option[T], combineSome: (T, T) => T): Op
 
 /** Combine two [[Seq]]s if they're distinct
   */
-def combineSeq[T](v1: Seq[T], v2: Seq[T]): Seq[T] = if v2.isEmpty || v1 == v2 then v1 else v1.appendedAll(v2)
+def combineSeq[T](v1: Seq[T], v2: Seq[T]): Seq[T] =
+  if v2.isEmpty || v1 == v2 then v1 else v1.appendedAll(v2)
 
 /** Combine two [[Map]]s if they're distinct
   */

--- a/runtime/src/eu/neverblink/linkml/runtime/FastUtils.scala
+++ b/runtime/src/eu/neverblink/linkml/runtime/FastUtils.scala
@@ -1,36 +1,131 @@
 package eu.neverblink.linkml.runtime
 
+/** A collection of high-performance, macro-expanded extension methods for `Option`.
+  *
+  * The semantics of these functions are identical to the standard `Option` methods (e.g., `mapFast`
+  * does exactly what `map` does, `getOrElseFast` exactly mirrors `getOrElse`), but they are
+  * appended with the `Fast` suffix to indicate their zero-allocation nature.
+  *
+  * By leveraging Scala 3's `inline` keyword, these methods expand directly at the call site at
+  * compile time. This eliminates the runtime overhead of lambda creation, closure allocation, and
+  * virtual method dispatch.
+  *
+  * Limitations and usage differences compared to the standard `Option` methods:
+  *
+  *   1. **Cannot be passed as values:** Because these are `inline def`s, they exist only at compile
+  *      time. You cannot partially apply them or pass them around as first-class function values
+  *      (e.g., `val f = opt.mapFast _` will fail to compile).
+  *   2. **Bytecode Bloat:** Overusing these methods in non-critical (cold) paths will needlessly
+  *      increase the size of your compiled bytecode.
+  */
 object FastUtils {
+
   extension [A](inline opt: Option[A]) {
+
+    /** Retrieves the option's value if present, otherwise evaluates the fallback value.
+      *
+      * Both the option and the default value are inlined, ensuring no by-name parameter closures
+      * are allocated.
+      *
+      * @param default
+      *   The fallback value to return if the option is empty.
+      * @return
+      *   The value of the option if it is `Some`, otherwise `default`.
+      */
     inline def getOrElseFast(inline default: A): A = opt match {
       case Some(a) => a
       case _ => default
     }
 
+    /** Applies a function to the value inside the option and returns the resulting option.
+      *
+      * The mapping function `f` is inlined, preventing the allocation of a `Function1` object.
+      *
+      * @tparam B
+      *   The type of the value in the returned option.
+      * @param f
+      *   The transformation function returning a new `Option`.
+      * @return
+      *   An `Option` containing the result of applying `f`, or `None` if this is empty.
+      */
     inline def flatMapFast[B](inline f: A => Option[B]): Option[B] = opt match {
       case Some(a) => f(a)
       case _ => None
     }
 
+    /** Applies a fallback value if the option is empty, or a mapping function if it contains a
+      * value.
+      *
+      * This is a zero-allocation alternative to `opt.map(f).getOrElse(ifEmpty)`. Both the empty
+      * case and the transformation function are inlined directly into the call site.
+      *
+      * @tparam B
+      *   The return type of the fold operation.
+      * @param ifEmpty
+      *   The value to return if the option is `None`.
+      * @param f
+      *   The transformation function to apply if the option is `Some`.
+      * @return
+      *   The result of applying `f` to the value, or `ifEmpty`.
+      */
     inline def foldFast[B](inline ifEmpty: B)(inline f: A => B): B = opt match {
       case Some(a) => f(a)
       case _ => ifEmpty
     }
 
+    /** Executes a side-effecting function on the value if the option is not empty.
+      *
+      * The effect function `f` is inlined, making this equivalent to writing a manual `if`
+      * statement or pattern match without the function allocation overhead.
+      *
+      * @param f
+      *   The side-effecting procedure to apply.
+      */
     inline def foreachFast[B](inline f: A => Unit): Unit = opt match {
       case Some(a) => f(a)
       case _ =>
     }
 
+    /** Transforms the value inside the option using the provided function.
+      *
+      * In addition to inlining the mapping function, this implementation uses `new Some(...)`
+      * directly instead of `Some.apply(...)`, saving a microscopic amount of method dispatch
+      * overhead.
+      *
+      * @tparam B
+      *   The type of the newly mapped value.
+      * @param f
+      *   The transformation function to apply.
+      * @return
+      *   A new `Option` containing the mapped value, or `None` if originally empty.
+      */
     inline def mapFast[B](inline f: A => B): Option[B] = opt match {
       case Some(a) => new Some(f(a))
       case _ => None
     }
 
+    /** Returns this option if it is non-empty, otherwise evaluates and returns the fallback option.
+      *
+      * This uses extremely fast reference equality (`eq None`) to check for emptiness rather than
+      * standard pattern matching, minimizing byte code and execution time.
+      *
+      * @param fallback
+      *   The alternative option to return if this one is empty.
+      * @return
+      *   This option if it has a value, otherwise the `fallback` option.
+      */
     inline def orElseFast(inline fallback: Option[A]): Option[A] =
       if (opt eq None) fallback
       else opt
 
+    /** Extracts the value from the option, or returns `null` if the option is empty.
+      *
+      * Useful for Java interoperability or extremely low-level zero-allocation logic. The `null` is
+      * explicitly cast to `A` to satisfy the type checker.
+      *
+      * @return
+      *   The underlying value if present, or `null`.
+      */
     inline def orNullFast: A = opt match {
       case Some(a) => a
       case _ => null.asInstanceOf[A]

--- a/runtime/src/eu/neverblink/linkml/runtime/FastUtils.scala
+++ b/runtime/src/eu/neverblink/linkml/runtime/FastUtils.scala
@@ -1,0 +1,39 @@
+package eu.neverblink.linkml.runtime
+
+object FastUtils {
+  extension [A](inline opt: Option[A]) {
+    inline def getOrElseFast(inline default: A): A = opt match {
+      case Some(a) => a
+      case _ => default
+    }
+
+    inline def flatMapFast[B](inline f: A => Option[B]): Option[B] = opt match {
+      case Some(a) => f(a)
+      case _ => None
+    }
+
+    inline def foldFast[B](inline ifEmpty: B)(inline f: A => B): B = opt match {
+      case Some(a) => f(a)
+      case _ => ifEmpty
+    }
+
+    inline def foreachFast[B](inline f: A => Unit): Unit = opt match {
+      case Some(a) => f(a)
+      case _ =>
+    }
+
+    inline def mapFast[B](inline f: A => B): Option[B] = opt match {
+      case Some(a) => new Some(f(a))
+      case _ => None
+    }
+
+    inline def orElseFast(inline fallback: Option[A]): Option[A] =
+      if (opt eq None) fallback
+      else opt
+
+    inline def orNullFast: A = opt match {
+      case Some(a) => a
+      case _ => null.asInstanceOf[A]
+    }
+  }
+}

--- a/runtime/src/eu/neverblink/linkml/runtime/Inference.scala
+++ b/runtime/src/eu/neverblink/linkml/runtime/Inference.scala
@@ -1,5 +1,7 @@
 package eu.neverblink.linkml.runtime
 
+import eu.neverblink.linkml.runtime.FastUtils.*
+
 /** Thrown when a slot's value contradicts the value inferred from its `equals_expression`, or when
   * an expression references a slot that has no value.
   */
@@ -18,13 +20,13 @@ final class InferenceException(message: String) extends RuntimeException(message
   *   The inferred value if the slot was empty, otherwise its current value
   */
 def inferOptional[T](slotName: String, current: Option[T], inferred: T): Option[T] =
-  current match {
-    case None => Some(inferred)
-    case Some(value) if value == inferred => current
-    case Some(value) =>
+  current.foldFast(new Some(inferred)) { value =>
+    if (value == inferred) current
+    else {
       throw InferenceException(
         s"Slot '$slotName' is set to '$value', but its expression infers '$inferred'",
       )
+    }
   }
 
 /** Check that a required slot's value agrees with its `equals_expression`. A required slot is never
@@ -55,7 +57,7 @@ def inferRequired[T](slotName: String, current: T, inferred: T): T =
   *   The referenced slot's current value
   */
 def inferenceInput[T](slotName: String, value: Option[T]): T =
-  value.getOrElse(
+  value.getOrElseFast(
     throw InferenceException(
       s"Slot '$slotName' is referenced by an expression, but has no value",
     ),

--- a/runtime/src/eu/neverblink/linkml/runtime/UriOrCurie.scala
+++ b/runtime/src/eu/neverblink/linkml/runtime/UriOrCurie.scala
@@ -1,6 +1,7 @@
 package eu.neverblink.linkml.runtime
 
 import java.net.URLEncoder
+import java.nio.charset.StandardCharsets
 import scala.util.matching.Regex
 
 sealed trait UriOrCurie {
@@ -35,7 +36,7 @@ object Uri {
     * [[base]] is a valid URI base and does not need escaping.
     */
   def synthetic(base: String, name: String): Uri =
-    Uri(base + URLEncoder.encode(name, "UTF-8"))
+    new Uri(base.concat(URLEncoder.encode(name, StandardCharsets.UTF_8)))
 }
 
 final case class Curie(original: String) extends UriOrCurie {
@@ -78,7 +79,7 @@ final class BasicPrefixResolver(schemaId: String) extends PrefixResolver {
     var normalizedUri = u.normalize().toString
     if (
       !normalizedUri.endsWith("/") && !normalizedUri.endsWith("?") && !normalizedUri.endsWith("#")
-    ) normalizedUri += "/"
+    ) normalizedUri = normalizedUri.concat("/")
     prefixToUri.put(prefix, normalizedUri)
     uriToPrefix.put(normalizedUri, prefix)
   }
@@ -90,7 +91,7 @@ final class BasicPrefixResolver(schemaId: String) extends PrefixResolver {
     if (index >= 0) {
       val prefix = curie.substring(0, index)
       val baseUri = prefixToUri.get(prefix)
-      if (baseUri ne null) baseUri + curie.substring(index + 1)
+      if (baseUri ne null) baseUri.concat(curie.substring(index + 1))
       else sys.error(s"Unknown prefix '$prefix' for CURIE '$curie' in schema '$schemaId'")
     } else curie // relative reference
   }

--- a/schemaview/src/eu/neverblink/linkml/schemaview/AttributeView.scala
+++ b/schemaview/src/eu/neverblink/linkml/schemaview/AttributeView.scala
@@ -2,6 +2,7 @@ package eu.neverblink.linkml.schemaview
 
 import eu.neverblink.linkml.metamodel.*
 import eu.neverblink.linkml.runtime.*
+import eu.neverblink.linkml.runtime.FastUtils.*
 import eu.neverblink.linkml.schemaview.SubjectType.implicitPrefix
 import eu.neverblink.linkml.schemaview.expression.StringInterpolationExpression
 import fastparse.Parsed
@@ -83,29 +84,26 @@ final case class TypeAttributeView(
   private val slot: SlotDefinition = slotView.slot
   private val _type: TypeDefinition = typeView._type
 
-  private def upgradeToImplicit(st: SubjectType): SubjectType = slot.implicitPrefix match {
-    case Some(value) =>
+  private def upgradeToImplicit(st: SubjectType): SubjectType = slot.implicitPrefix.foldFast(st) {
+    value =>
       SubjectType.implicitPrefix(
-        slotView.definingPrefixResolver.resolvePrefix(value)
-          .getOrElse(
-            throw RuntimeException(s"Unknown implicit_prefix for slot ${slot.name}: $value"),
-          ),
+        slotView.definingPrefixResolver.resolvePrefix(value).getOrElseFast(
+          throw RuntimeException(s"Unknown implicit_prefix for slot ${slot.name}: $value"),
+        ),
       )
-    case None => st
   }
 
   /** Return the RDF subject type that corresponds to this type/slot combination. This is used to
     * create subjects in the RDF representations.
     */
-  def subjectType: SubjectType = {
+  def subjectType: SubjectType =
     typeView.subjectType match {
-      case SubjectType.base => upgradeToImplicit(SubjectType.base)
-      case SubjectType.implicitPrefix(pfx) =>
+      case _: SubjectType.base.type => upgradeToImplicit(SubjectType.base)
+      case ip: SubjectType.implicitPrefix =>
         // this probably should not be allowed
-        upgradeToImplicit(SubjectType.implicitPrefix(pfx))
+        upgradeToImplicit(new SubjectType.implicitPrefix(ip.prefix))
       case st => st
     }
-  }
 
   /** @see [[slot.pattern]] */
   def pattern: Option[String] =

--- a/schemaview/src/eu/neverblink/linkml/schemaview/CollectionForm.scala
+++ b/schemaview/src/eu/neverblink/linkml/schemaview/CollectionForm.scala
@@ -62,8 +62,7 @@ object CollectionForm {
     */
   def ofRange(slot: SlotView): CollectionForm = {
     val range = slot.derivedRange
-    given SchemaView = slot.sv
-    range.resolve.get match {
+    range.resolve(using slot.sv).get match {
       case cls: ClassView => of(cls)
       case _ =>
         // Let's be lax here, `inlined:true` does not make sense on non-classes,
@@ -71,7 +70,6 @@ object CollectionForm {
         // TODO LNK-27: But we should have this as a warning if possible
         ListOnly
     }
-
   }
 
   private def isIdOrKey(slot: SlotDefinition): Boolean = slot.key || slot.identifier

--- a/schemaview/src/eu/neverblink/linkml/schemaview/ElementView.scala
+++ b/schemaview/src/eu/neverblink/linkml/schemaview/ElementView.scala
@@ -520,14 +520,14 @@ final case class EnumView(_enum: EnumDefinition, definingSchema: SchemaDefinitio
       }.toList
 
   lazy val toMeaning: Map[String, UriOrCurie] =
-    derivedValues.foldLeft(Map.empty[String, UriOrCurie]) { case (acc, (x, meaning)) =>
-      acc.updated(x.text, meaning)
-    }
+    derivedValues.foldLeft(Map.newBuilder[String, UriOrCurie]) { case (acc, (x, meaning)) =>
+      acc.addOne((x.text, meaning))
+    }.result()
 
   lazy val fromMeaning: Map[UriOrCurie, String] =
-    derivedValues.foldLeft(Map.empty[UriOrCurie, String]) { case (acc, (x, meaning)) =>
-      acc.updated(meaning, x.text)
-    }
+    derivedValues.foldLeft(Map.newBuilder[UriOrCurie, String]) { case (acc, (x, meaning)) =>
+      acc.addOne((meaning, x.text))
+    }.result()
 }
 
 // TODO LNK-63:

--- a/schemaview/src/eu/neverblink/linkml/schemaview/ElementView.scala
+++ b/schemaview/src/eu/neverblink/linkml/schemaview/ElementView.scala
@@ -91,13 +91,11 @@ final case class ClassView(cls: ClassDefinition, definingSchema: SchemaDefinitio
 
   def inner: ClassDefinition = cls
 
-  def uriOrCurie: UriOrCurie = cls.classUri.getOrElseFast {
-    Uri.synthetic(defaultPrefixUri, Case.PascalCase(cls.name))
-  }
+  def uriOrCurie: UriOrCurie =
+    cls.classUri.getOrElseFast(Uri.synthetic(defaultPrefixUri, Case.PascalCase(cls.name)))
 
-  override def aliasedName: String = cls.alias.getOrElseFast {
-    Case.PascalCase(cls.name)
-  }
+  override def aliasedName: String =
+    cls.alias.getOrElseFast(Case.PascalCase(cls.name))
 
   /** Derived attributes for this class and the identifier slot of a class, if it has one.
     */
@@ -196,14 +194,10 @@ final case class ClassView(cls: ClassDefinition, definingSchema: SchemaDefinitio
     val parents = new ListBuffer[ClassView]
     val cls = view.cls
     cls.mixins.foreach { r =>
-      sv.resolve(r.asInstanceOf[Reference[ClassView]]).foreachFast { cv =>
-        parents.addOne(cv)
-      }
+      sv.resolve(r.asInstanceOf[Reference[ClassView]]).foreachFast(parents.addOne)
     }
     cls.isA.foreachFast { r =>
-      sv.resolve(r.asInstanceOf[Reference[ClassView]]).foreachFast { cv =>
-        parents.addOne(cv)
-      }
+      sv.resolve(r.asInstanceOf[Reference[ClassView]]).foreachFast(parents.addOne)
     }
     parents.toList
   }
@@ -383,15 +377,13 @@ final case class SlotView(slot: SlotDefinition, definingSchema: SchemaDefinition
 
   def inner: SlotDefinition = slot
 
-  override def aliasedName: String = slot.alias.getOrElseFast {
-    Case.deSpaceCase(slot.name)
-  }
+  override def aliasedName: String =
+    slot.alias.getOrElseFast(Case.deSpaceCase(slot.name))
 
   /** Resolved URI string for the implicit_prefix metaslot for this slot, if defined
     */
-  def implicitPrefixReference: Option[String] = slot.implicitPrefix.flatMapFast { p =>
-    definingPrefixResolver.resolvePrefix(p)
-  }
+  def implicitPrefixReference: Option[String] =
+    slot.implicitPrefix.flatMapFast(definingPrefixResolver.resolvePrefix)
 
   /** Get and dereference the direct parents (mixins + inheritance) of this slot
     *
@@ -403,9 +395,7 @@ final case class SlotView(slot: SlotDefinition, definingSchema: SchemaDefinition
   private def getParents(slot: SlotDefinition): Iterable[SlotDefinition] = {
     val parents = new ListBuffer[SlotDefinition]
     slot.mixins.foreach { r =>
-      sv.resolve(r).foreachFast { cv =>
-        parents.addOne(cv)
-      }
+      sv.resolve(r).foreachFast(parents.addOne)
     }
     slot.isA.foreachFast { r =>
       sv.resolve(r).foreachFast { cv =>
@@ -485,9 +475,8 @@ final case class EnumView(_enum: EnumDefinition, definingSchema: SchemaDefinitio
   override private[schemaview] def evaluateConstructor(expr: String): Option[PermissibleValue] =
     new Some(ConstructorExpression.evaluateEnum(expr, this))
 
-  def uriOrCurie: UriOrCurie = _enum.enumUri.getOrElseFast {
-    Uri.synthetic(defaultPrefixUri, Case.PascalCase(_enum.name))
-  }
+  def uriOrCurie: UriOrCurie =
+    _enum.enumUri.getOrElseFast(Uri.synthetic(defaultPrefixUri, Case.PascalCase(_enum.name)))
 
   /** Permissible values of this enum and their (possibly synthetic) meanings */
   lazy val derivedValues: Seq[(pv: PermissibleValue, meaning: UriOrCurie)] =
@@ -559,26 +548,24 @@ final case class TypeView(_type: TypeDefinition, definingSchema: SchemaDefinitio
   /** The [[RuntimeType]] representation of this type. Translates Python-ese and LinkML-py runtime
     * names into the enum. Falls back to [[UnknownType]].
     */
-  def runtimeType: RuntimeType = inner.base.foldFast(UnknownType) { value =>
-    value match {
-      case "str" => StringType
-      case "int" => IntegerType
-      case "Bool" => BooleanType
-      case "double" => DoubleType
-      case "float" =>
-        // thanks, python
-        if (inner.typeUri.contains("xsd:double")) DoubleType
-        else FloatType
-      case "Decimal" => DecimalType
-      case "URI" => UriType
-      case "Curie" => CurieType
-      case "URIorCURIE" => UriOrCurieType
-      case "NCName" => NcNameType
-      case "XSDDateTime" => DateTimeType
-      case "XSDDate" => DateType
-      case "XSDTime" => TimeType
-      case _ => UnknownType
-    }
+  def runtimeType: RuntimeType = inner.base.foldFast(UnknownType) {
+    case "str" => StringType
+    case "int" => IntegerType
+    case "Bool" => BooleanType
+    case "double" => DoubleType
+    case "float" =>
+      // thanks, python
+      if (inner.typeUri.contains("xsd:double")) DoubleType
+      else FloatType
+    case "Decimal" => DecimalType
+    case "URI" => UriType
+    case "Curie" => CurieType
+    case "URIorCURIE" => UriOrCurieType
+    case "NCName" => NcNameType
+    case "XSDDateTime" => DateTimeType
+    case "XSDDate" => DateType
+    case "XSDTime" => TimeType
+    case _ => UnknownType
   }
 
   /** The [[CoreType]] representation of this type.

--- a/schemaview/src/eu/neverblink/linkml/schemaview/ElementView.scala
+++ b/schemaview/src/eu/neverblink/linkml/schemaview/ElementView.scala
@@ -584,21 +584,19 @@ final case class TypeView(_type: TypeDefinition, definingSchema: SchemaDefinitio
         case "str" => StringType
         case "int" => IntegerType
         case "Bool" => BooleanType
-        // thanks, python
-        case "float" if inner.typeUri.contains("xsd:double") => DoubleType
         case "double" => DoubleType
-        case "float" => FloatType
+        case "float" =>
+          // thanks, python
+          if (inner.typeUri.contains("xsd:double")) DoubleType
+          else FloatType
         case "Decimal" => DecimalType
-
         case "URI" => UriType
         case "Curie" => CurieType
         case "URIorCURIE" => UriOrCurieType
         case "NCName" => NcNameType
-
         case "XSDDateTime" => DateTimeType
         case "XSDDate" => DateType
         case "XSDTime" => TimeType
-
         case _ => UnknownType
       }
     case _ => UnknownType

--- a/schemaview/src/eu/neverblink/linkml/schemaview/ElementView.scala
+++ b/schemaview/src/eu/neverblink/linkml/schemaview/ElementView.scala
@@ -3,6 +3,7 @@ package eu.neverblink.linkml.schemaview
 import eu.neverblink.linkml
 import eu.neverblink.linkml.metamodel.*
 import eu.neverblink.linkml.runtime.*
+import eu.neverblink.linkml.runtime.FastUtils.*
 import eu.neverblink.linkml.schemaview
 import eu.neverblink.linkml.schemaview.CollectionForm.{CompactDict, SimpleDict}
 import eu.neverblink.linkml.schemaview.expression.ConstructorExpression
@@ -90,14 +91,12 @@ final case class ClassView(cls: ClassDefinition, definingSchema: SchemaDefinitio
 
   def inner: ClassDefinition = cls
 
-  def uriOrCurie: UriOrCurie = cls.classUri match {
-    case Some(uri) => uri
-    case _ => Uri.synthetic(defaultPrefixUri, Case.PascalCase(cls.name))
+  def uriOrCurie: UriOrCurie = cls.classUri.getOrElseFast {
+    Uri.synthetic(defaultPrefixUri, Case.PascalCase(cls.name))
   }
 
-  override def aliasedName: String = cls.alias match {
-    case Some(name) => name
-    case _ => Case.PascalCase(cls.name)
+  override def aliasedName: String = cls.alias.getOrElseFast {
+    Case.PascalCase(cls.name)
   }
 
   /** Derived attributes for this class and the identifier slot of a class, if it has one.
@@ -137,9 +136,9 @@ final case class ClassView(cls: ClassDefinition, definingSchema: SchemaDefinitio
   }
 
   /** The slot/type bundle for the identifier of this class, if it exists */
-  lazy val identifierView: Option[TypeAttributeView] = identifier.map(idSlot => {
+  lazy val identifierView: Option[TypeAttributeView] = identifier.mapFast(idSlot => {
     idSlot.derivedRange.resolve.get match {
-      case tv: TypeView => TypeAttributeView(idSlot, this, tv)
+      case tv: TypeView => new TypeAttributeView(idSlot, this, tv)
       case x =>
         throw RuntimeException(s"Invalid identifier slot: ${cls.name}.${idSlot.name} -> ${x.name}")
     }
@@ -191,24 +190,20 @@ final case class ClassView(cls: ClassDefinition, definingSchema: SchemaDefinitio
     * @return
     *   The subject type, or None if the class does not have an identifier
     */
-  def subjectType: Option[SubjectType] = identifierView.map(_.subjectType)
+  def subjectType: Option[SubjectType] = identifierView.mapFast(_.subjectType)
 
   private def getParents(view: ClassView): Seq[ClassView] = {
     val parents = new ListBuffer[ClassView]
     val cls = view.cls
     cls.mixins.foreach { r =>
-      sv.resolve(r.asInstanceOf[Reference[ClassView]]) match {
-        case Some(cv) => parents.addOne(cv)
-        case _ =>
+      sv.resolve(r.asInstanceOf[Reference[ClassView]]).foreachFast { cv =>
+        parents.addOne(cv)
       }
     }
-    cls.isA match {
-      case Some(r) =>
-        sv.resolve(r.asInstanceOf[Reference[ClassView]]) match {
-          case Some(cv) => parents.addOne(cv)
-          case _ =>
-        }
-      case _ =>
+    cls.isA.foreachFast { r =>
+      sv.resolve(r.asInstanceOf[Reference[ClassView]]).foreachFast { cv =>
+        parents.addOne(cv)
+      }
     }
     parents.toList
   }
@@ -275,9 +270,9 @@ final case class ClassView(cls: ClassDefinition, definingSchema: SchemaDefinitio
     // Use empty slot base here to avoid an extra allocation
     var currentSlot = ClassView.emptySlotDef
     currentSlot = sv.applySlotUsage(currentSlot, slotRef.value, cls)
-    sv.resolve(slotRef.asInstanceOf[Reference[SlotView]]) match {
+    sv.resolve(slotRef.asInstanceOf[Reference[SlotView]]).foreachFast { (resolved: SlotView) =>
       // Note this is a bit off-spec, but it's a pretty reasonable
-      case Some(resolved: SlotView) if !isSlotFromAttributes(slotRef) =>
+      if (!isSlotFromAttributes(slotRef)) {
         currentSlot =
           currentSlot.combineWith(resolved.slot.asInstanceOf[SlotDefinitionImpl], sv.combineRange)
         for slotAncestor <- resolved.ancestors(false) do {
@@ -286,7 +281,7 @@ final case class ClassView(cls: ClassDefinition, definingSchema: SchemaDefinitio
             sv.combineRange,
           )
         }
-      case _ =>
+      }
     }
     val finalSlot = currentSlot.copy(
       name = slotRef.value,
@@ -321,10 +316,10 @@ final case class ClassView(cls: ClassDefinition, definingSchema: SchemaDefinitio
     *   used instead of checking the class extensions.
     */
   def treeRootInlineType(overrideType: Option[String]): InlineType =
-    val value = overrideType.orElse {
-      cls.extensions.get("tree_root_as").map(_.extensionValue.value.strip)
+    val value = overrideType.orElseFast {
+      cls.extensions.get("tree_root_as").mapFast(_.extensionValue.value.strip)
     }
-    value.map(v =>
+    value.mapFast(v =>
       Case.camelCase(v) match {
         case "plain" => InlineType.plain
         case "optional" => InlineType.optional
@@ -354,7 +349,7 @@ final case class ClassView(cls: ClassDefinition, definingSchema: SchemaDefinitio
             else s"Class '$name' has unknown 'tree_root_as' override value: '$v'"
           })
       },
-    ).getOrElse(InlineType.plain)
+    ).getOrElseFast(InlineType.plain)
 
   /** Materialize this [[ClassView]] into a derived [[ClassDefinition]]. This inlines all slots as
     * attributes, and clears any inheritance slots. Additionally, sets the class uri using
@@ -388,16 +383,14 @@ final case class SlotView(slot: SlotDefinition, definingSchema: SchemaDefinition
 
   def inner: SlotDefinition = slot
 
-  override def aliasedName: String = slot.alias match {
-    case Some(name) => name
-    case _ => Case.deSpaceCase(slot.name)
+  override def aliasedName: String = slot.alias.getOrElseFast {
+    Case.deSpaceCase(slot.name)
   }
 
   /** Resolved URI string for the implicit_prefix metaslot for this slot, if defined
     */
-  def implicitPrefixReference: Option[String] = slot.implicitPrefix match {
-    case Some(p) => definingPrefixResolver.resolvePrefix(p)
-    case _ => None
+  def implicitPrefixReference: Option[String] = slot.implicitPrefix.flatMapFast { p =>
+    definingPrefixResolver.resolvePrefix(p)
   }
 
   /** Get and dereference the direct parents (mixins + inheritance) of this slot
@@ -410,18 +403,14 @@ final case class SlotView(slot: SlotDefinition, definingSchema: SchemaDefinition
   private def getParents(slot: SlotDefinition): Iterable[SlotDefinition] = {
     val parents = new ListBuffer[SlotDefinition]
     slot.mixins.foreach { r =>
-      sv.resolve(r) match {
-        case Some(cv) => parents.addOne(cv)
-        case _ =>
+      sv.resolve(r).foreachFast { cv =>
+        parents.addOne(cv)
       }
     }
-    slot.isA match {
-      case Some(r) =>
-        sv.resolve(r) match {
-          case Some(cv) => parents.addOne(cv)
-          case _ =>
-        }
-      case _ =>
+    slot.isA.foreachFast { r =>
+      sv.resolve(r).foreachFast { cv =>
+        parents.addOne(cv)
+      }
     }
     parents.toList
   }
@@ -454,10 +443,9 @@ final case class SlotView(slot: SlotDefinition, definingSchema: SchemaDefinition
     * Make sure you use this method after class/slot derivation is performed.
     */
   def derivedRange: Reference[ElementView[?, ?]] =
-    (slot.range match {
-      case Some(r) => r
-      case _ => sv.getDefaultRange(definingSchema)
-    }).asInstanceOf[Reference[ElementView[?, ?]]]
+    slot.range.getOrElseFast {
+      sv.getDefaultRange(definingSchema)
+    }.asInstanceOf[Reference[ElementView[?, ?]]]
 
   /** Get the default value of this slot if the `ifabsent` metaslot is defined.
     *
@@ -468,9 +456,8 @@ final case class SlotView(slot: SlotDefinition, definingSchema: SchemaDefinition
     *   The range of the slot. Obtain it from [[SlotView.derivedRange]].
     */
   def ifAbsent[R](range: ElementView[?, R]): Option[R] =
-    slot.ifabsent match {
-      case Some(ia) => range.evaluateConstructor(ia)
-      case _ => None
+    slot.ifabsent.flatMapFast { ia =>
+      range.evaluateConstructor(ia)
     }
 
   /** Get the URI of this slot, using the default prefix of the implicit [[SchemaView]] if not
@@ -482,9 +469,8 @@ final case class SlotView(slot: SlotDefinition, definingSchema: SchemaDefinition
 private object SlotView:
   // Exposed for slot derivation in ClassView.
   def uri(slotUri: Option[UriOrCurie], slotName: String, context: ElementView[?, ?]): UriOrCurie =
-    slotUri match {
-      case Some(uri) => uri
-      case _ => Uri.synthetic(context.defaultPrefixUri, Case.deSpaceCase(slotName))
+    slotUri.getOrElseFast {
+      Uri.synthetic(context.defaultPrefixUri, Case.deSpaceCase(slotName))
     }
 
 final case class EnumView(_enum: EnumDefinition, definingSchema: SchemaDefinition)(using
@@ -497,11 +483,10 @@ final case class EnumView(_enum: EnumDefinition, definingSchema: SchemaDefinitio
   override def aliasedName: String = Case.PascalCase(_enum.name)
 
   override private[schemaview] def evaluateConstructor(expr: String): Option[PermissibleValue] =
-    Some(ConstructorExpression.evaluateEnum(expr, this))
+    new Some(ConstructorExpression.evaluateEnum(expr, this))
 
-  def uriOrCurie: UriOrCurie = _enum.enumUri match {
-    case Some(uri) => uri
-    case _ => Uri.synthetic(defaultPrefixUri, Case.PascalCase(_enum.name))
+  def uriOrCurie: UriOrCurie = _enum.enumUri.getOrElseFast {
+    Uri.synthetic(defaultPrefixUri, Case.PascalCase(_enum.name))
   }
 
   /** Permissible values of this enum and their (possibly synthetic) meanings */
@@ -511,9 +496,8 @@ final case class EnumView(_enum: EnumDefinition, definingSchema: SchemaDefinitio
         acc.addOne(
           (
             x,
-            x.meaning match {
-              case Some(m) => m
-              case _ => Uri.synthetic(defaultPrefixUri, Case.deSpaceCase(x.text))
+            x.meaning.getOrElseFast {
+              Uri.synthetic(defaultPrefixUri, Case.deSpaceCase(x.text))
             },
           ),
         )
@@ -547,19 +531,16 @@ final case class TypeView(_type: TypeDefinition, definingSchema: SchemaDefinitio
     * the RDF representations.
     */
   def subjectType: SubjectType = runtimeType match {
-    case UriType => SubjectType.uri
-    case CurieType => SubjectType.curie
-    case UriOrCurieType => SubjectType.uriOrCurie
+    case _: UriType.type => SubjectType.uri
+    case _: CurieType.type => SubjectType.curie
+    case _: UriOrCurieType.type => SubjectType.uriOrCurie
     case _ =>
-      inner.implicitPrefix match {
-        case Some(prefix) =>
-          val reference =
-            definingPrefixResolver.resolvePrefix(prefix) match {
-              case Some(p) => p
-              case _ => throw RuntimeException(s"Unknown implicit prefix for type $name: $prefix")
-            }
-          new SubjectType.implicitPrefix(reference)
-        case _ => SubjectType.base
+      inner.implicitPrefix.foldFast(SubjectType.base) { prefix =>
+        val reference =
+          definingPrefixResolver.resolvePrefix(prefix).getOrElseFast {
+            throw RuntimeException(s"Unknown implicit prefix for type $name: $prefix")
+          }
+        new SubjectType.implicitPrefix(reference)
       }
   }
 
@@ -578,37 +559,34 @@ final case class TypeView(_type: TypeDefinition, definingSchema: SchemaDefinitio
   /** The [[RuntimeType]] representation of this type. Translates Python-ese and LinkML-py runtime
     * names into the enum. Falls back to [[UnknownType]].
     */
-  def runtimeType: RuntimeType = inner.base match {
-    case Some(value) =>
-      value match {
-        case "str" => StringType
-        case "int" => IntegerType
-        case "Bool" => BooleanType
-        case "double" => DoubleType
-        case "float" =>
-          // thanks, python
-          if (inner.typeUri.contains("xsd:double")) DoubleType
-          else FloatType
-        case "Decimal" => DecimalType
-        case "URI" => UriType
-        case "Curie" => CurieType
-        case "URIorCURIE" => UriOrCurieType
-        case "NCName" => NcNameType
-        case "XSDDateTime" => DateTimeType
-        case "XSDDate" => DateType
-        case "XSDTime" => TimeType
-        case _ => UnknownType
-      }
-    case _ => UnknownType
+  def runtimeType: RuntimeType = inner.base.foldFast(UnknownType) { value =>
+    value match {
+      case "str" => StringType
+      case "int" => IntegerType
+      case "Bool" => BooleanType
+      case "double" => DoubleType
+      case "float" =>
+        // thanks, python
+        if (inner.typeUri.contains("xsd:double")) DoubleType
+        else FloatType
+      case "Decimal" => DecimalType
+      case "URI" => UriType
+      case "Curie" => CurieType
+      case "URIorCURIE" => UriOrCurieType
+      case "NCName" => NcNameType
+      case "XSDDateTime" => DateTimeType
+      case "XSDDate" => DateType
+      case "XSDTime" => TimeType
+      case _ => UnknownType
+    }
   }
 
   /** The [[CoreType]] representation of this type.
     */
   def coreType: CoreType = runtimeType.repr
 
-  def uriOrCurie: UriOrCurie = _type.typeUri match {
-    case Some(uri) => uri
-    case _ => Uri.synthetic(defaultPrefixUri, _type.name)
+  def uriOrCurie: UriOrCurie = _type.typeUri.getOrElseFast {
+    Uri.synthetic(defaultPrefixUri, _type.name)
   }
 }
 

--- a/schemaview/src/eu/neverblink/linkml/schemaview/ElementView.scala
+++ b/schemaview/src/eu/neverblink/linkml/schemaview/ElementView.scala
@@ -7,6 +7,8 @@ import eu.neverblink.linkml.schemaview
 import eu.neverblink.linkml.schemaview.CollectionForm.{CompactDict, SimpleDict}
 import eu.neverblink.linkml.schemaview.expression.ConstructorExpression
 
+import scala.collection.mutable.ListBuffer
+
 /** Element views provide a rich interface for working with schema elements. They require an
   * implicit [[SchemaView]] and are always linked to a defining schema, which is the schema in which
   * the element was originally defined. This allows you to both have the full context of all
@@ -88,10 +90,15 @@ final case class ClassView(cls: ClassDefinition, definingSchema: SchemaDefinitio
 
   def inner: ClassDefinition = cls
 
-  def uriOrCurie: UriOrCurie =
-    cls.classUri.getOrElse(Uri.synthetic(defaultPrefixUri, Case.PascalCase(cls.name)))
+  def uriOrCurie: UriOrCurie = cls.classUri match {
+    case Some(uri) => uri
+    case _ => Uri.synthetic(defaultPrefixUri, Case.PascalCase(cls.name))
+  }
 
-  override def aliasedName: String = cls.alias.getOrElse(Case.PascalCase(cls.name))
+  override def aliasedName: String = cls.alias match {
+    case Some(name) => name
+    case _ => Case.PascalCase(cls.name)
+  }
 
   /** Derived attributes for this class and the identifier slot of a class, if it has one.
     */
@@ -143,21 +150,24 @@ final case class ClassView(cls: ClassDefinition, definingSchema: SchemaDefinitio
     */
   lazy val attributeViews: Map[String, AttributeView] = {
     derivedAttributes.map((k, slot) =>
-      k -> (slot.derivedRange.resolve.get match {
-        case classView: ClassView =>
-          if classView.isAny then AnyView(slot, this)
-          else if !slot.derivedInlined then
-            ClassReferenceAttributeView(
-              slot,
-              this,
-              classView,
-              classView.identifierView.get,
-            )
-          else ClassInlineAttributeView(slot, this, classView, InlineType(slot))
-        case tv: TypeView => TypeAttributeView(slot, this, tv)
-        case ev: EnumView => EnumAttributeView(slot, this, ev)
-        case x => throw RuntimeException(s"Invalid range: ${cls.name}.${slot.name} -> ${x.name}")
-      }),
+      (
+        k,
+        slot.derivedRange.resolve.get match {
+          case classView: ClassView =>
+            if classView.isAny then new AnyView(slot, this)
+            else if !slot.derivedInlined then
+              new ClassReferenceAttributeView(
+                slot,
+                this,
+                classView,
+                classView.identifierView.get,
+              )
+            else new ClassInlineAttributeView(slot, this, classView, InlineType(slot))
+          case tv: TypeView => new TypeAttributeView(slot, this, tv)
+          case ev: EnumView => new EnumAttributeView(slot, this, ev)
+          case x => throw RuntimeException(s"Invalid range: ${cls.name}.${slot.name} -> ${x.name}")
+        },
+      ),
     )
   }
 
@@ -183,10 +193,25 @@ final case class ClassView(cls: ClassDefinition, definingSchema: SchemaDefinitio
     */
   def subjectType: Option[SubjectType] = identifierView.map(_.subjectType)
 
-  private def getParents(view: ClassView): Iterable[ClassView] =
-    (view.cls.mixins ++ view.cls.isA).flatMap { r =>
-      sv.resolve(r.asInstanceOf[Reference[ClassView]])
+  private def getParents(view: ClassView): Iterable[ClassView] = {
+    val parents = new ListBuffer[ClassView]
+    val cls = view.cls
+    cls.mixins.foreach { r =>
+      sv.resolve(r.asInstanceOf[Reference[ClassView]]) match {
+        case Some(cv) => parents.addOne(cv)
+        case _ =>
+      }
     }
+    cls.isA match {
+      case Some(r) =>
+        sv.resolve(r.asInstanceOf[Reference[ClassView]]) match {
+          case Some(cv) => parents.addOne(cv)
+          case _ =>
+        }
+      case _ =>
+    }
+    parents.toList
+  }
 
   /** Get and dereference all the ancestors (transitive parents) of this class.
     *
@@ -203,8 +228,12 @@ final case class ClassView(cls: ClassDefinition, definingSchema: SchemaDefinitio
     */
   def directSlots: Seq[Reference[SlotDefinition]] = getDirectSlots(cls)
 
-  private def getDirectSlots(cls: ClassDefinition): Seq[Reference[SlotDefinition]] =
-    cls.slots ++ cls.attributes.keys.map(Reference[SlotDefinition])
+  private def getDirectSlots(cls: ClassDefinition): Seq[Reference[SlotDefinition]] = {
+    val slots = new ListBuffer[Reference[SlotDefinition]]
+    slots.addAll(cls.slots)
+    cls.attributes.keys.foreach(a => slots.addOne(Reference[SlotDefinition](a)))
+    slots.toList
+  }
 
   /** Test whether the class or its ancestors have this slot defined as an attribute.
     *
@@ -215,8 +244,10 @@ final case class ClassView(cls: ClassDefinition, definingSchema: SchemaDefinitio
     * @return
     *   True if the slot comes from class attributes, false otherwise
     */
-  def isSlotFromAttributes(slotRef: Reference[SlotDefinition]): Boolean =
-    ancestors(true).exists(anc => anc.cls.attributes.keys.exists(_ == slotRef.value))
+  def isSlotFromAttributes(slotRef: Reference[SlotDefinition]): Boolean = {
+    val name = slotRef.value
+    ancestors(true).exists(anc => anc.cls.attributes.keys.exists(_.equals(name)))
+  }
 
   /** Derive a slot for a class, taking into account the `slotUsage` and `attributes` for the class
     * and its ancestors, as well as the schema top-level slots and its ancestors.
@@ -272,7 +303,7 @@ final case class ClassView(cls: ClassDefinition, definingSchema: SchemaDefinitio
     )
     // Apply the original schema as the defining schema, so that default prefix / default range
     // resolution still works as defined in the original schema file.
-    SlotView(finalSlot, source.definingSchema)
+    new SlotView(finalSlot, source.definingSchema)
   }
 
   /** Test whether this class definition has an identifier slot
@@ -291,35 +322,37 @@ final case class ClassView(cls: ClassDefinition, definingSchema: SchemaDefinitio
     */
   def treeRootInlineType(overrideType: Option[String]): InlineType =
     val value = overrideType.orElse {
-      cls.extensions.get("tree_root_as").map(_.extensionValue.value.trim)
+      cls.extensions.get("tree_root_as").map(_.extensionValue.value.strip)
     }
-    lazy val msg =
-      s"Class '$name' has 'tree_root_as: ${value.get}', but it cannot be inlined in this form"
     value.map(v =>
-      Case.camelCase(v).strip() match {
+      Case.camelCase(v) match {
         case "plain" => InlineType.plain
         case "optional" => InlineType.optional
         case "list" => InlineType.list
         case "simpleDict" =>
           collectionForm match {
             case form: SimpleDict => InlineType.dict(form)
-            case _ => throw new IllegalArgumentException(msg)
+            case _ =>
+              throw new IllegalArgumentException(
+                s"Class '$name' has 'tree_root_as: $v', but it cannot be inlined in simpleDict form",
+              )
           }
         case "compactDict" =>
           collectionForm match {
             case form: DictForm =>
               // override simpledict inference to
               InlineType.dict(CompactDict(form.key))
-            case _ => throw new IllegalArgumentException(msg)
+            case _ =>
+              throw new IllegalArgumentException(
+                s"Class '$name' has 'tree_root_as: $v', but it cannot be inlined in compactDict form",
+              )
           }
-        case _ if overrideType.isEmpty =>
-          throw new IllegalArgumentException(
-            s"Class '$name' has unknown 'tree_root_as' extension value: '$v'",
-          )
         case _ =>
-          throw new IllegalArgumentException(
-            s"Class '$name' has unknown 'tree_root_as' override value: '$v'",
-          )
+          throw new IllegalArgumentException({
+            if (overrideType.isEmpty)
+              s"Class '$name' has unknown 'tree_root_as' extension value: '$v'"
+            else s"Class '$name' has unknown 'tree_root_as' override value: '$v'"
+          })
       },
     ).getOrElse(InlineType.plain)
 
@@ -327,23 +360,25 @@ final case class ClassView(cls: ClassDefinition, definingSchema: SchemaDefinitio
     * attributes, and clears any inheritance slots. Additionally, sets the class uri using
     * [[SchemaView]] logic.
     */
-  def materialize: ClassDefinitionImpl = {
+  def materialize: ClassDefinitionImpl =
     inner.asInstanceOf[ClassDefinitionImpl].copy(
-      classUri = Some(uriOrCurie),
+      classUri = new Some(uriOrCurie),
       isA = None,
-      mixins = Seq.empty,
+      mixins = Nil,
       attributes = derivedAttributes.map((slotKey, slot) =>
-        slotKey -> slot.inner.asInstanceOf[SlotDefinitionImpl].copy(
-          isA = None,
-          mixins = Seq.empty,
-          fromSchema = Some(slot.definingSchema.id),
+        (
+          slotKey,
+          slot.inner.asInstanceOf[SlotDefinitionImpl].copy(
+            isA = None,
+            mixins = Nil,
+            fromSchema = new Some(slot.definingSchema.id),
+          ),
         ),
       ),
-      slots = Seq.empty,
+      slots = Nil,
       slotUsage = Map.empty,
-      fromSchema = Some(definingSchema.id),
+      fromSchema = new Some(definingSchema.id),
     )
-  }
 }
 
 final case class SlotView(slot: SlotDefinition, definingSchema: SchemaDefinition)(using
@@ -353,12 +388,17 @@ final case class SlotView(slot: SlotDefinition, definingSchema: SchemaDefinition
 
   def inner: SlotDefinition = slot
 
-  override def aliasedName: String = slot.alias.getOrElse(Case.deSpaceCase(slot.name))
+  override def aliasedName: String = slot.alias match {
+    case Some(name) => name
+    case _ => Case.deSpaceCase(slot.name)
+  }
 
   /** Resolved URI string for the implicit_prefix metaslot for this slot, if defined
     */
-  def implicitPrefixReference: Option[String] =
-    slot.implicitPrefix.flatMap(definingPrefixResolver.resolvePrefix)
+  def implicitPrefixReference: Option[String] = slot.implicitPrefix match {
+    case Some(p) => definingPrefixResolver.resolvePrefix(p)
+    case _ => None
+  }
 
   /** Get and dereference the direct parents (mixins + inheritance) of this slot
     *
@@ -367,8 +407,24 @@ final case class SlotView(slot: SlotDefinition, definingSchema: SchemaDefinition
     */
   def parents: Iterable[SlotDefinition] = getParents(slot)
 
-  private def getParents(slot: SlotDefinition): Iterable[SlotDefinition] =
-    (slot.mixins ++ slot.isA).flatMap(sv.resolve)
+  private def getParents(slot: SlotDefinition): Iterable[SlotDefinition] = {
+    val parents = new ListBuffer[SlotDefinition]
+    slot.mixins.foreach { r =>
+      sv.resolve(r) match {
+        case Some(cv) => parents.addOne(cv)
+        case _ =>
+      }
+    }
+    slot.isA match {
+      case Some(r) =>
+        sv.resolve(r) match {
+          case Some(cv) => parents.addOne(cv)
+          case _ =>
+        }
+      case _ =>
+    }
+    parents.toList
+  }
 
   /** Get and dereference all the ancestors (transitive parents) of this slot.
     *
@@ -398,8 +454,10 @@ final case class SlotView(slot: SlotDefinition, definingSchema: SchemaDefinition
     * Make sure you use this method after class/slot derivation is performed.
     */
   def derivedRange: Reference[ElementView[?, ?]] =
-    slot.range.getOrElse(sv.getDefaultRange(definingSchema))
-      .asInstanceOf[Reference[ElementView[?, ?]]]
+    (slot.range match {
+      case Some(r) => r
+      case _ => sv.getDefaultRange(definingSchema)
+    }).asInstanceOf[Reference[ElementView[?, ?]]]
 
   /** Get the default value of this slot if the `ifabsent` metaslot is defined.
     *
@@ -410,7 +468,10 @@ final case class SlotView(slot: SlotDefinition, definingSchema: SchemaDefinition
     *   The range of the slot. Obtain it from [[SlotView.derivedRange]].
     */
   def ifAbsent[R](range: ElementView[?, R]): Option[R] =
-    slot.ifabsent.flatMap(range.evaluateConstructor)
+    slot.ifabsent match {
+      case Some(ia) => range.evaluateConstructor(ia)
+      case _ => None
+    }
 
   /** Get the URI of this slot, using the default prefix of the implicit [[SchemaView]] if not
     * explicitly defined.
@@ -421,7 +482,10 @@ final case class SlotView(slot: SlotDefinition, definingSchema: SchemaDefinition
 private object SlotView:
   // Exposed for slot derivation in ClassView.
   def uri(slotUri: Option[UriOrCurie], slotName: String, context: ElementView[?, ?]): UriOrCurie =
-    slotUri.getOrElse(Uri.synthetic(context.defaultPrefixUri, Case.deSpaceCase(slotName)))
+    slotUri match {
+      case Some(uri) => uri
+      case _ => Uri.synthetic(context.defaultPrefixUri, Case.deSpaceCase(slotName))
+    }
 
 final case class EnumView(_enum: EnumDefinition, definingSchema: SchemaDefinition)(using
     sv: SchemaView,
@@ -435,20 +499,35 @@ final case class EnumView(_enum: EnumDefinition, definingSchema: SchemaDefinitio
   override private[schemaview] def evaluateConstructor(expr: String): Option[PermissibleValue] =
     Some(ConstructorExpression.evaluateEnum(expr, this))
 
-  def uriOrCurie: UriOrCurie =
-    _enum.enumUri.getOrElse(Uri.synthetic(defaultPrefixUri, Case.PascalCase(_enum.name)))
+  def uriOrCurie: UriOrCurie = _enum.enumUri match {
+    case Some(uri) => uri
+    case _ => Uri.synthetic(defaultPrefixUri, Case.PascalCase(_enum.name))
+  }
 
   /** Permissible values of this enum and their (possibly synthetic) meanings */
   lazy val derivedValues: Seq[(pv: PermissibleValue, meaning: UriOrCurie)] =
-    _enum.permissibleValues.values.map(x =>
-      x -> x.meaning.getOrElse(Uri.synthetic(defaultPrefixUri, Case.deSpaceCase(x.text))),
-    ).toSeq
+    _enum.permissibleValues.values
+      .foldLeft(new ListBuffer[(pv: PermissibleValue, meaning: UriOrCurie)]) { (acc, x) =>
+        acc.addOne(
+          (
+            x,
+            x.meaning match {
+              case Some(m) => m
+              case _ => Uri.synthetic(defaultPrefixUri, Case.deSpaceCase(x.text))
+            },
+          ),
+        )
+      }.toList
 
   lazy val toMeaning: Map[String, UriOrCurie] =
-    derivedValues.map((x, meaning) => x.text -> meaning).toMap
+    derivedValues.foldLeft(Map.empty[String, UriOrCurie]) { case (acc, (x, meaning)) =>
+      acc.updated(x.text, meaning)
+    }
 
   lazy val fromMeaning: Map[UriOrCurie, String] =
-    derivedValues.map((x, meaning) => meaning -> x.text).toMap
+    derivedValues.foldLeft(Map.empty[UriOrCurie, String]) { case (acc, (x, meaning)) =>
+      acc.updated(meaning, x.text)
+    }
 }
 
 // TODO LNK-63:
@@ -475,11 +554,12 @@ final case class TypeView(_type: TypeDefinition, definingSchema: SchemaDefinitio
       inner.implicitPrefix match {
         case Some(prefix) =>
           val reference =
-            definingPrefixResolver.resolvePrefix(prefix).getOrElse(
-              throw RuntimeException(s"Unknown implicit prefix for type $name: $prefix"),
-            )
-          SubjectType.implicitPrefix(reference)
-        case None => SubjectType.base
+            definingPrefixResolver.resolvePrefix(prefix) match {
+              case Some(p) => p
+              case _ => throw RuntimeException(s"Unknown implicit prefix for type $name: $prefix")
+            }
+          new SubjectType.implicitPrefix(reference)
+        case _ => SubjectType.base
       }
   }
 
@@ -521,15 +601,17 @@ final case class TypeView(_type: TypeDefinition, definingSchema: SchemaDefinitio
 
         case _ => UnknownType
       }
-    case None => UnknownType
+    case _ => UnknownType
   }
 
   /** The [[CoreType]] representation of this type.
     */
   def coreType: CoreType = runtimeType.repr
 
-  def uriOrCurie: UriOrCurie =
-    _type.typeUri.getOrElse(Uri.synthetic(defaultPrefixUri, _type.name))
+  def uriOrCurie: UriOrCurie = _type.typeUri match {
+    case Some(uri) => uri
+    case _ => Uri.synthetic(defaultPrefixUri, _type.name)
+  }
 }
 
 final case class SubsetView(subset: SubsetDefinition, definingSchema: SchemaDefinition)(using

--- a/schemaview/src/eu/neverblink/linkml/schemaview/ElementView.scala
+++ b/schemaview/src/eu/neverblink/linkml/schemaview/ElementView.scala
@@ -185,7 +185,7 @@ final case class ClassView(cls: ClassDefinition, definingSchema: SchemaDefinitio
     * @return
     *   Direct parents of the class, mixins before inheritance
     */
-  def parents: Iterable[ClassView] = getParents(this)
+  def parents: Seq[ClassView] = getParents(this)
 
   /** Get the subject type for this class, if possible. Uses the class' identifier slot's range.
     * @return
@@ -193,7 +193,7 @@ final case class ClassView(cls: ClassDefinition, definingSchema: SchemaDefinitio
     */
   def subjectType: Option[SubjectType] = identifierView.map(_.subjectType)
 
-  private def getParents(view: ClassView): Iterable[ClassView] = {
+  private def getParents(view: ClassView): Seq[ClassView] = {
     val parents = new ListBuffer[ClassView]
     val cls = view.cls
     cls.mixins.foreach { r =>

--- a/schemaview/src/eu/neverblink/linkml/schemaview/Importer.scala
+++ b/schemaview/src/eu/neverblink/linkml/schemaview/Importer.scala
@@ -1,11 +1,11 @@
 package eu.neverblink.linkml.schemaview
 
 import eu.neverblink.linkml.metamodel.{Codec, SchemaDefinition}
+import eu.neverblink.linkml.runtime.FastUtils.*
 import eu.neverblink.linkml.validation.*
 import eu.neverblink.linkml.yaml.DecodeError
 import org.virtuslab.yaml.{ConstructError, ParseError, Range, ScannerError, YamlError, parseYaml}
 
-import scala.util.Try
 import scala.util.control.NonFatal
 
 /** Failure of reading or parsing a schema, as a structured issue from the validation model. */
@@ -43,18 +43,19 @@ trait Importer {
     *   failure
     */
   def parseSchema(yaml: String, uri: String = ""): Either[SchemaParseError, SchemaDefinition] =
-    parseYaml(yaml) match {
+    new Left(parseYaml(yaml) match {
       case Right(node) =>
         // The metamodel decoder signals structural problems by throwing DecodeError, which carries
         // the offending node's position.
-        try Right(Codec.codec.decode(node))
+        try return new Right(Codec.codec.decode(node))
         catch {
           case ex: DecodeError =>
-            Left(Importer.parseError(ex.getMessage, uri, ex.position.map(Importer.codeRegion)))
-          case NonFatal(ex) => Left(Importer.parseError(ex.getMessage, uri, None))
+            Importer.parseError(ex.getMessage, uri, ex.position.map(Importer.codeRegion))
+          case ex if NonFatal(ex) =>
+            Importer.parseError(ex.getMessage, uri, None)
         }
-      case Left(err) => Left(Importer.parseError(err.msg, uri, Importer.codeRegionOf(err)))
-    }
+      case Left(err) => Importer.parseError(err.msg, uri, Importer.codeRegionOf(err))
+    })
 }
 
 object Importer {
@@ -65,8 +66,8 @@ object Importer {
       uri: String,
       codeRegion: Option[CodeRegionImpl],
   ): SchemaParseError =
-    SchemaParseErrorImpl(
-      location = IssueLocationImpl(codeRegion = codeRegion),
+    new SchemaParseErrorImpl(
+      location = new IssueLocationImpl(codeRegion = codeRegion),
       parserMessage = parserMessage,
       sourceUri = uri,
     )
@@ -74,26 +75,26 @@ object Importer {
   /** Extract the position a [[YamlError]] reported, if it carries one.
     */
   private def codeRegionOf(error: YamlError): Option[CodeRegionImpl] = error match {
-    case e: ParseError.ExpectedTokenKind => Some(codeRegion(e.got.range))
-    case e: ScannerError.Obtained => Some(codeRegion(e.got.range))
-    case e: ScannerError.AtRange => Some(codeRegion(e.range))
-    case e: ConstructError => e.node.flatMap(_.pos).map(codeRegion)
+    case e: ParseError.ExpectedTokenKind => new Some(codeRegion(e.got.range))
+    case e: ScannerError.Obtained => new Some(codeRegion(e.got.range))
+    case e: ScannerError.AtRange => new Some(codeRegion(e.range))
+    case e: ConstructError => e.node.flatMapFast(_.pos).mapFast(codeRegion)
     // ComposerError and NoRegisteredTagDirective carry no position.
     case _ => None
   }
 
   /** Convert a YAML [[Range]], whose lines and columns are 0-based, into a 1-based code region. */
   private[schemaview] def codeRegion(range: Range): CodeRegionImpl =
-    CodeRegionImpl(
+    new CodeRegionImpl(
       startLine = range.start.line + 1,
       startColumn = range.start.column + 1,
-      endLine = range.end.map(_.line + 1),
-      endColumn = range.end.map(_.column + 1),
+      endLine = range.end.mapFast(_.line + 1),
+      endColumn = range.end.mapFast(_.column + 1),
     )
 
   /** Build a [[SchemaImportError]] for a schema text that could not be obtained at all. */
   private[schemaview] def importError(uri: String, reason: String): SchemaImportError =
-    SchemaImportErrorImpl(
+    new SchemaImportErrorImpl(
       location = IssueLocationImpl(),
       importUri = uri,
       reason = reason,
@@ -103,8 +104,10 @@ object Importer {
   private[schemaview] def readText(
       uri: String,
   )(read: => String): Either[SchemaImportError, String] =
-    Try(read).toEither.left.map(ex => importError(uri, ex.getMessage))
-
+    try new Right(read)
+    catch {
+      case ex if NonFatal(ex) => new Left(importError(uri, ex.getMessage))
+    }
 }
 
 /** A simple Importer that reads the schema text as a string and then parses it into a
@@ -115,7 +118,7 @@ trait StringImporter extends Importer {
   final override def readSchema(path: String): Either[ImportFailure, SchemaDefinition] =
     Importer.readText(path)(read(path)) match {
       case Right(text) => parseSchema(text, path)
-      case Left(failure) => Left(failure)
+      case err => err.asInstanceOf[Either[ImportFailure, SchemaDefinition]]
     }
 
   /** Read the schema text from the given path and return it as a string.

--- a/schemaview/src/eu/neverblink/linkml/schemaview/InlineType.scala
+++ b/schemaview/src/eu/neverblink/linkml/schemaview/InlineType.scala
@@ -17,15 +17,15 @@ object InlineType {
   /** Derive an [[InlineType]] for a given slot's range using an implicit SchemaView
     */
   def apply(v: SlotView): InlineType = {
-    val inlined = v.derivedInlined
-
-    if !v.slot.required && !v.slot.multivalued then optional
-    else if v.slot.multivalued && (!inlined || v.slot.inlinedAsList) then list
-    else if v.slot.multivalued && inlined && !v.slot.inlinedAsList then {
-      CollectionForm.ofRange(v) match {
-        case CollectionForm.ListOnly => list
-        case style: DictForm => dict(style)
-      }
-    } else plain
+    val slot = v.slot
+    if (slot.multivalued) {
+      if (!slot.inlinedAsList && v.derivedInlined) {
+        CollectionForm.ofRange(v) match {
+          case style: DictForm => dict(style)
+          case _ => list
+        }
+      } else list
+    } else if (slot.required) plain
+    else optional
   }
 }

--- a/schemaview/src/eu/neverblink/linkml/schemaview/MacroValidator.scala
+++ b/schemaview/src/eu/neverblink/linkml/schemaview/MacroValidator.scala
@@ -220,9 +220,13 @@ private class ReferenceValidatorImpl(using Quotes) extends MacroUtils {
         case '[t1] =>
           val seq = x.asInstanceOf[Expr[Seq[t1]]]
           '{
-            $seq.zipWithIndex.map((e, idx) =>
-              ${ genValidator[t1](tpe1, 'e, sv, vc) }.prependedPath(s"$idx/"),
-            ).fold(ValidatorResult.ok)(_ + _)
+            $seq.foldLeft(ValidatorResult.ok) {
+              var idx = 0
+              (acc, e) =>
+                val res = ${ genValidator[t1](tpe1, 'e, sv, vc) }.prependedPath(s"$idx/")
+                idx += 1
+                acc + res
+            }
           }
       }
     }
@@ -233,9 +237,9 @@ private class ReferenceValidatorImpl(using Quotes) extends MacroUtils {
         case ('[t1], '[t2]) =>
           val map = x.asInstanceOf[Expr[Map[t1, t2]]]
           '{
-            $map.map((k, v) => ${ genValidator[t2](tpe2, 'v, sv, vc) }.prependedPath(s"$k/")).fold(
-              ValidatorResult.ok,
-            )(_ + _)
+            $map.foldLeft(ValidatorResult.ok) { case (acc, (k, v)) =>
+              acc + ${ genValidator[t2](tpe2, 'v, sv, vc) }.prependedPath(s"$k/")
+            }
           }
       }
     }

--- a/schemaview/src/eu/neverblink/linkml/schemaview/MacroValidator.scala
+++ b/schemaview/src/eu/neverblink/linkml/schemaview/MacroValidator.scala
@@ -74,8 +74,7 @@ object ValidatorResult {
   */
 final case class UnknownReference(path: String, referenceValue: String):
   /** Add a [[prefix]] to this class' path */
-  def prependedPath(prefix: String): UnknownReference =
-    copy(path = prefix + path)
+  def prependedPath(prefix: String): UnknownReference = copy(path = prefix.concat(path))
 
 /** A `range` reference that is resolvable, but points to an invalid value
   *
@@ -88,8 +87,7 @@ final case class UnknownReference(path: String, referenceValue: String):
   */
 final case class InvalidRange(path: String, value: String, actualType: String):
   /** Add a [[prefix]] to this class' path */
-  def prependedPath(prefix: String): InvalidRange =
-    copy(path = prefix + path)
+  def prependedPath(prefix: String): InvalidRange = copy(path = prefix.concat(path))
 
 /** An inferred default `range`, that is not allowed as the `default_range` slot is not resolvable.
   *
@@ -98,8 +96,7 @@ final case class InvalidRange(path: String, value: String, actualType: String):
   */
 final case class InvalidDefaultRange(path: String):
   /** Add a [[prefix]] to this class' path */
-  def prependedPath(prefix: String): InvalidDefaultRange =
-    copy(path = prefix + path)
+  def prependedPath(prefix: String): InvalidDefaultRange = copy(path = prefix.concat(path))
 
 private trait MacroValidator[T] {
   def validate(t: T)(using SchemaView, ValidatorContext): ValidatorResult

--- a/schemaview/src/eu/neverblink/linkml/schemaview/SchemaIssues.scala
+++ b/schemaview/src/eu/neverblink/linkml/schemaview/SchemaIssues.scala
@@ -1,5 +1,6 @@
 package eu.neverblink.linkml.schemaview
 
+import eu.neverblink.linkml.runtime.FastUtils.*
 import eu.neverblink.linkml.validation.{IssueSeverity, SchemaFatal, SchemaIssue}
 
 /** Presentation helpers for the generated schema validation report model.
@@ -12,7 +13,7 @@ object SchemaIssues {
     *   Only populated on issues that have been through `infer()`; the validator does not do that
     *   for you.
     */
-  def description(issue: SchemaIssue): String = issue.message.getOrElse("")
+  def description(issue: SchemaIssue): String = issue.message.getOrElseFast("")
 
   /** Longer description, including hints to fix where applicable. Issues whose long form is
     * identical to the short one declare no `details`, so fall back to `message`.
@@ -20,13 +21,14 @@ object SchemaIssues {
     * @note
     *   Only populated on issues that have been through `infer()`.
     */
-  def verbose(issue: SchemaIssue): String = issue.details.orElse(issue.message).getOrElse("")
+  def verbose(issue: SchemaIssue): String =
+    issue.details.orElseFast(issue.message).getOrElseFast("")
 
   /** Human-readable severity label. */
   def level(issue: SchemaIssue): String = issue.severity match {
-    case IssueSeverity.Fatal => "Fatal"
-    case IssueSeverity.Error => "Error"
-    case IssueSeverity.Warning => "Warning"
+    case _: IssueSeverity.Fatal.type => "Fatal"
+    case _: IssueSeverity.Error.type => "Error"
+    case _: IssueSeverity.Warning.type => "Warning"
   }
 
   /** Format a collection of issues into a text representation
@@ -48,13 +50,15 @@ object SchemaIssues {
   ): String = {
     val limited = problems.take(maxProblems)
     val stringified = limited.map(x =>
-      (if showLevel then level(x) + ": " else "") +
-        (if verbose then SchemaIssues.verbose(x) else description(x)),
+      (if showLevel then level(x).concat(": ") else "").concat(
+        if verbose then SchemaIssues.verbose(x) else description(x),
+      ),
     )
     val printed = stringified.mkString("\n")
     val restCount = problems.size - maxProblems
-    val rest = if restCount > 0 then s"\nand $restCount more problems..." else ""
-    printed + rest
+    if (restCount > 0) {
+      s"$printed\nand $restCount more problems..."
+    } else printed
   }
 
   /** Exception thrown when a schema cannot be loaded at all – a parse failure, an unreadable

--- a/schemaview/src/eu/neverblink/linkml/schemaview/SchemaReachabilityQuery.scala
+++ b/schemaview/src/eu/neverblink/linkml/schemaview/SchemaReachabilityQuery.scala
@@ -18,7 +18,7 @@ sealed abstract class SchemaReachabilityQuery(using sv: SchemaView) {
     *   true if the provided [[Element]] is reachable
     */
   def reachable(element: Element): Boolean =
-    resolved.contains(ElementTypeTag(element) -> element.name)
+    resolved.contains((ElementTypeTag(element), element.name))
 
   /** @return
     *   true if the underlying [[Element]] of the provided [[ElementView]] is reachable

--- a/schemaview/src/eu/neverblink/linkml/schemaview/SchemaReachabilityQuery.scala
+++ b/schemaview/src/eu/neverblink/linkml/schemaview/SchemaReachabilityQuery.scala
@@ -1,6 +1,7 @@
 package eu.neverblink.linkml.schemaview
 
 import eu.neverblink.linkml.metamodel.*
+import eu.neverblink.linkml.runtime.FastUtils.*
 import SchemaReachabilityQuery.*
 import ElementTypeTag.*
 
@@ -105,22 +106,19 @@ final class DerivedReachabilityQuery(
       case ElementTypeTag.typeDef =>
         val type_ = sv.types(name)._type
         type_.typeof.foreach { tr =>
-          tr.resolve match {
-            case Some(td) => result.addOne((typeDef, td.name))
-            case _ =>
+          tr.resolve.foreachFast { td =>
+            result.addOne((typeDef, td.name))
           }
         }
         type_.unionOf.foreach { tr =>
-          tr.resolve match {
-            case Some(td) => result.addOne((typeDef, td.name))
-            case _ =>
+          tr.resolve.foreachFast { td =>
+            result.addOne((typeDef, td.name))
           }
         }
       case ElementTypeTag.enumDef =>
         sv.enums(name)._enum.inherits.foreach { er =>
-          er.resolve match {
-            case Some(ed) => result.addOne((enumDef, ed.name))
-            case _ =>
+          er.resolve.foreachFast { ed =>
+            result.addOne((enumDef, ed.name))
           }
         }
       case _ =>
@@ -172,37 +170,32 @@ final class UnderivedReachabilityQuery(
       case ElementTypeTag.typeDef =>
         val type_ = sv.types(name)._type
         type_.typeof.foreach { tr =>
-          tr.resolve match {
-            case Some(td) => result.addOne((typeDef, td.name))
-            case _ =>
+          tr.resolve.foreachFast { td =>
+            result.addOne((typeDef, td.name))
           }
         }
         type_.unionOf.foreach { tr =>
-          tr.resolve match {
-            case Some(td) => result.addOne((typeDef, td.name))
-            case _ =>
+          tr.resolve.foreachFast { td =>
+            result.addOne((typeDef, td.name))
           }
         }
       case ElementTypeTag.slotDef =>
         val slotView = sv.slotDefinitions(name)
         slotView.slot.isA.foreach { sr =>
-          sr.resolve match {
-            case Some(sd) => result.addOne((slotDef, sd.name))
-            case _ =>
+          sr.resolve.foreachFast { sd =>
+            result.addOne((slotDef, sd.name))
           }
         }
         slotView.slot.mixins.foreach { sr =>
-          sr.resolve match {
-            case Some(sd) => result.addOne((slotDef, sd.name))
-            case _ =>
+          sr.resolve.foreachFast { sd =>
+            result.addOne((slotDef, sd.name))
           }
         }
         collectSlotRefs(slotView, result)
       case ElementTypeTag.enumDef =>
         sv.enums(name)._enum.inherits.foreach { er =>
-          er.resolve match {
-            case Some(ed) => result.addOne((enumDef, ed.name))
-            case _ =>
+          er.resolve.foreachFast { ed =>
+            result.addOne((enumDef, ed.name))
           }
         }
       case _ =>

--- a/schemaview/src/eu/neverblink/linkml/schemaview/SchemaValidator.scala
+++ b/schemaview/src/eu/neverblink/linkml/schemaview/SchemaValidator.scala
@@ -1,7 +1,8 @@
 package eu.neverblink.linkml.schemaview
 
 import eu.neverblink.linkml.metamodel.*
-import eu.neverblink.linkml.runtime.{NcName, PrefixResolver, Reference}
+import eu.neverblink.linkml.runtime.{NcName, PrefixResolver, Reference, Uri}
+import eu.neverblink.linkml.runtime.FastUtils.*
 import eu.neverblink.linkml.validation.*
 
 import java.util
@@ -14,7 +15,7 @@ final class SchemaValidator(using sv: SchemaView) {
 
   /** Location of an issue that is pinned to a JSON path within the root schema. */
   private def at(jsonPath: String): IssueLocationImpl =
-    IssueLocationImpl(schemaId = Some(sv.root.id), jsonPointer = Some(jsonPath))
+    new IssueLocationImpl(schemaId = new Some(sv.root.id), jsonPointer = new Some(jsonPath))
 
   /** Location of an issue that pertains to a class of the root schema. */
   private def classLocation(className: String): IssueLocationImpl =
@@ -22,7 +23,7 @@ final class SchemaValidator(using sv: SchemaView) {
 
   /** Location of an issue that pertains to the root schema as a whole. */
   private def rootLocation: IssueLocationImpl =
-    IssueLocationImpl(schemaId = Some(sv.root.id))
+    IssueLocationImpl(schemaId = new Some(sv.root.id))
 
   // TODO: warn about shadowing
 
@@ -45,7 +46,7 @@ final class SchemaValidator(using sv: SchemaView) {
       // gets its own issue type with a hint.
       if ref.referenceValue == "string" then UnknownStringReferenceImpl(location = at(ref.path))
       else
-        UnknownReferenceImpl(
+        new UnknownReferenceImpl(
           location = at(ref.path),
           referenceValue = ref.referenceValue,
         ),
@@ -54,30 +55,35 @@ final class SchemaValidator(using sv: SchemaView) {
   /** Any usages of an undefined `default_range`. Empty if no usages found. */
   lazy val usedUndefinedDefaultRange: Seq[SchemaFatal] =
     macroResult.invalidDefaultRanges.map(range =>
-      InvalidDefaultRangeImpl(location = at(range.path)),
+      new InvalidDefaultRangeImpl(location = at(range.path)),
     )
 
   lazy val schemaIdClash: Seq[SchemaFatal] = {
-    val schemas = sv.schemas.toIndexedSeq
-    for
-      (s1, s1index) <- schemas.zipWithIndex
-      s2 <- schemas.slice(s1index + 1, schemas.size)
-      if s1.id == s2.id
-        // TODO LNK-154 Robust file system importing
-        && s1 != s2
-    yield SchemaIdClashImpl(location = IssueLocationImpl(schemaId = Some(s1.id)))
+    val clashes = Vector.newBuilder[SchemaFatal]
+    val schemas = sv.schemas
+    schemas.foreach {
+      val seen = new util.HashMap[Uri, SchemaDefinition](schemas.size << 1, 0.5f)
+      s1 =>
+        val s2 = seen.getOrDefault(s1.id, s1)
+        if (s1 != s2) { // TODO LNK-154 Robust file system importing
+          clashes.addOne(
+            new SchemaIdClashImpl(location = IssueLocationImpl(schemaId = new Some(s1.id))),
+          )
+        }
+    }
+    clashes.result()
   }
 
   /** Warning if defining a slot without a `range` will cause a fatal error, None otherwise
     */
   private lazy val undefinedDefaultRange: Option[SchemaWarning] =
     if isDefaultRangeAllowed then None
-    else Some(UndefinedDefaultRangeImpl(location = rootLocation))
+    else new Some(UndefinedDefaultRangeImpl(location = rootLocation))
 
   /** Any `range` slots pointing at invalid elements in the schema. */
   lazy val invalidRangeTypes: Seq[SchemaFatal] =
     macroResult.invalidRanges.map(range =>
-      InvalidRangeImpl(
+      new InvalidRangeImpl(
         location = at(range.path),
         rangeValue = range.value,
         actualType = range.actualType,
@@ -91,7 +97,7 @@ final class SchemaValidator(using sv: SchemaView) {
     // if len(tree_roots) > 0: # -> validation error
     val treeRoots = sv.root.classes.values.filter(_.treeRoot).toSeq
     if treeRoots.size > 1 then
-      Some(
+      new Some(
         MultipleTreeRootsImpl(
           location = rootLocation,
           classNames = treeRoots.map(_.name),
@@ -103,7 +109,7 @@ final class SchemaValidator(using sv: SchemaView) {
   /** Warning when there does not exist a `tree_root` class, None otherwise */
   private lazy val noTreeRoot: Option[SchemaWarning] = {
     val treeRoots = sv.root.classes.values.filter(_.treeRoot)
-    if treeRoots.isEmpty then Some(NoTreeRootClassImpl(location = rootLocation))
+    if treeRoots.isEmpty then new Some(NoTreeRootClassImpl(location = rootLocation))
     else None
 
   }
@@ -118,20 +124,20 @@ final class SchemaValidator(using sv: SchemaView) {
         .collect { case s if s.slot.identifier || s.slot.key => s.slot }
       if (keyOrId.size > 1) {
         errors.addOne(
-          MultipleKeyOrIdSlotsImpl(
+          new MultipleKeyOrIdSlotsImpl(
             location = classLocation(derivedCls.cls.name),
             className = derivedCls.cls.name,
             slotNames = keyOrId.toSeq.map(_.name),
           ),
         )
       } else if (keyOrId.size == 1) {
-        keyOrId.head.range.flatMap(sv.resolve).orElse(sv.schemas.collectFirst {
-          case s if s.defaultRange.isDefined => s.defaultRange.flatMap(sv.resolve)
-        }.flatten).orNull match {
+        keyOrId.head.range.flatMapFast(sv.resolve).orElseFast(sv.schemas.collectFirst {
+          case s if s.defaultRange.isDefined => sv.resolve(s.defaultRange.get)
+        }.flatten).orNullFast match {
           case _: TypeDefinition | null =>
           case elem =>
             errors.addOne(
-              InvalidKeyOrIdSlotTypeImpl(
+              new InvalidKeyOrIdSlotTypeImpl(
                 location = classLocation(derivedCls.cls.name),
                 className = derivedCls.cls.name,
                 elementName = elem.name,
@@ -293,7 +299,7 @@ final class SchemaValidator(using sv: SchemaView) {
         .filter(x => !applicableSlotNames.contains(x))
       if (problemSlots.nonEmpty) {
         acc.addOne(
-          InvalidSlotUsageImpl(
+          new InvalidSlotUsageImpl(
             location = classLocation(cls.cls.name),
             className = cls.cls.name,
             slotNames = problemSlots.toSeq,
@@ -310,7 +316,7 @@ final class SchemaValidator(using sv: SchemaView) {
   ): Option[SchemaError] = {
     slotDefinition.implicitPrefix match {
       case Some(prefix) if prefixResolver.resolvePrefix(prefix).isEmpty =>
-        Some(
+        new Some(
           undefinedPrefix(prefix, s"$locationPrefix/${slotDefinition.name}/implicit_prefix"),
         )
       case _ => None
@@ -323,20 +329,19 @@ final class SchemaValidator(using sv: SchemaView) {
   private lazy val unknownPrefixes: Seq[SchemaError] = {
     sv.root.emitPrefixes.zipWithIndex.flatMap((prefix, idx) =>
       if sv.rootPrefixResolver.resolvePrefix(prefix).isEmpty
-      then Some(undefinedPrefix(prefix, s"/emit_prefixes/$idx"))
+      then new Some(undefinedPrefix(prefix, s"/emit_prefixes/$idx"))
       else None,
     ) ++
       sv.types.values.flatMap(tv => {
         tv._type.implicitPrefix match {
           case Some(prefix) if tv.definingPrefixResolver.resolvePrefix(prefix).isEmpty =>
-            Some(undefinedPrefix(prefix, s"/types/${tv._type.name}/implicit_prefix"))
+            new Some(undefinedPrefix(prefix, s"/types/${tv._type.name}/implicit_prefix"))
           case _ => None
         }
       }) ++
       sv.slotDefinitions.values.flatMap(slotView =>
         slotImplicitPrefix(slotView.inner, slotView.definingPrefixResolver, "/slots"),
-      )
-      ++
+      ) ++
       sv.classes.values.flatMap(classView =>
         classView.cls.slotUsage.values.flatMap(
           slotImplicitPrefix(
@@ -359,9 +364,9 @@ final class SchemaValidator(using sv: SchemaView) {
     sv.elements.values.flatMap { elem =>
       if elem.uriOrCurie.isValid then None
       else
-        Some(
-          InvalidUriOrCurieImpl(
-            location = IssueLocationImpl(schemaId = Some(elem.definingSchema.id)),
+        new Some(
+          new InvalidUriOrCurieImpl(
+            location = IssueLocationImpl(schemaId = new Some(elem.definingSchema.id)),
             uriOrCurie = elem.uriOrCurie,
             elementType = elem.elementType,
             elementName = elem.inner.name,

--- a/schemaview/src/eu/neverblink/linkml/schemaview/SchemaValidator.scala
+++ b/schemaview/src/eu/neverblink/linkml/schemaview/SchemaValidator.scala
@@ -416,18 +416,17 @@ final class SchemaValidator(using sv: SchemaView) {
     * @return
     *   None if no problems were
     */
-  def lint(maxProblems: Int = 5, verbose: Boolean = false): Option[String] = {
-    if lintProblems.isEmpty then None
-    else
-      Some(
-        s"Found ${lintProblems.size} problems in the schema:\n" + SchemaIssues.format(
-          lintProblems.map(_.infer()),
-          maxProblems,
-          verbose,
-          showLevel = true,
-        ),
+  def lint(maxProblems: Int = 5, verbose: Boolean = false): Option[String] =
+    if (lintProblems.isEmpty) None
+    else {
+      val formattedProblems = SchemaIssues.format(
+        lintProblems.map(_.infer()),
+        maxProblems,
+        verbose,
+        showLevel = true,
       )
-  }
+      new Some(s"Found ${lintProblems.size} problems in the schema:\n$formattedProblems")
+    }
 }
 
 object SchemaValidator {

--- a/schemaview/src/eu/neverblink/linkml/schemaview/SchemaView.scala
+++ b/schemaview/src/eu/neverblink/linkml/schemaview/SchemaView.scala
@@ -129,9 +129,9 @@ final case class SchemaView(schemas: Seq[SchemaDefinition]) extends ReferenceRes
     * These should be used in ElementView instead of creating a new prefix resolver every time.
     */
   private lazy val prefixResolvers: Map[Uri, BasicPrefixResolver] =
-    schemas.foldLeft(Map.empty[Uri, BasicPrefixResolver]) { (acc, schema) =>
-      acc.updated(schema.id, createPrefixResolver(schema))
-    }
+    schemas.foldLeft(Map.newBuilder[Uri, BasicPrefixResolver]) { (acc, schema) =>
+      acc.addOne((schema.id, createPrefixResolver(schema)))
+    }.result()
 
   def getPrefixResolver(schema: SchemaDefinition): BasicPrefixResolver =
     prefixResolvers(schema.id)
@@ -219,16 +219,15 @@ final case class SchemaView(schemas: Seq[SchemaDefinition]) extends ReferenceRes
     * `Option[ClassView]`.
     */
   def treeRootWithOverride(treeRootOverride: Option[String]): Try[Option[ClassView]] =
-    treeRootOverride match {
+    new Success(treeRootOverride match {
       case Some(className) =>
-        classes.get(className) match {
-          case x: Some[_] => new Success(x)
-          case _ =>
-            val msg = s"Could not find class '$className' defined as the tree root override"
-            new Failure(new RuntimeException(msg))
-        }
-      case _ => new Success(treeRoot)
-    }
+        val optCv = classes.get(className)
+        if (optCv eq None) {
+          val msg = s"Could not find class '$className' defined as the tree root override"
+          return new Failure(new RuntimeException(msg))
+        } else optCv
+      case _ => treeRoot
+    })
 
   /** Apply `slot_usage` and `attributes` for a class and then its ancestors, with mixins having
     * priority.

--- a/schemaview/src/eu/neverblink/linkml/schemaview/SchemaView.scala
+++ b/schemaview/src/eu/neverblink/linkml/schemaview/SchemaView.scala
@@ -281,27 +281,17 @@ final case class SchemaView(schemas: Seq[SchemaDefinition]) extends ReferenceRes
   {
     val problems = validator.fatalProblems
     if (problems.nonEmpty) {
-      val formatted = SchemaProblem.format(
-        problems,
-        maxProblems = 5,
-        verbose = true,
-        showLevel = false,
-      )
-      sys.error(s"Fatal validation problems:\n$formatted")
+      throw SchemaIssues.FatalSchemaException(problems.map(_.infer()), maxProblems = 5)
     }
   }
 
   /** Whether the merged schema is valid */
-  lazy val isValid: Boolean = validator.validate().isSuccess
+  lazy val isValid: Boolean = validator.validationProblems.isEmpty
 
-  /** Validate the merged schema, checking for errors and fatal errors
-    *
-    * @param maxProblems
-    *   Max number of problems to include
-    * @return
-    *   Unit if the schema is valid, an exception with formatted problems otherwise
+  /** Errors and fatal problems in the merged schema, empty if the schema is valid. Warnings are not
+    * included - use [[lint]] for a report that covers those too.
     */
-  def validate(maxProblems: Int = 5): Try[Unit] = validator.validate(maxProblems)
+  def validationProblems: Seq[SchemaError | SchemaFatal] = validator.validationProblems
 
   /** Produce validation report with all detected problems
     *
@@ -343,7 +333,8 @@ object SchemaView {
   def loadSchemaViewFromUri(
       uri: String,
       importer: Importer = FileSystemImporter,
-  ): SchemaView = new SchemaView(loadSchemas(uri, importer))
+  ): Either[Seq[SchemaFatal], SchemaView] =
+    guarded(loadSchemas(uri, importer).left.map(Seq(_)).flatMap(viewOf))
 
   /** Loads a schema view from the specified YAML string, loading its imports. This is mainly for
     * testing and custom applications, as in most cases you would want to load from a URI to get
@@ -361,10 +352,28 @@ object SchemaView {
   def loadSchemaViewFromString(
       yaml: String,
       importer: Importer = FileSystemImporter,
-  ): SchemaView = {
-    val root = importer.parseSchema(yaml)
-    new SchemaView(root +: loadImports(root, "", importer))
-  }
+  ): Either[Seq[SchemaFatal], SchemaView] =
+    guarded(
+      importer.parseSchema(yaml)
+        .flatMap(root => loadImports(root, "", importer).map(root +: _))
+        .left.map(Seq(_))
+        .flatMap(viewOf),
+    )
+
+  /** Run a load, reporting anything it throws as an
+    * [[eu.neverblink.linkml.validation.UnexpectedError]].
+    */
+  private def guarded(
+      load: => Either[Seq[SchemaFatal], SchemaView],
+  ): Either[Seq[SchemaFatal], SchemaView] =
+    try load
+    catch { case NonFatal(ex) => Left(Seq(unexpectedError(ex))) }
+
+  private def unexpectedError(ex: Throwable): UnexpectedErrorImpl =
+    UnexpectedErrorImpl(
+      location = IssueLocationImpl(),
+      reason = Option(ex.getMessage).getOrElse(ex.toString),
+    )
 
   /** Loads individual schema definitions from the specified URI, optionally loading their imports.
     * Import loading is recursive.
@@ -385,15 +394,38 @@ object SchemaView {
   def loadSchemas(
       uri: String,
       importer: Importer = FileSystemImporter,
-  ): Seq[SchemaDefinition] =
+  ): Either[ImportFailure, Seq[SchemaDefinition]] =
     loadSchemasInternal(uri, true, importer, mutable.Set.empty)
+
+  /** Build a view from already-loaded schemas, turning the constructor's fatal validation problems
+    * into a Left rather than an exception.
+    */
+  private def viewOf(schemas: Seq[SchemaDefinition]): Either[Seq[SchemaFatal], SchemaView] =
+    try Right(SchemaView(schemas))
+    catch {
+      case ex: SchemaIssues.FatalSchemaException => Left(ex.problems)
+      case NonFatal(ex) => Left(Seq(unexpectedError(ex)))
+    }
+
+  /** Load one of the schemas bundled as a resource, reporting a missing resource as an import
+    * failure rather than letting the resource lookup throw.
+    */
+  private def builtIn(
+      uri: String,
+      resource: String,
+      importer: Importer,
+  ): Either[ImportFailure, SchemaDefinition] =
+    Importer.readText(uri)(Resources.read(resource)) match {
+      case Right(text) => importer.parseSchema(text, uri)
+      case Left(failure) => Left(failure)
+    }
 
   private def loadSchemasInternal(
       uri: String,
       doImportLoading: Boolean,
       importer: Importer,
       visited: mutable.Set[String],
-  ): Seq[SchemaDefinition] = {
+  ): Either[ImportFailure, Seq[SchemaDefinition]] = {
     // TODO LNK-154 Robust file system importing
     var normalizedUri = uri.stripSuffix(PlatformSpecificUtils.separator)
     if (!normalizedUri.endsWith(".yaml") && !normalizedUri.endsWith(".yml")) {
@@ -401,27 +433,27 @@ object SchemaView {
     }
     // After URI normalization, check if we've already visited this URI to avoid infinite loops
     // and repeatedly loading the same schema.
-    if visited.contains(normalizedUri) then Seq()
+    if visited.contains(normalizedUri) then Right(Seq())
     else
       visited.add(normalizedUri)
-      val schema: SchemaDefinition =
+      // Built-in schemas come from bundled resources, everything else from the importer. Both
+      // routes yield the same structured issues on failure.
+      val loaded: Either[ImportFailure, SchemaDefinition] =
         if (normalizedUri.startsWith("https://w3id.org/linkml/")) {
-          importer.parseSchema(Resources.read(normalizedUri.stripPrefix("https://w3id.org/linkml")))
+          builtIn(normalizedUri, normalizedUri.stripPrefix("https://w3id.org/linkml"), importer)
         } else if (normalizedUri.startsWith("linkml:")) {
-          importer.parseSchema(Resources.read("/".concat(normalizedUri.stripPrefix("linkml:"))))
+          builtIn(normalizedUri, "/" + normalizedUri.stripPrefix("linkml:"), importer)
         } else {
-          try importer.readSchema(normalizedUri)
-          catch {
-            case ex if NonFatal(ex) =>
-              sys.error(s"Cannot import schema '$normalizedUri'\n${ex.getMessage}")
-          }
+          importer.readSchema(normalizedUri)
         }
-      if (doImportLoading) {
-        var baseUri = ""
-        val idx = normalizedUri.lastIndexOf(PlatformSpecificUtils.separator)
-        if (idx > 0) baseUri = normalizedUri.substring(0, idx)
-        schema +: loadImportsInternal(schema, baseUri, importer, visited)
-      } else Seq(schema)
+      loaded.flatMap { schema =>
+        if (doImportLoading) {
+          var baseUri = ""
+          val idx = normalizedUri.lastIndexOf(PlatformSpecificUtils.separator)
+          if (idx > 0) baseUri = normalizedUri.substring(0, idx)
+          loadImportsInternal(schema, baseUri, importer, visited).map(schema +: _)
+        } else Right(Seq(schema))
+      }
   }
 
   /** Loads a schema's imports from the specified schema, loading its imports recursively from the

--- a/schemaview/src/eu/neverblink/linkml/schemaview/SchemaView.scala
+++ b/schemaview/src/eu/neverblink/linkml/schemaview/SchemaView.scala
@@ -12,7 +12,7 @@ import eu.neverblink.linkml.validation.{
 }
 
 import scala.annotation.unused
-import scala.collection.mutable
+import scala.collection.{immutable, mutable}
 import scala.compiletime.erasedValue
 import scala.util.{Failure, Success, Try}
 import scala.util.control.NonFatal
@@ -36,13 +36,33 @@ final case class SchemaView(schemas: Seq[SchemaDefinition]) extends ReferenceRes
 
   inline def resolve[T](inline ref: Reference[T]): Option[T] =
     (inline erasedValue[T] match {
-      case _: TypeDefinition => types.get(ref.value).map(_._type)
-      case _: ClassDefinition => classes.get(ref.value).map(_.cls)
-      case _: EnumDefinition => enums.get(ref.value).map(_._enum)
-      case _: SubsetDefinition => subsets.get(ref.value).map(_.subset)
+      case _: TypeDefinition =>
+        types.get(ref.value) match {
+          case Some(tv) => new Some(tv._type)
+          case _ => None
+        }
+      case _: ClassDefinition =>
+        classes.get(ref.value) match {
+          case Some(cv) => new Some(cv.cls)
+          case _ => None
+        }
+      case _: EnumDefinition =>
+        enums.get(ref.value) match {
+          case Some(ev) => new Some(ev._enum)
+          case _ => None
+        }
+      case _: SubsetDefinition =>
+        subsets.get(ref.value) match {
+          case Some(sv) => new Some(sv.subset)
+          case _ => None
+        }
       // `range` slot's `range` is underspecified as per the metamodel notes,
       // I think it should be ClassDef | TypeDef | EnumDef
-      case _: Element => getElement(ref.value).map(_.inner)
+      case _: Element =>
+        elements.get(ref.value) match {
+          case Some(ev) => new Some(ev.inner)
+          case _ => None
+        }
       // And now... element views! (sigh)
       // You can cast the argument of this method to get a view instead of the raw definition.
       // I tried to make it nicer, but the Scala compiler said "no".
@@ -51,7 +71,7 @@ final case class SchemaView(schemas: Seq[SchemaDefinition]) extends ReferenceRes
       case _: EnumView => enums.get(ref.value)
       case _: SlotView => slotDefinitions.get(ref.value)
       case _: SubsetView => subsets.get(ref.value)
-      case _: ElementView[?, ?] => getElement(ref.value)
+      case _: ElementView[?, ?] => elements.get(ref.value)
       case _ => compiletime.error("SchemaView can't dereference ".concat(compiletime.codeOf(ref)))
     }).asInstanceOf[Option[T]]
 
@@ -96,43 +116,58 @@ final case class SchemaView(schemas: Seq[SchemaDefinition]) extends ReferenceRes
     }.result()
 
   lazy val elements: Map[String, ElementView[? <: Element, ?]] =
-    subsets ++ slotDefinitions ++ enums ++ types ++ classes
+    immutable.HashMap.newBuilder[String, ElementView[? <: Element, ?]]
+      .addAll(subsets)
+      .addAll(slotDefinitions)
+      .addAll(enums)
+      .addAll(types)
+      .addAll(classes)
+      .result()
 
   /** Cached prefix resolvers for each schema in the view.
     *
     * These should be used in ElementView instead of creating a new prefix resolver every time.
     */
   private lazy val prefixResolvers: Map[Uri, BasicPrefixResolver] =
-    schemas.map(schema => schema.id -> createPrefixResolver(schema)).toMap
+    schemas.foldLeft(Map.empty[Uri, BasicPrefixResolver]) { (acc, schema) =>
+      acc.updated(schema.id, createPrefixResolver(schema))
+    }
 
-  def getPrefixResolver(schema: SchemaDefinition): BasicPrefixResolver = {
+  def getPrefixResolver(schema: SchemaDefinition): BasicPrefixResolver =
     prefixResolvers(schema.id)
-  }
+
+  private val defaultRange = new Reference[TypeView]("string")
 
   /** Get the default range for the model, with the `string` type fallback as specified in the spec.
     *
     * @see
     *   https://linkml.io/linkml-model/latest/docs/specification/04derived-schemas/#rule-populate-schema-metadata
     */
-  def getDefaultRange(schema: SchemaDefinition): Reference[TypeView] = {
-    schema.defaultRange
-      .map(_.asInstanceOf[Reference[TypeView]])
-      .getOrElse(Reference[TypeView]("string"))
+  def getDefaultRange(schema: SchemaDefinition): Reference[TypeView] = schema.defaultRange match {
+    case Some(r) => r.asInstanceOf[Reference[TypeView]]
+    case _ => defaultRange
   }
 
   /** Get the default URI prefix (prefix map value) for the schema, with a fallback to the schema ID
     * (this fallback mirrors the python implementation).
     */
   def getDefaultPrefix(schema: SchemaDefinition): String = {
-    given PrefixResolver = getPrefixResolver(schema)
-    schema.defaultPrefix // NCName / CURIE prefix
-      .flatMap(schema.prefixes.get)
-      .map(_.prefixReference.uri) // URI prefix value
-      .getOrElse {
-        // fallback
+    given PrefixResolver = prefixResolvers(schema.id)
+    val prefixRef = schema.defaultPrefix match {
+      case Some(prefix) => schema.prefixes.get(prefix)
+      case _         => None
+    }
+    prefixRef match {
+      case Some(ref) => ref.prefixReference.uri
+      case _ =>
         val uri = schema.id.uri
-        if (uri.endsWith("#") || uri.endsWith("/")) uri else uri.concat("/")
-      }
+        val len = uri.length
+        if (len > 0) {
+          val ch = uri.charAt(len - 1)
+          if (ch == '#' || ch == '/') uri
+          else uri.concat("/")
+        } else "/"
+    }
   }
 
   /** Get all elements reachable from a given starting set, following slots, ranges, inheritance and
@@ -143,7 +178,7 @@ final case class SchemaView(schemas: Seq[SchemaDefinition]) extends ReferenceRes
     */
   def underivedReachabilityQuery(
       from: Seq[ElementView[?, ?]],
-  ): UnderivedReachabilityQuery = UnderivedReachabilityQuery(from)
+  ): UnderivedReachabilityQuery = new UnderivedReachabilityQuery(from)
 
   /** Get all elements reachable from a given starting set, following derived attributes and other
     * reference slots. This will run the query as-if schema derivation was performed.
@@ -163,7 +198,7 @@ final case class SchemaView(schemas: Seq[SchemaDefinition]) extends ReferenceRes
       from: Seq[ElementView[?, ?]],
       inlinedOnly: Boolean,
       includeClassAncestors: Boolean,
-  ): DerivedReachabilityQuery = DerivedReachabilityQuery(from, inlinedOnly, includeClassAncestors)
+  ): DerivedReachabilityQuery = new DerivedReachabilityQuery(from, inlinedOnly, includeClassAncestors)
 
   /** Get a schema element by its ID
     */
@@ -186,12 +221,12 @@ final case class SchemaView(schemas: Seq[SchemaDefinition]) extends ReferenceRes
     treeRootOverride match {
       case Some(className) =>
         classes.get(className) match {
-          case Some(cls) => Success(Some(cls))
+          case x: Some[_] => new Success(x)
           case _ =>
             val msg = s"Could not find class '$className' defined as the tree root override"
-            Failure(RuntimeException(msg))
+            new Failure(new RuntimeException(msg))
         }
-      case _ => Try(treeRoot)
+      case _ => new Success(treeRoot)
     }
 
   /** Apply `slot_usage` and `attributes` for a class and then its ancestors, with mixins having
@@ -207,12 +242,27 @@ final case class SchemaView(schemas: Seq[SchemaDefinition]) extends ReferenceRes
       cls: ClassDefinition,
   ): SlotDefinitionImpl = {
     var currentSlot = slot
-    def combine(s: SlotDefinitionImpl): Unit =
-      currentSlot = currentSlot.combineWith(s, combineRange)
-    cls.slotUsage.get(slotName).foreach(combine)
-    cls.attributes.get(slotName).foreach(combine)
-    for c <- cls.mixins.flatMap(resolve) do currentSlot = applySlotUsage(currentSlot, slotName, c)
-    for c <- cls.isA.flatMap(resolve) do currentSlot = applySlotUsage(currentSlot, slotName, c)
+    cls.slotUsage.get(slotName) match {
+      case Some(s) => currentSlot = currentSlot.combineWith(s, combineRange)
+      case _ =>
+    }
+    cls.attributes.get(slotName) match {
+      case Some(s) => currentSlot = currentSlot.combineWith(s, combineRange)
+      case _ =>
+    }
+    cls.mixins.foreach { r => 
+      resolve(r) match {
+        case Some(c) => currentSlot = applySlotUsage(currentSlot, slotName, c)
+        case _ =>
+      }
+    }
+    cls.isA match {
+      case Some(r) => resolve(r) match {
+        case Some(c) => currentSlot = applySlotUsage(currentSlot, slotName, c)
+        case _ =>
+      }
+      case _ =>
+    }
     currentSlot
   }
 
@@ -225,7 +275,7 @@ final case class SchemaView(schemas: Seq[SchemaDefinition]) extends ReferenceRes
   ): Reference[Element] = v1
 
   val rootPrefixResolver: BasicPrefixResolver = createPrefixResolver(root)
-  private val validator = SchemaValidator()
+  private val validator = new SchemaValidator()
 
   {
     val problems = validator.fatalProblems

--- a/schemaview/src/eu/neverblink/linkml/schemaview/SchemaView.scala
+++ b/schemaview/src/eu/neverblink/linkml/schemaview/SchemaView.scala
@@ -52,7 +52,7 @@ final case class SchemaView(schemas: Seq[SchemaDefinition]) extends ReferenceRes
       case _: SlotView => slotDefinitions.get(ref.value)
       case _: SubsetView => subsets.get(ref.value)
       case _: ElementView[?, ?] => getElement(ref.value)
-      case _ => compiletime.error("SchemaView can't dereference " + compiletime.codeOf(ref))
+      case _ => compiletime.error("SchemaView can't dereference ".concat(compiletime.codeOf(ref)))
     }).asInstanceOf[Option[T]]
 
   /** All types defined in the loaded schemas, as views.
@@ -131,7 +131,7 @@ final case class SchemaView(schemas: Seq[SchemaDefinition]) extends ReferenceRes
       .getOrElse {
         // fallback
         val uri = schema.id.uri
-        if (uri.endsWith("#") || uri.endsWith("/")) uri else uri + "/"
+        if (uri.endsWith("#") || uri.endsWith("/")) uri else uri.concat("/")
       }
   }
 
@@ -377,8 +377,9 @@ object SchemaView {
   ): Either[ImportFailure, Seq[SchemaDefinition]] = {
     // TODO LNK-154 Robust file system importing
     var normalizedUri = uri.stripSuffix(PlatformSpecificUtils.separator)
-    if (!normalizedUri.endsWith(".yaml") && !normalizedUri.endsWith(".yml"))
-      normalizedUri += ".yaml"
+    if (!normalizedUri.endsWith(".yaml") && !normalizedUri.endsWith(".yml")) {
+      normalizedUri = normalizedUri.concat(".yaml")
+    }
     // After URI normalization, check if we've already visited this URI to avoid infinite loops
     // and repeatedly loading the same schema.
     if visited.contains(normalizedUri) then Right(Seq())
@@ -391,6 +392,7 @@ object SchemaView {
           builtIn(normalizedUri, normalizedUri.stripPrefix("https://w3id.org/linkml"), importer)
         } else if (normalizedUri.startsWith("linkml:")) {
           builtIn(normalizedUri, "/" + normalizedUri.stripPrefix("linkml:"), importer)
+          importer.parseSchema(Resources.read("/".concat(normalizedUri.stripPrefix("linkml:"))))
         } else {
           importer.readSchema(normalizedUri)
         }

--- a/schemaview/src/eu/neverblink/linkml/schemaview/SchemaView.scala
+++ b/schemaview/src/eu/neverblink/linkml/schemaview/SchemaView.scala
@@ -152,15 +152,15 @@ final case class SchemaView(schemas: Seq[SchemaDefinition]) extends ReferenceRes
     * (this fallback mirrors the python implementation).
     */
   def getDefaultPrefix(schema: SchemaDefinition): String = {
-    given PrefixResolver = prefixResolvers(schema.id)
+    val prefixResolver = prefixResolvers(schema.id)
     val prefixRef = schema.defaultPrefix match {
       case Some(prefix) => schema.prefixes.get(prefix)
-      case _         => None
+      case _ => None
     }
     prefixRef match {
-      case Some(ref) => ref.prefixReference.uri
+      case Some(ref) => ref.prefixReference.uri(using prefixResolver)
       case _ =>
-        val uri = schema.id.uri
+        val uri = schema.id.uri(using prefixResolver)
         val len = uri.length
         if (len > 0) {
           val ch = uri.charAt(len - 1)
@@ -198,7 +198,8 @@ final case class SchemaView(schemas: Seq[SchemaDefinition]) extends ReferenceRes
       from: Seq[ElementView[?, ?]],
       inlinedOnly: Boolean,
       includeClassAncestors: Boolean,
-  ): DerivedReachabilityQuery = new DerivedReachabilityQuery(from, inlinedOnly, includeClassAncestors)
+  ): DerivedReachabilityQuery =
+    new DerivedReachabilityQuery(from, inlinedOnly, includeClassAncestors)
 
   /** Get a schema element by its ID
     */
@@ -250,17 +251,18 @@ final case class SchemaView(schemas: Seq[SchemaDefinition]) extends ReferenceRes
       case Some(s) => currentSlot = currentSlot.combineWith(s, combineRange)
       case _ =>
     }
-    cls.mixins.foreach { r => 
+    cls.mixins.foreach { r =>
       resolve(r) match {
         case Some(c) => currentSlot = applySlotUsage(currentSlot, slotName, c)
         case _ =>
       }
     }
     cls.isA match {
-      case Some(r) => resolve(r) match {
-        case Some(c) => currentSlot = applySlotUsage(currentSlot, slotName, c)
-        case _ =>
-      }
+      case Some(r) =>
+        resolve(r) match {
+          case Some(c) => currentSlot = applySlotUsage(currentSlot, slotName, c)
+          case _ =>
+        }
       case _ =>
     }
     currentSlot
@@ -280,17 +282,27 @@ final case class SchemaView(schemas: Seq[SchemaDefinition]) extends ReferenceRes
   {
     val problems = validator.fatalProblems
     if (problems.nonEmpty) {
-      throw SchemaIssues.FatalSchemaException(problems.map(_.infer()), maxProblems = 5)
+      val formatted = SchemaProblem.format(
+        problems,
+        maxProblems = 5,
+        verbose = true,
+        showLevel = false,
+      )
+      sys.error(s"Fatal validation problems:\n$formatted")
     }
   }
 
   /** Whether the merged schema is valid */
-  lazy val isValid: Boolean = validator.validationProblems.isEmpty
+  lazy val isValid: Boolean = validator.validate().isSuccess
 
-  /** Errors and fatal problems in the merged schema, empty if the schema is valid. Warnings are not
-    * included - use [[lint]] for a report that covers those too.
+  /** Validate the merged schema, checking for errors and fatal errors
+    *
+    * @param maxProblems
+    *   Max number of problems to include
+    * @return
+    *   Unit if the schema is valid, an exception with formatted problems otherwise
     */
-  def validationProblems: Seq[SchemaError | SchemaFatal] = validator.validationProblems
+  def validate(maxProblems: Int = 5): Try[Unit] = validator.validate(maxProblems)
 
   /** Produce validation report with all detected problems
     *
@@ -332,8 +344,7 @@ object SchemaView {
   def loadSchemaViewFromUri(
       uri: String,
       importer: Importer = FileSystemImporter,
-  ): Either[Seq[SchemaFatal], SchemaView] =
-    guarded(loadSchemas(uri, importer).left.map(Seq(_)).flatMap(viewOf))
+  ): SchemaView = new SchemaView(loadSchemas(uri, importer))
 
   /** Loads a schema view from the specified YAML string, loading its imports. This is mainly for
     * testing and custom applications, as in most cases you would want to load from a URI to get
@@ -351,28 +362,10 @@ object SchemaView {
   def loadSchemaViewFromString(
       yaml: String,
       importer: Importer = FileSystemImporter,
-  ): Either[Seq[SchemaFatal], SchemaView] =
-    guarded(
-      importer.parseSchema(yaml)
-        .flatMap(root => loadImports(root, "", importer).map(root +: _))
-        .left.map(Seq(_))
-        .flatMap(viewOf),
-    )
-
-  /** Run a load, reporting anything it throws as an
-    * [[eu.neverblink.linkml.validation.UnexpectedError]].
-    */
-  private def guarded(
-      load: => Either[Seq[SchemaFatal], SchemaView],
-  ): Either[Seq[SchemaFatal], SchemaView] =
-    try load
-    catch { case NonFatal(ex) => Left(Seq(unexpectedError(ex))) }
-
-  private def unexpectedError(ex: Throwable): UnexpectedErrorImpl =
-    UnexpectedErrorImpl(
-      location = IssueLocationImpl(),
-      reason = Option(ex.getMessage).getOrElse(ex.toString),
-    )
+  ): SchemaView = {
+    val root = importer.parseSchema(yaml)
+    new SchemaView(root +: loadImports(root, "", importer))
+  }
 
   /** Loads individual schema definitions from the specified URI, optionally loading their imports.
     * Import loading is recursive.
@@ -393,38 +386,15 @@ object SchemaView {
   def loadSchemas(
       uri: String,
       importer: Importer = FileSystemImporter,
-  ): Either[ImportFailure, Seq[SchemaDefinition]] =
+  ): Seq[SchemaDefinition] =
     loadSchemasInternal(uri, true, importer, mutable.Set.empty)
-
-  /** Build a view from already-loaded schemas, turning the constructor's fatal validation problems
-    * into a Left rather than an exception.
-    */
-  private def viewOf(schemas: Seq[SchemaDefinition]): Either[Seq[SchemaFatal], SchemaView] =
-    try Right(SchemaView(schemas))
-    catch {
-      case ex: SchemaIssues.FatalSchemaException => Left(ex.problems)
-      case NonFatal(ex) => Left(Seq(unexpectedError(ex)))
-    }
-
-  /** Load one of the schemas bundled as a resource, reporting a missing resource as an import
-    * failure rather than letting the resource lookup throw.
-    */
-  private def builtIn(
-      uri: String,
-      resource: String,
-      importer: Importer,
-  ): Either[ImportFailure, SchemaDefinition] =
-    Importer.readText(uri)(Resources.read(resource)) match {
-      case Right(text) => importer.parseSchema(text, uri)
-      case Left(failure) => Left(failure)
-    }
 
   private def loadSchemasInternal(
       uri: String,
       doImportLoading: Boolean,
       importer: Importer,
       visited: mutable.Set[String],
-  ): Either[ImportFailure, Seq[SchemaDefinition]] = {
+  ): Seq[SchemaDefinition] = {
     // TODO LNK-154 Robust file system importing
     var normalizedUri = uri.stripSuffix(PlatformSpecificUtils.separator)
     if (!normalizedUri.endsWith(".yaml") && !normalizedUri.endsWith(".yml")) {
@@ -432,28 +402,27 @@ object SchemaView {
     }
     // After URI normalization, check if we've already visited this URI to avoid infinite loops
     // and repeatedly loading the same schema.
-    if visited.contains(normalizedUri) then Right(Seq())
+    if visited.contains(normalizedUri) then Seq()
     else
       visited.add(normalizedUri)
-      // Built-in schemas come from bundled resources, everything else from the importer. Both
-      // routes yield the same structured issues on failure.
-      val loaded: Either[ImportFailure, SchemaDefinition] =
+      val schema: SchemaDefinition =
         if (normalizedUri.startsWith("https://w3id.org/linkml/")) {
-          builtIn(normalizedUri, normalizedUri.stripPrefix("https://w3id.org/linkml"), importer)
+          importer.parseSchema(Resources.read(normalizedUri.stripPrefix("https://w3id.org/linkml")))
         } else if (normalizedUri.startsWith("linkml:")) {
-          builtIn(normalizedUri, "/" + normalizedUri.stripPrefix("linkml:"), importer)
           importer.parseSchema(Resources.read("/".concat(normalizedUri.stripPrefix("linkml:"))))
         } else {
-          importer.readSchema(normalizedUri)
+          try importer.readSchema(normalizedUri)
+          catch {
+            case ex if NonFatal(ex) =>
+              sys.error(s"Cannot import schema '$normalizedUri'\n${ex.getMessage}")
+          }
         }
-      loaded.flatMap { schema =>
-        if (doImportLoading) {
-          var baseUri = ""
-          val idx = normalizedUri.lastIndexOf(PlatformSpecificUtils.separator)
-          if (idx > 0) baseUri = normalizedUri.substring(0, idx)
-          loadImportsInternal(schema, baseUri, importer, visited).map(schema +: _)
-        } else Right(Seq(schema))
-      }
+      if (doImportLoading) {
+        var baseUri = ""
+        val idx = normalizedUri.lastIndexOf(PlatformSpecificUtils.separator)
+        if (idx > 0) baseUri = normalizedUri.substring(0, idx)
+        schema +: loadImportsInternal(schema, baseUri, importer, visited)
+      } else Seq(schema)
   }
 
   /** Loads a schema's imports from the specified schema, loading its imports recursively from the

--- a/schemaview/src/eu/neverblink/linkml/schemaview/SchemaView.scala
+++ b/schemaview/src/eu/neverblink/linkml/schemaview/SchemaView.scala
@@ -2,6 +2,7 @@ package eu.neverblink.linkml.schemaview
 
 import eu.neverblink.linkml.metamodel.*
 import eu.neverblink.linkml.runtime.*
+import eu.neverblink.linkml.runtime.FastUtils.*
 import eu.neverblink.linkml.schemaview
 import eu.neverblink.linkml.schemaview.SchemaView.*
 import eu.neverblink.linkml.validation.{
@@ -36,33 +37,13 @@ final case class SchemaView(schemas: Seq[SchemaDefinition]) extends ReferenceRes
 
   inline def resolve[T](inline ref: Reference[T]): Option[T] =
     (inline erasedValue[T] match {
-      case _: TypeDefinition =>
-        types.get(ref.value) match {
-          case Some(tv) => new Some(tv._type)
-          case _ => None
-        }
-      case _: ClassDefinition =>
-        classes.get(ref.value) match {
-          case Some(cv) => new Some(cv.cls)
-          case _ => None
-        }
-      case _: EnumDefinition =>
-        enums.get(ref.value) match {
-          case Some(ev) => new Some(ev._enum)
-          case _ => None
-        }
-      case _: SubsetDefinition =>
-        subsets.get(ref.value) match {
-          case Some(sv) => new Some(sv.subset)
-          case _ => None
-        }
+      case _: TypeDefinition => types.get(ref.value).mapFast(_._type)
+      case _: ClassDefinition => classes.get(ref.value).mapFast(_.cls)
+      case _: EnumDefinition => enums.get(ref.value).mapFast(_._enum)
+      case _: SubsetDefinition => subsets.get(ref.value).mapFast(_.subset)
       // `range` slot's `range` is underspecified as per the metamodel notes,
       // I think it should be ClassDef | TypeDef | EnumDef
-      case _: Element =>
-        elements.get(ref.value) match {
-          case Some(ev) => new Some(ev.inner)
-          case _ => None
-        }
+      case _: Element => elements.get(ref.value).mapFast(_.inner)
       // And now... element views! (sigh)
       // You can cast the argument of this method to get a view instead of the raw definition.
       // I tried to make it nicer, but the Scala compiler said "no".
@@ -79,7 +60,7 @@ final case class SchemaView(schemas: Seq[SchemaDefinition]) extends ReferenceRes
     */
   lazy val types: Map[String, TypeView] =
     schemas.foldLeft(Map.newBuilder[String, TypeView]) { (acc, schema) =>
-      schema.types.foreach((k, v) => acc.addOne((k, TypeView(v, schema))))
+      schema.types.foreach((k, v) => acc.addOne((k, new TypeView(v, schema))))
       acc
     }.result()
 
@@ -103,7 +84,7 @@ final case class SchemaView(schemas: Seq[SchemaDefinition]) extends ReferenceRes
     */
   lazy val enums: Map[String, EnumView] =
     schemas.foldLeft(Map.newBuilder[String, EnumView]) { (acc, schema) =>
-      schema.enums.map((k, v) => acc.addOne((k, EnumView(v, schema))))
+      schema.enums.map((k, v) => acc.addOne((k, new EnumView(v, schema))))
       acc
     }.result()
 
@@ -111,7 +92,7 @@ final case class SchemaView(schemas: Seq[SchemaDefinition]) extends ReferenceRes
     */
   lazy val subsets: Map[String, SubsetView] =
     schemas.foldLeft(Map.newBuilder[String, SubsetView]) { (acc, schema) =>
-      schema.subsets.map((k, v) => acc.addOne((k, SubsetView(v, schema))))
+      schema.subsets.map((k, v) => acc.addOne((k, new SubsetView(v, schema))))
       acc
     }.result()
 
@@ -143,30 +124,27 @@ final case class SchemaView(schemas: Seq[SchemaDefinition]) extends ReferenceRes
     * @see
     *   https://linkml.io/linkml-model/latest/docs/specification/04derived-schemas/#rule-populate-schema-metadata
     */
-  def getDefaultRange(schema: SchemaDefinition): Reference[TypeView] = schema.defaultRange match {
-    case Some(r) => r.asInstanceOf[Reference[TypeView]]
-    case _ => defaultRange
-  }
+  def getDefaultRange(schema: SchemaDefinition): Reference[TypeView] =
+    schema.defaultRange.foldFast(defaultRange)(r => r.asInstanceOf[Reference[TypeView]])
 
   /** Get the default URI prefix (prefix map value) for the schema, with a fallback to the schema ID
     * (this fallback mirrors the python implementation).
     */
   def getDefaultPrefix(schema: SchemaDefinition): String = {
     val prefixResolver = prefixResolvers(schema.id)
-    val prefixRef = schema.defaultPrefix match {
-      case Some(prefix) => schema.prefixes.get(prefix)
-      case _ => None
+    val prefixRef = schema.defaultPrefix.flatMapFast { prefix =>
+      schema.prefixes.get(prefix)
     }
-    prefixRef match {
-      case Some(ref) => ref.prefixReference.uri(using prefixResolver)
-      case _ =>
-        val uri = schema.id.uri(using prefixResolver)
-        val len = uri.length
-        if (len > 0) {
-          val ch = uri.charAt(len - 1)
-          if (ch == '#' || ch == '/') uri
-          else uri.concat("/")
-        } else "/"
+    prefixRef.foldFast {
+      val uri = schema.id.uri(using prefixResolver)
+      val len = uri.length
+      if (len > 0) {
+        val ch = uri.charAt(len - 1)
+        if (ch == '#' || ch == '/') uri
+        else uri.concat("/")
+      } else "/"
+    } { ref =>
+      ref.prefixReference.uri(using prefixResolver)
     }
   }
 
@@ -219,14 +197,12 @@ final case class SchemaView(schemas: Seq[SchemaDefinition]) extends ReferenceRes
     * `Option[ClassView]`.
     */
   def treeRootWithOverride(treeRootOverride: Option[String]): Try[Option[ClassView]] =
-    new Success(treeRootOverride match {
-      case Some(className) =>
-        val optCv = classes.get(className)
-        if (optCv eq None) {
-          val msg = s"Could not find class '$className' defined as the tree root override"
-          return new Failure(new RuntimeException(msg))
-        } else optCv
-      case _ => treeRoot
+    new Success(treeRootOverride.foldFast(treeRoot) { className =>
+      val optCv = classes.get(className)
+      if (optCv eq None) {
+        val msg = s"Could not find class '$className' defined as the tree root override"
+        return new Failure(new RuntimeException(msg))
+      } else optCv
     })
 
   /** Apply `slot_usage` and `attributes` for a class and then its ancestors, with mixins having
@@ -242,27 +218,21 @@ final case class SchemaView(schemas: Seq[SchemaDefinition]) extends ReferenceRes
       cls: ClassDefinition,
   ): SlotDefinitionImpl = {
     var currentSlot = slot
-    cls.slotUsage.get(slotName) match {
-      case Some(s) => currentSlot = currentSlot.combineWith(s, combineRange)
-      case _ =>
+    cls.slotUsage.get(slotName).foreachFast { s =>
+      currentSlot = currentSlot.combineWith(s, combineRange)
     }
-    cls.attributes.get(slotName) match {
-      case Some(s) => currentSlot = currentSlot.combineWith(s, combineRange)
-      case _ =>
+    cls.attributes.get(slotName).foreachFast { s =>
+      currentSlot = currentSlot.combineWith(s, combineRange)
     }
     cls.mixins.foreach { r =>
-      resolve(r) match {
-        case Some(c) => currentSlot = applySlotUsage(currentSlot, slotName, c)
-        case _ =>
+      resolve(r).foreachFast { c =>
+        currentSlot = applySlotUsage(currentSlot, slotName, c)
       }
     }
-    cls.isA match {
-      case Some(r) =>
-        resolve(r) match {
-          case Some(c) => currentSlot = applySlotUsage(currentSlot, slotName, c)
-          case _ =>
-        }
-      case _ =>
+    cls.isA.foreachFast { r =>
+      resolve(r).foreachFast { c =>
+        currentSlot = applySlotUsage(currentSlot, slotName, c)
+      }
     }
     currentSlot
   }
@@ -367,13 +337,15 @@ object SchemaView {
       load: => Either[Seq[SchemaFatal], SchemaView],
   ): Either[Seq[SchemaFatal], SchemaView] =
     try load
-    catch { case NonFatal(ex) => Left(Seq(unexpectedError(ex))) }
+    catch { case ex if NonFatal(ex) => new Left(Seq(unexpectedError(ex))) }
 
-  private def unexpectedError(ex: Throwable): UnexpectedErrorImpl =
-    UnexpectedErrorImpl(
+  private def unexpectedError(ex: Throwable): UnexpectedErrorImpl = {
+    val msg = ex.getMessage
+    new UnexpectedErrorImpl(
       location = IssueLocationImpl(),
-      reason = Option(ex.getMessage).getOrElse(ex.toString),
+      reason = if (msg ne null) msg else ex.toString,
     )
+  }
 
   /** Loads individual schema definitions from the specified URI, optionally loading their imports.
     * Import loading is recursive.
@@ -401,11 +373,13 @@ object SchemaView {
     * into a Left rather than an exception.
     */
   private def viewOf(schemas: Seq[SchemaDefinition]): Either[Seq[SchemaFatal], SchemaView] =
-    try Right(SchemaView(schemas))
-    catch {
-      case ex: SchemaIssues.FatalSchemaException => Left(ex.problems)
-      case NonFatal(ex) => Left(Seq(unexpectedError(ex)))
-    }
+    new Left(
+      try return new Right(SchemaView(schemas))
+      catch {
+        case ex: SchemaIssues.FatalSchemaException => ex.problems
+        case ex if NonFatal(ex) => Seq(unexpectedError(ex))
+      },
+    )
 
   /** Load one of the schemas bundled as a resource, reporting a missing resource as an import
     * failure rather than letting the resource lookup throw.
@@ -417,7 +391,7 @@ object SchemaView {
   ): Either[ImportFailure, SchemaDefinition] =
     Importer.readText(uri)(Resources.read(resource)) match {
       case Right(text) => importer.parseSchema(text, uri)
-      case Left(failure) => Left(failure)
+      case err => err.asInstanceOf[Either[ImportFailure, SchemaDefinition]]
     }
 
   private def loadSchemasInternal(
@@ -433,7 +407,7 @@ object SchemaView {
     }
     // After URI normalization, check if we've already visited this URI to avoid infinite loops
     // and repeatedly loading the same schema.
-    if visited.contains(normalizedUri) then Right(Seq())
+    if visited.contains(normalizedUri) then new Right(Nil)
     else
       visited.add(normalizedUri)
       // Built-in schemas come from bundled resources, everything else from the importer. Both
@@ -442,7 +416,7 @@ object SchemaView {
         if (normalizedUri.startsWith("https://w3id.org/linkml/")) {
           builtIn(normalizedUri, normalizedUri.stripPrefix("https://w3id.org/linkml"), importer)
         } else if (normalizedUri.startsWith("linkml:")) {
-          builtIn(normalizedUri, "/" + normalizedUri.stripPrefix("linkml:"), importer)
+          builtIn(normalizedUri, "/".concat(normalizedUri.stripPrefix("linkml:")), importer)
         } else {
           importer.readSchema(normalizedUri)
         }
@@ -452,7 +426,7 @@ object SchemaView {
           val idx = normalizedUri.lastIndexOf(PlatformSpecificUtils.separator)
           if (idx > 0) baseUri = normalizedUri.substring(0, idx)
           loadImportsInternal(schema, baseUri, importer, visited).map(schema +: _)
-        } else Right(Seq(schema))
+        } else new Right(Seq(schema))
       }
   }
 

--- a/schemaview/test/src/eu/neverblink/linkml/schemaview/SchemaValidatorSpec.scala
+++ b/schemaview/test/src/eu/neverblink/linkml/schemaview/SchemaValidatorSpec.scala
@@ -2,10 +2,7 @@ package eu.neverblink.linkml.schemaview
 
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
-
 import eu.neverblink.linkml.validation.{SchemaError, SchemaFatal}
-
-import scala.util.Success
 
 class SchemaValidatorSpec extends AnyWordSpec, Matchers {
   def load(schemaYaml: String): SchemaView =

--- a/yaml/src/eu/neverblink/linkml/yaml/LinkmlYamlCodec.scala
+++ b/yaml/src/eu/neverblink/linkml/yaml/LinkmlYamlCodec.scala
@@ -2,8 +2,9 @@ package eu.neverblink.linkml.yaml
 
 import eu.neverblink.linkml.runtime.*
 import org.virtuslab.yaml.*
+
 import scala.annotation.nowarn
-import scala.collection.immutable.ListMap
+import scala.collection.immutable.{ListMap, VectorMap}
 import scala.collection.mutable
 import scala.quoted.*
 import scala.util.control.NoStackTrace
@@ -27,8 +28,12 @@ object LinkmlYamlCodec {
   implicit val anythingCodec: LinkmlYamlCodec[LinkmlAny] = new LinkmlYamlCodec[LinkmlAny] {
     override def decode(node: Node, id: Option[Any]): LinkmlAny = LinkmlAny.apply(node.asYaml)
 
-    override def encode(x: LinkmlAny, skipId: Boolean): Node =
-      parseYaml(x.toString).getOrElse(Node.ScalarNode(null))
+    override def encode(x: LinkmlAny, skipId: Boolean): Node = parseYaml(x.toString) match {
+      case Right(n) => n
+      case _ => nullNode
+    }
+
+    private val nullNode = Node.ScalarNode(null)
   }
 
   implicit val uriOrCurieCodec: LinkmlYamlCodec[UriOrCurie] = new LinkmlYamlCodec[UriOrCurie] {
@@ -42,8 +47,13 @@ object LinkmlYamlCodec {
 
   inline def derived[T]: LinkmlYamlCodec[T] = ${ LinkmlYamlCodecImpl.make }
 
-  def getFields(n: Node.MappingNode): Map[String, Node] =
-    n.mappings.collect { case (n: Node.ScalarNode, v) if Tag.str eq n.tag => (n.value, v) }
+  def getFields(n: Node.MappingNode): java.util.HashMap[String, Node] =
+    new java.util.HashMap[String, Node](n.mappings.size << 1) {
+      n.mappings.foreach {
+        case (n: Node.ScalarNode, v) if Tag.str eq n.tag => put(n.value, v)
+        case _ =>
+      }
+    }
 }
 
 private object LinkmlYamlCodecImpl {
@@ -142,10 +152,10 @@ private class LinkmlYamlCodecImpl(using Quotes) extends MacroUtils {
           '{
             $node match {
               case n: Node.MappingNode =>
-                n.mappings.map { case (k, v) =>
+                n.mappings.foldLeft(VectorMap.newBuilder[t1, t2]) { case (acc, (k, v)) =>
                   val vId = ${ genDecode[t1](tpe1, 'k, '{ None }) }
-                  (vId, ${ genDecode[t2](tpe2, 'v, '{ new Some(vId) }) })
-                }
+                  acc.addOne((vId, ${ genDecode[t2](tpe2, 'v, '{ new Some(vId) }) }))
+                }.result().asInstanceOf[Map[t1, t2]]
               case n: Node.ScalarNode if Tag.nullTag eq n.tag => Map.empty
               case n => LinkmlYamlCodec.decodeError("map or null value", n)
             }
@@ -233,7 +243,7 @@ private class LinkmlYamlCodecImpl(using Quotes) extends MacroUtils {
     val classInfo = getClassInfo(tpe)
     val fields = classInfo.fields
 
-    def genDecodeFields(kvs: Expr[Map[String, Node]])(using Quotes): Expr[T] = {
+    def genDecodeFields(kvs: Expr[java.util.HashMap[String, Node]])(using Quotes): Expr[T] = {
       val readBlock = new mutable.ListBuffer[Statement]
       val valDefs = new mutable.ArrayBuffer[ValDef](fields.size)
       fields.foreach { fieldInfo =>
@@ -278,12 +288,8 @@ private class LinkmlYamlCodecImpl(using Quotes) extends MacroUtils {
             valDefs.addOne(valDef)
             readBlock.addOne(valDef)
             readBlock.addOne('{
-              $kvs.get($mappedName) match {
-                case Some(v) =>
-                  ${
-                    Assign(Ref(valDef.symbol), genDecode[ft](fTpe, 'v, '{ None }).asTerm).asExpr
-                  }
-                case _ =>
+              (if ($kvs ne null) $kvs.get($mappedName) else null) match {
+                case null =>
                   ${
                     if (fieldInfo.defaultValue.isEmpty) {
                       if (fieldInfo.kind == FieldKind.Id) {
@@ -306,6 +312,10 @@ private class LinkmlYamlCodecImpl(using Quotes) extends MacroUtils {
                     } else {
                       '{}
                     }
+                  }
+                case v =>
+                  ${
+                    Assign(Ref(valDef.symbol), genDecode[ft](fTpe, 'v, '{ None }).asTerm).asExpr
                   }
               }
             }.asTerm.changeOwner(Symbol.spliceOwner))
@@ -384,7 +394,7 @@ private class LinkmlYamlCodecImpl(using Quotes) extends MacroUtils {
                 case _ =>
                   val kvs = $node match {
                     case n: Node.MappingNode => LinkmlYamlCodec.getFields(n)
-                    case n: Node.ScalarNode if Tag.nullTag eq n.tag => Map.empty[String, Node]
+                    case n: Node.ScalarNode if Tag.nullTag eq n.tag => null
                     case n => LinkmlYamlCodec.decodeError("map or null value", n)
                   }
                   ${ genDecodeFields('kvs) }
@@ -395,7 +405,7 @@ private class LinkmlYamlCodecImpl(using Quotes) extends MacroUtils {
         '{
           val kvs = $node match {
             case n: Node.MappingNode => LinkmlYamlCodec.getFields(n)
-            case n: Node.ScalarNode if Tag.nullTag eq n.tag => Map.empty[String, Node]
+            case n: Node.ScalarNode if Tag.nullTag eq n.tag => null
             case n => LinkmlYamlCodec.decodeError("map or null value", n)
           }
           ${ genDecodeFields('kvs) }

--- a/yaml/src/eu/neverblink/linkml/yaml/LinkmlYamlCodec.scala
+++ b/yaml/src/eu/neverblink/linkml/yaml/LinkmlYamlCodec.scala
@@ -1,6 +1,7 @@
 package eu.neverblink.linkml.yaml
 
 import eu.neverblink.linkml.runtime.*
+import eu.neverblink.linkml.runtime.FastUtils.*
 import org.virtuslab.yaml.*
 
 import scala.annotation.nowarn
@@ -17,10 +18,8 @@ abstract class LinkmlYamlCodec[T] {
 
 object LinkmlYamlCodec {
   def decodeError(msg: String, node: Node): Nothing = throw new DecodeError(
-    node.pos match {
-      case Some(pos) =>
-        s"Expected $msg at ${pos.start.line}:${pos.start.column} but got:\n${pos.errorMsg}"
-      case _ => s"Expected $msg but got:\n$node"
+    node.pos.foldFast(s"Expected $msg but got:\n$node") { pos =>
+      s"Expected $msg at ${pos.start.line}:${pos.start.column} but got:\n${pos.errorMsg}"
     },
     node.pos,
   )

--- a/yaml/src/eu/neverblink/linkml/yaml/LinkmlYamlCodec.scala
+++ b/yaml/src/eu/neverblink/linkml/yaml/LinkmlYamlCodec.scala
@@ -47,13 +47,14 @@ object LinkmlYamlCodec {
 
   inline def derived[T]: LinkmlYamlCodec[T] = ${ LinkmlYamlCodecImpl.make }
 
-  def getFields(n: Node.MappingNode): java.util.HashMap[String, Node] =
-    new java.util.HashMap[String, Node](n.mappings.size << 1) {
-      n.mappings.foreach {
-        case (n: Node.ScalarNode, v) if Tag.str eq n.tag => put(n.value, v)
-        case _ =>
-      }
+  def getFields(n: Node.MappingNode): java.util.HashMap[String, Node] = {
+    val m = new java.util.HashMap[String, Node](n.mappings.size << 1, 0.5f)
+    n.mappings.foreach {
+      case (n: Node.ScalarNode, v) if Tag.str eq n.tag => m.put(n.value, v)
+      case _ =>
     }
+    m
+  }
 }
 
 private object LinkmlYamlCodecImpl {


### PR DESCRIPTION
Most valuable improvements are fixes of O(n^2) algorithmic complexity due to `LinkMap` usage by scala-yaml and sttp-apispec libraries

It allows to validate and generate schemas with more than 100K+ much faster

Below are comparison of results of generator benchmarks with JDK 25 on MacBook

Before:
```txt
Benchmark                                          (schema)   Mode  Cnt     Score    Error  Units
GeneratorBench.jsonSchemaFromSchemaView      cgmes-core.yml  thrpt    5  1329.252 ± 13.504  ops/s
GeneratorBench.jsonSchemaFromSchemaView  cgmes-dynamics.yml  thrpt    5   553.612 ± 38.489  ops/s
GeneratorBench.jsonSchemaFromSchemaView         TC57CIM.yml  thrpt    5    49.410 ±  3.561  ops/s
GeneratorBench.jsonSchemaFromSchemas         cgmes-core.yml  thrpt    5   465.980 ± 11.221  ops/s
GeneratorBench.jsonSchemaFromSchemas     cgmes-dynamics.yml  thrpt    5   190.011 ±  2.750  ops/s
GeneratorBench.jsonSchemaFromSchemas            TC57CIM.yml  thrpt    5    19.823 ±  1.171  ops/s
GeneratorBench.jsonSchemaFromYaml            cgmes-core.yml  thrpt    5   197.692 ±  6.514  ops/s
GeneratorBench.jsonSchemaFromYaml        cgmes-dynamics.yml  thrpt    5    52.173 ±  1.956  ops/s
GeneratorBench.jsonSchemaFromYaml               TC57CIM.yml  thrpt    5     8.607 ±  0.194  ops/s
GeneratorBench.linkmlFromSchemaView          cgmes-core.yml  thrpt    5   397.085 ±  7.515  ops/s
GeneratorBench.linkmlFromSchemaView      cgmes-dynamics.yml  thrpt    5   183.268 ±  3.406  ops/s
GeneratorBench.linkmlFromSchemaView             TC57CIM.yml  thrpt    5    22.066 ±  1.010  ops/s
GeneratorBench.linkmlFromSchemas             cgmes-core.yml  thrpt    5   264.761 ±  3.443  ops/s
GeneratorBench.linkmlFromSchemas         cgmes-dynamics.yml  thrpt    5   112.949 ±  1.113  ops/s
GeneratorBench.linkmlFromSchemas                TC57CIM.yml  thrpt    5    13.962 ±  0.368  ops/s
GeneratorBench.linkmlFromYaml                cgmes-core.yml  thrpt    5   146.870 ±  3.215  ops/s
GeneratorBench.linkmlFromYaml            cgmes-dynamics.yml  thrpt    5    41.732 ±  0.997  ops/s
GeneratorBench.linkmlFromYaml                   TC57CIM.yml  thrpt    5     7.320 ±  0.155  ops/s
GeneratorBench.shaclFromSchemaView           cgmes-core.yml  thrpt    5   322.338 ±  1.994  ops/s
GeneratorBench.shaclFromSchemaView       cgmes-dynamics.yml  thrpt    5   242.307 ± 14.913  ops/s
GeneratorBench.shaclFromSchemaView              TC57CIM.yml  thrpt    5    27.051 ±  0.180  ops/s
GeneratorBench.shaclFromSchemas              cgmes-core.yml  thrpt    5   227.636 ±  2.884  ops/s
GeneratorBench.shaclFromSchemas          cgmes-dynamics.yml  thrpt    5   138.209 ±  1.789  ops/s
GeneratorBench.shaclFromSchemas                 TC57CIM.yml  thrpt    5    16.961 ±  0.211  ops/s
GeneratorBench.shaclFromYaml                 cgmes-core.yml  thrpt    5   136.361 ±  0.931  ops/s
GeneratorBench.shaclFromYaml             cgmes-dynamics.yml  thrpt    5    47.058 ±  0.934  ops/s
GeneratorBench.shaclFromYaml                    TC57CIM.yml  thrpt    5     8.003 ±  0.097  ops/s
```

After:
```txt
Benchmark                                          (schema)   Mode  Cnt     Score    Error  Units
GeneratorBench.jsonSchemaFromSchemaView      cgmes-core.yml  thrpt    5  1380.925 ±  3.683  ops/s
GeneratorBench.jsonSchemaFromSchemaView  cgmes-dynamics.yml  thrpt    5   638.019 ± 87.642  ops/s
GeneratorBench.jsonSchemaFromSchemaView         TC57CIM.yml  thrpt    5    73.524 ±  1.681  ops/s
GeneratorBench.jsonSchemaFromSchemas         cgmes-core.yml  thrpt    5   474.095 ±  8.165  ops/s
GeneratorBench.jsonSchemaFromSchemas     cgmes-dynamics.yml  thrpt    5   203.613 ±  0.664  ops/s
GeneratorBench.jsonSchemaFromSchemas            TC57CIM.yml  thrpt    5    23.945 ±  0.678  ops/s
GeneratorBench.jsonSchemaFromYaml            cgmes-core.yml  thrpt    5   225.390 ±  2.617  ops/s
GeneratorBench.jsonSchemaFromYaml        cgmes-dynamics.yml  thrpt    5    62.441 ±  1.577  ops/s
GeneratorBench.jsonSchemaFromYaml               TC57CIM.yml  thrpt    5    10.771 ±  0.517  ops/s
GeneratorBench.linkmlFromSchemaView          cgmes-core.yml  thrpt    5   414.917 ±  3.144  ops/s
GeneratorBench.linkmlFromSchemaView      cgmes-dynamics.yml  thrpt    5   189.570 ±  1.036  ops/s
GeneratorBench.linkmlFromSchemaView             TC57CIM.yml  thrpt    5    23.188 ±  0.903  ops/s
GeneratorBench.linkmlFromSchemas             cgmes-core.yml  thrpt    5   271.521 ±  5.297  ops/s
GeneratorBench.linkmlFromSchemas         cgmes-dynamics.yml  thrpt    5   116.784 ±  0.882  ops/s
GeneratorBench.linkmlFromSchemas                TC57CIM.yml  thrpt    5    15.016 ±  0.350  ops/s
GeneratorBench.linkmlFromYaml                cgmes-core.yml  thrpt    5   163.277 ±  2.611  ops/s
GeneratorBench.linkmlFromYaml            cgmes-dynamics.yml  thrpt    5    49.564 ±  1.848  ops/s
GeneratorBench.linkmlFromYaml                   TC57CIM.yml  thrpt    5     8.441 ±  0.470  ops/s
GeneratorBench.shaclFromSchemaView           cgmes-core.yml  thrpt    5   325.509 ±  1.561  ops/s
GeneratorBench.shaclFromSchemaView       cgmes-dynamics.yml  thrpt    5   245.886 ± 15.019  ops/s
GeneratorBench.shaclFromSchemaView              TC57CIM.yml  thrpt    5    27.382 ±  0.530  ops/s
GeneratorBench.shaclFromSchemas              cgmes-core.yml  thrpt    5   229.031 ±  1.899  ops/s
GeneratorBench.shaclFromSchemas          cgmes-dynamics.yml  thrpt    5   140.368 ±  0.782  ops/s
GeneratorBench.shaclFromSchemas                 TC57CIM.yml  thrpt    5    17.688 ±  0.301  ops/s
GeneratorBench.shaclFromYaml                 cgmes-core.yml  thrpt    5   149.914 ±  2.108  ops/s
GeneratorBench.shaclFromYaml             cgmes-dynamics.yml  thrpt    5    55.772 ±  1.560  ops/s
GeneratorBench.shaclFromYaml                    TC57CIM.yml  thrpt    5     9.148 ±  0.452  ops/s
```