### PR TITLE
LNK-153 Fix wrong inlining that introduces unexpected slowdown for JSON Schema generation

### DIFF
--- a/generator/src/eu/neverblink/linkml/generator/jsonschema/JsonSchemaGenerator.scala
+++ b/generator/src/eu/neverblink/linkml/generator/jsonschema/JsonSchemaGenerator.scala
@@ -282,15 +282,15 @@ object JsonSchemaGenerator {
   extension (schema: Schema)
     /** Wrap this Schema in an array
       */
-    inline def arrayOf: Schema = arraySchema.copy(items = new Some(schema))
+    def arrayOf: Schema = arraySchema.copy(items = new Some(schema))
 
     /** Wrap this Schema in an array if the condition is true, return the schema unchanged otherwise
       */
-    inline def arrayOfIf(condition: Boolean): Schema = if condition then schema.arrayOf else schema
+    def arrayOfIf(condition: Boolean): Schema = if condition then schema.arrayOf else schema
 
     /** Wrap this Schema as a dict (object with additional properties set to this schema)
       */
-    inline def dictOf: Schema = objectSchema.copy(additionalProperties = new Some(schema))
+    def dictOf: Schema = objectSchema.copy(additionalProperties = new Some(schema))
 
   private implicit lazy val codec: JsonValueCodec[Schema] = {
     implicit val schemaLikeCodec: JsonValueCodec[SchemaLike] = new JsonValueCodec {


### PR DESCRIPTION
Results of generator benchmarks with JDK 25 on MacBook after this fix:
```txt
Benchmark                                          (schema)   Mode  Cnt     Score     Error  Units
GeneratorBench.jsonSchemaFromSchemaView      cgmes-core.yml  thrpt    5  1439.854 ±   9.919  ops/s
GeneratorBench.jsonSchemaFromSchemaView  cgmes-dynamics.yml  thrpt    5   674.716 ± 102.619  ops/s
GeneratorBench.jsonSchemaFromSchemaView         TC57CIM.yml  thrpt    5    74.900 ±   2.379  ops/s
GeneratorBench.jsonSchemaFromSchemas         cgmes-core.yml  thrpt    5   487.460 ±  18.575  ops/s
GeneratorBench.jsonSchemaFromSchemas     cgmes-dynamics.yml  thrpt    5   205.109 ±   2.191  ops/s
GeneratorBench.jsonSchemaFromSchemas            TC57CIM.yml  thrpt    5    24.430 ±   0.319  ops/s
GeneratorBench.jsonSchemaFromYaml            cgmes-core.yml  thrpt    5   228.240 ±   2.975  ops/s
GeneratorBench.jsonSchemaFromYaml        cgmes-dynamics.yml  thrpt    5    61.799 ±   1.886  ops/s
GeneratorBench.jsonSchemaFromYaml               TC57CIM.yml  thrpt    5    10.838 ±   0.290  ops/s
GeneratorBench.linkmlFromSchemaView          cgmes-core.yml  thrpt    5   409.093 ±   3.132  ops/s
GeneratorBench.linkmlFromSchemaView      cgmes-dynamics.yml  thrpt    5   186.885 ±   1.347  ops/s
GeneratorBench.linkmlFromSchemaView             TC57CIM.yml  thrpt    5    22.635 ±   0.463  ops/s
GeneratorBench.linkmlFromSchemas             cgmes-core.yml  thrpt    5   266.863 ±   3.897  ops/s
GeneratorBench.linkmlFromSchemas         cgmes-dynamics.yml  thrpt    5   116.081 ±   1.638  ops/s
GeneratorBench.linkmlFromSchemas                TC57CIM.yml  thrpt    5    14.939 ±   0.316  ops/s
GeneratorBench.linkmlFromYaml                cgmes-core.yml  thrpt    5   162.527 ±   2.302  ops/s
GeneratorBench.linkmlFromYaml            cgmes-dynamics.yml  thrpt    5    49.177 ±   2.336  ops/s
GeneratorBench.linkmlFromYaml                   TC57CIM.yml  thrpt    5     8.398 ±   0.221  ops/s
GeneratorBench.shaclFromSchemaView           cgmes-core.yml  thrpt    5   323.348 ±   0.491  ops/s
GeneratorBench.shaclFromSchemaView       cgmes-dynamics.yml  thrpt    5   241.314 ±  19.182  ops/s
GeneratorBench.shaclFromSchemaView              TC57CIM.yml  thrpt    5    27.416 ±   0.200  ops/s
GeneratorBench.shaclFromSchemas              cgmes-core.yml  thrpt    5   229.739 ±   1.919  ops/s
GeneratorBench.shaclFromSchemas          cgmes-dynamics.yml  thrpt    5   141.263 ±   1.072  ops/s
GeneratorBench.shaclFromSchemas                 TC57CIM.yml  thrpt    5    17.558 ±   0.309  ops/s
GeneratorBench.shaclFromYaml                 cgmes-core.yml  thrpt    5   149.689 ±   0.454  ops/s
GeneratorBench.shaclFromYaml             cgmes-dynamics.yml  thrpt    5    55.351 ±   1.319  ops/s
GeneratorBench.shaclFromYaml                    TC57CIM.yml  thrpt    5     9.238 ±   0.118  ops/s
```