### PR TITLE
Add release attestations, improve install.sh

### DIFF
--- a/.github/workflows/install.yml
+++ b/.github/workflows/install.yml
@@ -51,12 +51,21 @@ jobs:
           "$RUNNER_TEMP/linkml-exec/linkml-scala" --version
 
       # A sourced install.sh must never terminate the caller's shell.
+      # `set +e` mirrors an interactive shell, which is the case that matters. It also keeps
+      # the check portable: bash 3.2 (the /bin/bash on macOS runners) does not extend the
+      # `&&` suppression of `-e` into a sourced file, so `. script && ...` would abort here.
       - name: Sourcing install.sh survives a failure
         run: |
-          LINKML_SCALA_VERSION=v0.0.0-does-not-exist
-          export LINKML_SCALA_VERSION
-          . ./cli/install.sh && { echo "Error: expected a non-zero status."; exit 1; }
-          echo "Still alive after a failed source, as expected."
+          export LINKML_SCALA_VERSION=v0.0.0-does-not-exist
+          set +e
+          . ./cli/install.sh
+          rc=$?
+          set -e
+          if [ "$rc" -eq 0 ]; then
+            echo "Error: expected a non-zero status from a failed install."
+            exit 1
+          fi
+          echo "Still alive after a failed source (status $rc), as expected."
 
       - name: Installed binary reports its version
         run: |

--- a/.github/workflows/install.yml
+++ b/.github/workflows/install.yml
@@ -36,7 +36,7 @@ jobs:
       - name: Checkout sources
         uses: actions/checkout@v7
 
-      # The invocation the README documents. Sourcing also puts the install dir on PATH
+      # The invocation documented in README. Sourcing also puts the install dir on PATH
       # for the rest of this step, which executing the script cannot do.
       - name: Install via install.sh
         run: |

--- a/.github/workflows/install.yml
+++ b/.github/workflows/install.yml
@@ -36,10 +36,27 @@ jobs:
       - name: Checkout sources
         uses: actions/checkout@v7
 
+      # The invocation the README documents. Sourcing also puts the install dir on PATH
+      # for the rest of this step, which executing the script cannot do.
       - name: Install via install.sh
         run: |
           . ./cli/install.sh
+          command -v linkml-scala # sourcing must make it callable immediately
           echo "$HOME/.local/bin" >> "$GITHUB_PATH"
+
+      # The other documented form. Must work without a TTY and without prompting.
+      - name: Install via install.sh, executed rather than sourced
+        run: |
+          LINKML_SCALA_INSTALL_DIR="$RUNNER_TEMP/linkml-exec" bash ./cli/install.sh
+          "$RUNNER_TEMP/linkml-exec/linkml-scala" --version
+
+      # A sourced install.sh must never terminate the caller's shell.
+      - name: Sourcing install.sh survives a failure
+        run: |
+          LINKML_SCALA_VERSION=v0.0.0-does-not-exist
+          export LINKML_SCALA_VERSION
+          . ./cli/install.sh && { echo "Error: expected a non-zero status."; exit 1; }
+          echo "Still alive after a failed source, as expected."
 
       - name: Installed binary reports its version
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -129,7 +129,7 @@ jobs:
           gzip -9 -k linkml-scala-windows-x86_64.exe &
           wait
 
-      # See: docs/verifyiing_downloads.md
+      # See: docs/verifying_downloads.md
       - name: Generate Checksums
         run: sha256sum linkml-scala* | tee SHA256SUMS
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -92,6 +92,8 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
+      id-token: write # Required by actions/attest to mint a Sigstore OIDC token
+      attestations: write # Required to record the provenance attestation on the repo
     needs:
       - aot-compile
       - jar-assemble
@@ -127,12 +129,23 @@ jobs:
           gzip -9 -k linkml-scala-windows-x86_64.exe &
           wait
 
