### PR TITLE
Make CI cache smaller, speed up CI

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -16,6 +16,15 @@ jobs:
       - name: Checkout sources
         uses: actions/checkout@v7
 
+      # Coursier unpacks every JDK it fetches (Temurin here, GraalVM in the release
+      # workflow) into ~/.cache/coursier/arc, so cache-action uploads each one twice:
+      # once as the downloaded archive, once extracted. That dwarfs the ~50 MB of jars
+      # we actually want cached. Park the extracted copies in the runner temp dir, which
+      # is never cached. Re-extracting is far cheaper than shipping GBs each run.
+      - name: Relocate the coursier archive cache
+        shell: bash
+        run: echo "COURSIER_ARCHIVE_CACHE=${{ runner.temp }}/cs-arc" >> "$GITHUB_ENV"
+
       - name: Cache dependencies
         uses: coursier/cache-action@v8
 
@@ -33,14 +42,18 @@ jobs:
       - name: Checkout sources
         uses: actions/checkout@v7
 
+      - name: Relocate the coursier archive cache # see scalafmt-lint
+        shell: bash
+        run: echo "COURSIER_ARCHIVE_CACHE=${{ runner.temp }}/cs-arc" >> "$GITHUB_ENV"
+
       - name: Cache dependencies
         uses: coursier/cache-action@v8
 
-      - name: Setup JVM and Mill
-        uses: coursier/setup-action@v3
+      - name: Setup JVM
+        uses: actions/setup-java@v5
         with:
-          jvm: temurin:17
-          apps: mill
+          distribution: temurin
+          java-version: 17
 
       - name: Install PyYAML
         run: pip install --quiet pyyaml
@@ -51,8 +64,7 @@ jobs:
           ./mill --no-server cli.jvm.assembly
           jar="$(pwd)/out/cli/jvm/assembly.dest/out.jar"
           test -f "$jar" || { echo "no assembly at $jar"; ls -la "$(dirname "$jar")"; exit 1; }
-          # Resolve java via JAVA_HOME: the setup action exports it but does not
-          # necessarily put java itself on PATH.
+          # Prefer JAVA_HOME over whatever java happens to be first on PATH.
           java="java"
           if [ -x "$JAVA_HOME/bin/java" ]; then java="$JAVA_HOME/bin/java"; fi
           mkdir -p "$RUNNER_TEMP/bin"
@@ -83,14 +95,18 @@ jobs:
       - name: Checkout sources
         uses: actions/checkout@v7
 
+      - name: Relocate the coursier archive cache # see scalafmt-lint
+        shell: bash
+        run: echo "COURSIER_ARCHIVE_CACHE=${{ runner.temp }}/cs-arc" >> "$GITHUB_ENV"
+
       - name: Cache dependencies
         uses: coursier/cache-action@v8
 
-      - name: Setup JVM and Mill
-        uses: coursier/setup-action@v3
+      - name: Setup JVM
+        uses: actions/setup-java@v5
         with:
-          jvm: temurin:17
-          apps: mill
+          distribution: temurin
+          java-version: 17
 
       - name: Setup Node.js
         uses: actions/setup-node@v6
@@ -115,6 +131,10 @@ jobs:
     steps:
       - name: Checkout sources
         uses: actions/checkout@v7
+
+      - name: Relocate the coursier archive cache # see scalafmt-lint
+        shell: bash
+        run: echo "COURSIER_ARCHIVE_CACHE=${{ runner.temp }}/cs-arc" >> "$GITHUB_ENV"
 
       - name: Cache dependencies
         uses: coursier/cache-action@v8

--- a/.github/workflows/deploy-playground.yml
+++ b/.github/workflows/deploy-playground.yml
@@ -21,14 +21,19 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v7
 
+      # Keeps extracted JDKs out of the cached coursier dir. See checks.yml
+      - name: Relocate the coursier archive cache
+        shell: bash
+        run: echo "COURSIER_ARCHIVE_CACHE=${{ runner.temp }}/cs-arc" >> "$GITHUB_ENV"
+
       - name: Cache dependencies
         uses: coursier/cache-action@v8
 
-      - name: Setup JVM and Mill
-        uses: coursier/setup-action@v3
+      - name: Setup JVM
+        uses: actions/setup-java@v5
         with:
-          jvm: temurin:17
-          apps: mill
+          distribution: temurin
+          java-version: 17
 
       - name: Setup Node.js
         uses: actions/setup-node@v6

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,14 +15,19 @@ jobs:
         with:
           fetch-depth: 0 # Required so Mill can see the full Git history and tags
 
+      # Keeps extracted JDKs out of the cached coursier dir. See checks.yml
+      - name: Relocate the coursier archive cache
+        shell: bash
+        run: echo "COURSIER_ARCHIVE_CACHE=${{ runner.temp }}/cs-arc" >> "$GITHUB_ENV"
+
       - name: Cache Dependencies
         uses: coursier/cache-action@v8
 
-      - name: Setup JVM and Mill
-        uses: coursier/setup-action@v3
+      - name: Setup JVM
+        uses: actions/setup-java@v5
         with:
-          jvm: temurin:17 # The minimal JDK version for Scala Next
-          apps: mill
+          distribution: temurin
+          java-version: 17 # The minimal JDK version for Scala Next
 
       - name: Assembly Uber-JAR
         run: |
@@ -46,13 +51,20 @@ jobs:
       - name: Checkout Repository
         uses: actions/checkout@v7
 
+      # Matters most here: nativeImage pulls a ~360 MB GraalVM tarball and unpacks it
+      # to ~1 GB, and both copies used to land in the cache. See checks.yml.
+      - name: Relocate the coursier archive cache
+        shell: bash
+        run: echo "COURSIER_ARCHIVE_CACHE=${{ runner.temp }}/cs-arc" >> "$GITHUB_ENV"
+
       - name: Cache Dependencies
         uses: coursier/cache-action@v8
 
-      - name: Setup JVM and Mill
-        uses: coursier/setup-action@v3
+      - name: Setup JVM
+        uses: actions/setup-java@v5
         with:
-          jvm: temurin:17 # The minimal JDK version for Scala Next
+          distribution: temurin
+          java-version: 17 # The minimal JDK version for Scala Next
 
       - name: Setup MSVC (Windows only)
         if: runner.os == 'Windows'
@@ -178,14 +190,19 @@ jobs:
         with:
           fetch-depth: 0 # Required so Mill can derive the version from Git tags
 
+      # Keeps extracted JDKs out of the cached coursier dir; see checks.yml
+      - name: Relocate the coursier archive cache
+        shell: bash
+        run: echo "COURSIER_ARCHIVE_CACHE=${{ runner.temp }}/cs-arc" >> "$GITHUB_ENV"
+
       - name: Cache Dependencies
         uses: coursier/cache-action@v8
 
-      - name: Setup JVM and Mill
-        uses: coursier/setup-action@v3
+      - name: Setup JVM
+        uses: actions/setup-java@v5
         with:
-          jvm: temurin:25
-          apps: mill
+          distribution: temurin
+          java-version: 25
 
       - name: Setup Node.js
         uses: actions/setup-node@v6

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -32,14 +32,19 @@ jobs:
           fetch-depth: 256 # limits number of snapshots between releases
           fetch-tags: true # forces GitHub to fetch tags even on a partial history
 
+      # Keeps extracted JDKs out of the cached coursier dir. See checks.yml
+      - name: Relocate the coursier archive cache
+        shell: bash
+        run: echo "COURSIER_ARCHIVE_CACHE=${{ runner.temp }}/cs-arc" >> "$GITHUB_ENV"
+
       - name: Cache dependencies
         uses: coursier/cache-action@v8
 
-      - name: Setup JVM and Mill
-        uses: coursier/setup-action@v3
+      - name: Setup JVM
+        uses: actions/setup-java@v5
         with:
-          jvm: temurin:${{ matrix.java }}
-          apps: mill
+          distribution: temurin
+          java-version: ${{ matrix.java }}
 
       - name: Setup Node.js
         uses: actions/setup-node@v6

--- a/.gitignore
+++ b/.gitignore
@@ -41,3 +41,6 @@ ui/dist/
 
 # AI
 .claude/
+
+# Python
+__pycache__/


### PR DESCRIPTION
We were caching entire JDKs for no reason, which resulted in 2.5 GB caches being pulled for every job...