### PR TITLE
Add macOS Intel builds

### DIFF
--- a/.github/workflows/install.yml
+++ b/.github/workflows/install.yml
@@ -27,7 +27,7 @@ jobs:
       fail-fast: false
       matrix:
         # Every platform with a published release asset that install.sh supports.
-        os: [ ubuntu-latest, ubuntu-22.04-arm, macos-14 ]
+        os: [ ubuntu-latest, ubuntu-22.04-arm, macos-14, macos-15-intel ]
     defaults:
       run:
         shell: bash

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -40,7 +40,8 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [macos-14, ubuntu-22.04, ubuntu-22.04-arm, windows-latest]
+        # Oldest available image per platform, so the binaries stay usable on older systems.
+        os: [macos-14, macos-15-intel, ubuntu-22.04, ubuntu-22.04-arm, windows-latest]
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v7
@@ -114,16 +115,19 @@ jobs:
         run: |
           mv bin/linkml-scala-assembly/linkml-scala.jar linkml-scala.jar
           mv bin/linkml-scala-macos-14/linkml-scala linkml-scala-macos-arm64
+          mv bin/linkml-scala-macos-15-intel/linkml-scala linkml-scala-macos-x86_64
           mv bin/linkml-scala-ubuntu-22.04/linkml-scala linkml-scala-linux-x86_64
           mv bin/linkml-scala-ubuntu-22.04-arm/linkml-scala linkml-scala-linux-arm64
           mv bin/linkml-scala-windows-latest/linkml-scala.exe linkml-scala-windows-x86_64.exe
           chmod +x linkml-scala-macos-arm64
+          chmod +x linkml-scala-macos-x86_64
           chmod +x linkml-scala-linux-x86_64
           chmod +x linkml-scala-linux-arm64
 
       - name: Create Gzipped Versions
         run: |
           gzip -9 -k linkml-scala-macos-arm64 &
+          gzip -9 -k linkml-scala-macos-x86_64 &
           gzip -9 -k linkml-scala-linux-x86_64 &
           gzip -9 -k linkml-scala-linux-arm64 &
           gzip -9 -k linkml-scala-windows-x86_64.exe &

--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ In some cases, LinkML-Scala diverges from the Python implementation, or is missi
 
 ### Method 1: Install script (recommended for Unix/macOS)
 
-If you are on Linux (x86-64, ARM64), macOS (ARM64), or using WSL on Windows, the easiest way to grab the latest release is via our installation script:
+If you are on Linux (x86-64, ARM64), macOS (x86-64, ARM64), or using WSL on Windows, the easiest way to grab the latest release is via our installation script:
 
 ```shell
 . <(curl -sSfL https://raw.githubusercontent.com/NeverBlink-OSS/linkml-scala/refs/heads/main/cli/install.sh)

--- a/cli/install.sh
+++ b/cli/install.sh
@@ -95,15 +95,6 @@ _linkml_scala_install() {
       ;;
   esac
 
-  # Not every OS/arch pair has a native binary. Point at the JVM build instead.
-  if [ "$os$arch_suffix" = "darwin-x86_64" ]; then
-    echo "Error: there is no native binary for Intel macOS." >&2
-    echo "Use the JVM build instead (requires Java 17 or newer):" >&2
-    echo "  curl -fsSLO https://github.com/$repo_base/releases/download/$tag/linkml-scala.jar" >&2
-    echo "  java -jar linkml-scala.jar --help" >&2
-    return 1
-  fi
-
   asset="$binary_name$arch_suffix"
   release_url="https://github.com/$repo_base/releases/download/$tag"
 

--- a/docs/verifying_downloads.md
+++ b/docs/verifying_downloads.md
@@ -12,14 +12,14 @@ Every LinkML-Scala artifact is published with a cryptographic signature, so you 
 
 ### Checksums
 
-Each release publishes a `SHA256SUMS` file covering every asset – the four native binaries, their `.gz` counterparts, and `linkml-scala.jar`. Download it next to whatever you grabbed and compare:
+Each release publishes a `SHA256SUMS` file covering every asset – the five native binaries, their `.gz` counterparts, and `linkml-scala.jar`. Download it next to whatever you grabbed and compare:
 
 ```shell
 curl -fsSLO https://github.com/NeverBlink-OSS/linkml-scala/releases/latest/download/SHA256SUMS
 sha256sum --ignore-missing -c SHA256SUMS
 ```
 
-`--ignore-missing` is what lets you verify a single asset without downloading all nine. On macOS, use `shasum -a 256 --ignore-missing -c SHA256SUMS` instead.
+`--ignore-missing` is what lets you verify a single asset without downloading all eleven. On macOS, use `shasum -a 256 --ignore-missing -c SHA256SUMS` instead.
 
 Expect one `OK` line per file you actually have:
 


### PR DESCRIPTION
Because why not.

The install.sh CI will fail in this PR, this will be fixed after release.