+      # See: docs/verifyiing_downloads.md
+      - name: Generate Checksums
+        run: sha256sum linkml-scala* | tee SHA256SUMS
+
+      - name: Attest Build Provenance
+        uses: actions/attest@v4
+        with:
+          subject-path: |
+            linkml-scala*
+            SHA256SUMS
+
       - name: Upload Binaries
         uses: ncipollo/release-action@v1.21.0
         with:
           tag: "${{ github.ref_name }}"
           name: "${{ github.ref_name }}"
-          artifacts: linkml-scala*
+          artifacts: "linkml-scala*,SHA256SUMS"
           allowUpdates: true
           replacesArtifacts: true
           omitBodyDuringUpdate: true

--- a/README.md
+++ b/README.md
@@ -73,6 +73,8 @@ If you are on Linux (x86-64, ARM64), macOS (ARM64), or using WSL on Windows, the
 linkml-scala
 ```
 
+Read the script before running it: [install.sh](cli/install.sh).
+
 ### Method 2: Using [mise](https://mise.jdx.dev/getting-started.html) (cross-platform)
 
 You can install `linkml-scala` on any platform (including Windows) using the [mise](https://mise.jdx.dev/getting-started.html)
@@ -86,7 +88,7 @@ linkml-scala
 Or pin a specific version (recommended for reproducible setups, e.g. in a project's `mise.toml`):
 
 ```shell
-mise use 'ubi:NeverBlink-OSS/linkml-scala@v0.11.2'
+mise use 'ubi:NeverBlink-OSS/linkml-scala@v0.12.0'
 linkml-scala
 ```
 
@@ -110,6 +112,9 @@ Simply rename the downloaded executable, and run it:
 ren linkml-scala-windows-x86_64.exe linkml-scala.exe
 linkml-scala.exe
 ```
+
+Releases ship a `SHA256SUMS` manifest and a signed build provenance attestation, so you can confirm
+a download came from our release workflow. **[See how to verify it.](docs/verifying_downloads.md)**
 
 ### CLI – getting started
 

--- a/cli/install.sh
+++ b/cli/install.sh
@@ -37,7 +37,7 @@ _linkml_scala_install() {
   local install_dir="${LINKML_SCALA_INSTALL_DIR:-$HOME/.local/bin}"
   local tag="${LINKML_SCALA_VERSION:-}"
   local tool os arch arch_suffix binary_name asset release_url tmp_dir
-  local release_info expected actual profile path_line answer
+  local latest_url expected actual profile path_line answer
 
   for tool in curl gzip mktemp; do
     if ! command -v "$tool" >/dev/null 2>&1; then
@@ -53,17 +53,24 @@ _linkml_scala_install() {
     return 1
   fi
 
-  # Resolve the release tag unless one was pinned.
+  # Resolve the release tag unless one was pinned. This follows the redirect that
+  # /releases/latest issues, rather than asking api.github.com, which rate-limits
+  # unauthenticated callers to 60 requests per hour per IP.
   if [ -z "$tag" ]; then
-    release_info=$(curl -fsSL "https://api.github.com/repos/$repo_base/releases/latest") || {
-      echo "Error: could not fetch the latest release info for $repo_base." >&2
+    latest_url=$(curl -fsSLI -o /dev/null -w '%{url_effective}' \
+      "https://github.com/$repo_base/releases/latest") || {
+      echo "Error: could not reach GitHub to determine the latest release." >&2
+      echo "Set LINKML_SCALA_VERSION to install a specific release instead." >&2
       return 1
     }
-    tag=$(printf '%s' "$release_info" | grep -o '"tag_name": *"[^"]*' | head -n 1 | sed 's/.*"//')
-    if [ -z "$tag" ]; then
-      echo "Error: could not determine the latest release tag." >&2
-      return 1
-    fi
+    case "$latest_url" in
+      */releases/tag/?*) tag="${latest_url##*/tag/}" ;;
+      *)
+        echo "Error: could not determine the latest release tag of $repo_base." >&2
+        echo "Set LINKML_SCALA_VERSION to install a specific release instead." >&2
+        return 1
+        ;;
+    esac
   fi
 
   os=$(uname -s | tr '[:upper:]' '[:lower:]')

--- a/cli/install.sh
+++ b/cli/install.sh
@@ -1,89 +1,234 @@
-#!/bin/bash
+#!/usr/bin/env bash
+#
+# Installs the linkml-scala CLI from GitHub Releases.
+#
+# Source it, so that the install directory lands on the PATH of the current shell:
+#
+#   . <(curl -sSfL https://raw.githubusercontent.com/NeverBlink-OSS/linkml-scala/main/cli/install.sh)
+#
+# Or download it, read it, and run it - PATH changes then only apply to new shells:
+#
+#   curl -fsSLO https://raw.githubusercontent.com/NeverBlink-OSS/linkml-scala/main/cli/install.sh
+#   bash install.sh
+#
+# Environment variables:
+#   LINKML_SCALA_VERSION           Release tag to install, e.g. v0.12.0 (default: latest).
+#   LINKML_SCALA_INSTALL_DIR       Where to put the binary (default: $HOME/.local/bin).
+#   LINKML_SCALA_REQUIRE_CHECKSUM  Set to 1 to abort if the release publishes no SHA256SUMS.
+#   LINKML_SCALA_MODIFY_PROFILE    Preset the "add to PATH?" answer (1/yes to accept,
+#                                  anything else to decline). Skips the prompt.
+#
+# The script never calls `exit`, so it is also safe to `source`.
+#
+# If the install directory is not on your PATH, the script asks before adding it to your
+# shell profile. It never edits anything without an explicit yes, and never prompts when
+# there is no terminal to prompt on (CI, `curl | bash`) - there it just prints the line.
 
-# This script installs the latest cli release from the GitHub repository
-# Let's start by fetching the latest release information
-REPO_BASE="NeverBlink-OSS/linkml-scala"
-REPO="https://api.github.com/repos/$REPO_BASE/releases/latest"
-RELEASE_INFO=$(curl -fsSL "$REPO") || {
-  echo "Error: Could not fetch latest release info from $REPO";
-  return 1 2>/dev/null || exit 1;
-}
-
-# And let's get the tag name of the latest release
-TAG_NAME=$(echo $RELEASE_INFO | grep -o '"tag_name": "[^"]*' | sed 's/"tag_name": "//')
-if [ -z "$TAG_NAME" ]; then
-  echo "Error: Could not fetch the latest release tag name.";
-  return 1 2>/dev/null || exit 1;
-fi
-
-# Check the operating system and architecture
-OS=$(uname -s | tr '[:upper:]' '[:lower:]')
-ARCH=$(uname -m)
-# Map the architecture to the appropriate binary name
-case $OS in
-  linux) BINARY_NAME="linkml-scala-linux" ;;
-  darwin) BINARY_NAME="linkml-scala-macos" ;;
-  *) echo "Unsupported operating system: $OS"; exit 1 ;;
-esac
-# Append the architecture to the binary name but yell for cases we don't support
-case $ARCH in
-  x86_64) ARCH_NAME="-x86_64"
-        # check that os not darwin here
-        if [ "$OS" = "darwin" ]; then
-          echo "Unsupported architecture: $ARCH on macOS"
-          return 1 2>/dev/null || exit 1
-        fi;;
-  aarch64)
-    ARCH_NAME="-arm64" ;;
-  arm64)
-      ARCH_NAME="-arm64" ;;
-  *) echo "Unsupported architecture: $ARCH"
-    return 1 2>/dev/null || exit 1
-    ;;
-esac
-
-# Check the installation directory
-INSTALL_DIR="$HOME/.local/bin"
-if [ ! -d "$INSTALL_DIR" ]; then
-  echo "Creating installation directory: $INSTALL_DIR"
-  mkdir -p "$INSTALL_DIR"
-fi
-
-# Download the binary
-DOWNLOAD_URL="https://github.com/$REPO_BASE/releases/download/$TAG_NAME/$BINARY_NAME$ARCH_NAME.gz"
-echo "Downloading $BINARY_NAME from $DOWNLOAD_URL"
-curl -fL "$DOWNLOAD_URL" -o "$INSTALL_DIR/linkml-scala.gz" || {
-  echo "Error: Failed to download the binary from $DOWNLOAD_URL";
-  return 1 2>/dev/null || exit 1;
-}
-gzip -d -f "$INSTALL_DIR/linkml-scala.gz" || {
-  echo "Error: Failed to decompress $INSTALL_DIR/linkml-scala.gz"
-  return 1 2>/dev/null || exit 1
-}
-CONTENT=$(wc -c < "$INSTALL_DIR/linkml-scala" 2>/dev/null || echo 0)
-if [ "${CONTENT:-0}" -lt 500 ]; then
-  echo "Error: Failed to download the binary from $DOWNLOAD_URL";
-  return 1 2>/dev/null || exit 1;
-fi
-chmod +x "$INSTALL_DIR/linkml-scala"
-
-# Ensure that the installation directory is in the PATH
-if [[ ":$PATH:" != *":$INSTALL_DIR:"* ]]; then
-  echo "Adding $INSTALL_DIR to PATH"
-  # Add the binary to the PATH for the current session
-  export PATH="$PATH:$INSTALL_DIR"
-  # Check shell config file from bash and zsh
-  if expr "$SHELL" : '.*zsh' >/dev/null; then
-    grep -q "PATH=.*$INSTALL_DIR" "$HOME/.zshrc" 2>/dev/null || echo "export PATH=\"\$PATH:$INSTALL_DIR\"" >> "$HOME/.zshrc"
-  elif expr "$SHELL" : '.*bash' >/dev/null; then
-    grep -q "PATH=.*$INSTALL_DIR" "$HOME/.bashrc" 2>/dev/null || echo "export PATH=\"\$PATH:$INSTALL_DIR\"" >> "$HOME/.bashrc"
+_linkml_scala_sha256() {
+  if command -v sha256sum >/dev/null 2>&1; then
+    sha256sum "$1"
+  else
+    shasum -a 256 "$1"
   fi
-fi
+}
 
-# Link the binary to the installation directory
-if [ -f "$INSTALL_DIR/linkml-scala" ]; then
-  echo "Installation successful! You can now use LinkML Scala CLI by running 'linkml-scala'."
-else
-  echo "Error: Installation failed. The binary was not found in the installation directory."
-  exit 1
-fi
+_linkml_scala_install() {
+  local repo_base="NeverBlink-OSS/linkml-scala"
+  local install_dir="${LINKML_SCALA_INSTALL_DIR:-$HOME/.local/bin}"
+  local tag="${LINKML_SCALA_VERSION:-}"
+  local tool os arch arch_suffix binary_name asset release_url tmp_dir
+  local release_info expected actual profile path_line answer
+
+  for tool in curl gzip mktemp; do
+    if ! command -v "$tool" >/dev/null 2>&1; then
+      echo "Error: '$tool' is required but was not found." >&2
+      return 1
+    fi
+  done
+
+  # macOS ships shasum rather than GNU coreutils' sha256sum.
+  if ! command -v sha256sum >/dev/null 2>&1 && ! command -v shasum >/dev/null 2>&1; then
+    echo "Error: neither 'sha256sum' nor 'shasum' is available, so the download" >&2
+    echo "cannot be verified. Refusing to install." >&2
+    return 1
+  fi
+
+  # Resolve the release tag unless one was pinned.
+  if [ -z "$tag" ]; then
+    release_info=$(curl -fsSL "https://api.github.com/repos/$repo_base/releases/latest") || {
+      echo "Error: could not fetch the latest release info for $repo_base." >&2
+      return 1
+    }
+    tag=$(printf '%s' "$release_info" | grep -o '"tag_name": *"[^"]*' | head -n 1 | sed 's/.*"//')
+    if [ -z "$tag" ]; then
+      echo "Error: could not determine the latest release tag." >&2
+      return 1
+    fi
+  fi
+
+  os=$(uname -s | tr '[:upper:]' '[:lower:]')
+  arch=$(uname -m)
+
+  case "$os" in
+    linux) binary_name="linkml-scala-linux" ;;
+    darwin) binary_name="linkml-scala-macos" ;;
+    *)
+      echo "Error: unsupported operating system '$os'." >&2
+      echo "On Windows, install with mise instead:  mise use 'ubi:$repo_base'" >&2
+      return 1
+      ;;
+  esac
+
+  case "$arch" in
+    x86_64 | amd64) arch_suffix="-x86_64" ;;
+    aarch64 | arm64) arch_suffix="-arm64" ;;
+    *)
+      echo "Error: unsupported architecture '$arch'." >&2
+      return 1
+      ;;
+  esac
+
+  # Not every OS/arch pair has a native binary. Point at the JVM build instead.
+  if [ "$os$arch_suffix" = "darwin-x86_64" ]; then
+    echo "Error: there is no native binary for Intel macOS." >&2
+    echo "Use the JVM build instead (requires Java 17 or newer):" >&2
+    echo "  curl -fsSLO https://github.com/$repo_base/releases/download/$tag/linkml-scala.jar" >&2
+    echo "  java -jar linkml-scala.jar --help" >&2
+    return 1
+  fi
+
+  asset="$binary_name$arch_suffix"
+  release_url="https://github.com/$repo_base/releases/download/$tag"
+
+  tmp_dir=$(mktemp -d) || {
+    echo "Error: could not create a temporary directory." >&2
+    return 1
+  }
+
+  echo "Installing linkml-scala $tag ($asset)"
+
+  if ! curl -fL --progress-bar "$release_url/$asset.gz" -o "$tmp_dir/$asset.gz"; then
+    echo "Error: failed to download $release_url/$asset.gz" >&2
+    rm -rf "$tmp_dir"
+    return 1
+  fi
+
+  # Verify the download against the release's checksum manifest. A 404 here is an
+  # expected, handled case for older releases, so curl stays quiet about it (no -S).
+  if curl -fsL "$release_url/SHA256SUMS" -o "$tmp_dir/SHA256SUMS"; then
+    expected=$(awk -v want="$asset.gz" \
+      '{ name = $2; sub(/^\*/, "", name); if (name == want) { print $1; exit } }' \
+      "$tmp_dir/SHA256SUMS")
+    if [ -z "$expected" ]; then
+      echo "Error: SHA256SUMS for $tag does not list $asset.gz." >&2
+      rm -rf "$tmp_dir"
+      return 1
+    fi
+    actual=$(_linkml_scala_sha256 "$tmp_dir/$asset.gz" | cut -d ' ' -f 1)
+    if [ "$expected" != "$actual" ]; then
+      echo "Error: checksum mismatch for $asset.gz - refusing to install." >&2
+      echo "  expected: $expected" >&2
+      echo "  actual:   $actual" >&2
+      rm -rf "$tmp_dir"
+      return 1
+    fi
+    echo "Checksum verified against SHA256SUMS."
+  else
+    # Releases up to and including v0.12.0 predate the SHA256SUMS asset.
+    # TODO: make this a hard failure once the oldest supported release publishes one.
+    if [ "${LINKML_SCALA_REQUIRE_CHECKSUM:-}" = "1" ]; then
+      echo "Error: release $tag publishes no SHA256SUMS and" >&2
+      echo "LINKML_SCALA_REQUIRE_CHECKSUM=1 was set. Refusing to install." >&2
+      rm -rf "$tmp_dir"
+      return 1
+    fi
+    echo "Warning: release $tag publishes no SHA256SUMS, so the download could not be" >&2
+    echo "verified. Install a newer release to get a verifiable download." >&2
+  fi
+
+  # Best effort: Sigstore-backed proof that these bytes came out of the release workflow.
+  if command -v gh >/dev/null 2>&1; then
+    if gh attestation verify "$tmp_dir/$asset.gz" --repo "$repo_base" >/dev/null 2>&1; then
+      echo "Build provenance verified with gh attestation."
+    else
+      echo "Note: no build provenance found for $tag (older releases have none)." >&2
+    fi
+  fi
+
+  if ! gzip -d -f "$tmp_dir/$asset.gz"; then
+    echo "Error: failed to decompress $asset.gz" >&2
+    rm -rf "$tmp_dir"
+    return 1
+  fi
+
+  if ! mkdir -p "$install_dir"; then
+    echo "Error: could not create the install directory $install_dir." >&2
+    rm -rf "$tmp_dir"
+    return 1
+  fi
+
+  chmod +x "$tmp_dir/$asset"
+  if ! mv -f "$tmp_dir/$asset" "$install_dir/linkml-scala"; then
+    echo "Error: could not install into $install_dir." >&2
+    rm -rf "$tmp_dir"
+    return 1
+  fi
+  rm -rf "$tmp_dir"
+
+  echo "Installed linkml-scala $tag to $install_dir/linkml-scala"
+
+  case ":$PATH:" in
+    *":$install_dir:"*)
+      echo "Run 'linkml-scala --help' to get started."
+      return 0
+      ;;
+  esac
+
+  # Usable straight away if this script was sourced; a no-op when it was executed.
+  export PATH="$PATH:$install_dir"
+
+  case "${SHELL:-}" in
+    *zsh) profile="$HOME/.zshrc" ;;
+    *bash) profile="$HOME/.bashrc" ;;
+    *) profile="" ;; # Unknown shell - we would only guess wrong.
+  esac
+  path_line="export PATH=\"\$PATH:$install_dir\""
+  answer=""
+
+  # Only ever edit a profile with permission. Honour a preset answer for unattended
+  # installs, and never prompt when there is no terminal to prompt on - piping this
+  # script into a shell, or running it in CI, must not block.
+  if [ -n "$profile" ] && [ -n "${LINKML_SCALA_MODIFY_PROFILE:-}" ]; then
+    answer="$LINKML_SCALA_MODIFY_PROFILE"
+  elif [ -n "$profile" ] && [ -t 0 ]; then
+    printf '\n%s is not on your PATH.\nAdd it to %s? [y/N] ' "$install_dir" "$profile"
+    read -r answer
+  fi
+
+  case "$answer" in
+    1 | y | Y | yes | YES)
+      if [ -f "$profile" ] && grep -qF "$install_dir" "$profile"; then
+        echo "$profile already refers to $install_dir - leaving it unchanged."
+      elif printf '\n# Added by the linkml-scala installer\n%s\n' "$path_line" >>"$profile"; then
+        echo "Added $install_dir to your PATH in $profile."
+        echo "Open a new shell, or run 'source $profile', to pick it up."
+      else
+        echo "Error: could not write to $profile. Add this line yourself:" >&2
+        echo "  $path_line" >&2
+        return 1
+      fi
+      ;;
+    *)
+      echo
+      echo "Leaving your shell profile alone. To put $install_dir on your PATH"
+      echo "permanently, add this line to it:"
+      echo
+      echo "  $path_line"
+      echo
+      echo "Or call the binary by its full path:"
+      echo "  $install_dir/linkml-scala --help"
+      ;;
+  esac
+}
+
+_linkml_scala_install "$@"

--- a/docs/verifying_downloads.md
+++ b/docs/verifying_downloads.md
@@ -1,0 +1,81 @@
+# Verifying downloads
+
+Every LinkML-Scala artifact is published with a cryptographic signature, so you can be sure you downloaded a genuine build:
+
+| Release channel                                                                                                  | Signature type                                                | How to check it           |
+|------------------------------------------------------------------------------------------------------------------|---------------------------------------------------------------|---------------------------|
+| [GitHub Releases](https://github.com/NeverBlink-OSS/linkml-scala/releases) (native binaries, `linkml-scala.jar`) | `SHA256SUMS` manifest + Sigstore build provenance attestation | [below](#github-releases) |
+| [npm](https://www.npmjs.com/package/@neverblink/linkml) (`@neverblink/linkml`)                                   | Registry signature + SLSA provenance (npm trusted publishing) | [below](#npm)             |
+| [Maven Central](https://central.sonatype.com/namespace/eu.neverblink.linkml)                                     | PGP signature on every artifact                               | [below](#maven-central)   |
+
+## GitHub Releases
+
+### Checksums
+
+Each release publishes a `SHA256SUMS` file covering every asset – the four native binaries, their `.gz` counterparts, and `linkml-scala.jar`. Download it next to whatever you grabbed and compare:
+
+```shell
+curl -fsSLO https://github.com/NeverBlink-OSS/linkml-scala/releases/latest/download/SHA256SUMS
+sha256sum --ignore-missing -c SHA256SUMS
+```
+
+`--ignore-missing` is what lets you verify a single asset without downloading all nine. On macOS, use `shasum -a 256 --ignore-missing -c SHA256SUMS` instead.
+
+Expect one `OK` line per file you actually have:
+
+```
+linkml-scala-linux-x86_64.gz: OK
+```
+
+### Build provenance
+
+Checksums only prove that your copy matches the manifest. The provenance attestation also proves that these exact bytes were produced by our release workflow, from a specific commit in this repository. Nobody can forge one without control of the repository's Actions runs.
+
+Verify it with the [GitHub CLI](https://cli.github.com/):
+
+```shell
+gh attestation verify linkml-scala-linux-x86_64 --repo NeverBlink-OSS/linkml-scala
+```
+
+`SHA256SUMS` is attested too:
+
+```shell
+gh attestation verify SHA256SUMS --repo NeverBlink-OSS/linkml-scala
+```
+
+Note that `install.sh` performs both of these checks for you – the checksum always, and the attestation when `gh` happens to be installed.
+
+## npm
+
+`@neverblink/linkml` is published with [npm trusted publishing](https://docs.npmjs.com/trusted-publishers), which means the registry holds both a signature and a SLSA provenance attestation tying the tarball to the release workflow. Once it is in your dependency tree, check the whole tree at once:
+
+```shell
+npm audit signatures
+```
+
+You can also see the provenance, including the source commit and the workflow that published it, on
+the [package page](https://www.npmjs.com/package/@neverblink/linkml).
+
+## Maven Central
+
+Every artifact under `eu.neverblink.linkml` is PGP-signed. Signatures sit next to the artifact with an `.asc` suffix.
+
+```shell
+# Fetch the signing key (replace the version and artifact as needed)
+gpg --keyserver keyserver.ubuntu.com --recv-keys 0DB83C00CF3505E9D904FB58A6D1F7F53F035C53
+
+BASE=https://repo1.maven.org/maven2/eu/neverblink/linkml/generator_3/0.12.0
+curl -fsSLO "$BASE/generator_3-0.12.0.jar"
+curl -fsSLO "$BASE/generator_3-0.12.0.jar.asc"
+gpg --verify generator_3-0.12.0.jar.asc generator_3-0.12.0.jar
+```
+
+The signing key fingerprint is:
+
+```
+0DB8 3C00 CF35 05E9 D904  FB58 A6D1 F7F5 3F03 5C53
+```
+
+## Reporting a problem
+
+If a checksum or signature ever fails to verify, please **don't** run the artifact. Open a [security advisory](https://github.com/NeverBlink-OSS/linkml-scala/security/advisories/new) or reach out at [contact@neverblink.eu](mailto:contact@neverblink.eu).


### PR DESCRIPTION
- Ask user to edit .bashrc
- Make the install script a bit more robust (esp. around exits), add CI tests for that
- Attest published binaries with github sigstore
- Publish SHA256 checksums for binaries