### PR TITLE
More efficient generation and validation of schemas (up to 10% speedup)

### DIFF
--- a/benchmark/src/eu/neverblink/linkml/benchmark/GeneratorBench.scala
+++ b/benchmark/src/eu/neverblink/linkml/benchmark/GeneratorBench.scala
@@ -1,5 +1,6 @@
 package eu.neverblink.linkml.benchmark
 
+import com.github.plokhotnyuk.jsoniter_scala.core.{WriterConfig, writeToStream}
 import eu.neverblink.linkml.benchmark.BenchUtil.BlackholeOutputStream
 import eu.neverblink.linkml.generator.jsonschema.JsonSchemaGenerator
 import eu.neverblink.linkml.generator.linkml.LinkMlGenerator
@@ -39,19 +40,15 @@ class GeneratorBench extends CommonParams {
 
   @Benchmark
   def jsonSchemaFromYaml(bh: Blackhole): Unit =
-    bh.consume(
-      JsonSchemaGenerator(using
-        SchemaIssues.orThrow(SchemaView.loadSchemaViewFromString(yaml)),
-      ).serialize(),
-    )
+    writeJsonSchema(bh)(using SchemaIssues.orThrow(SchemaView.loadSchemaViewFromString(yaml)))
 
   @Benchmark
   def jsonSchemaFromSchemas(bh: Blackhole): Unit =
-    bh.consume(JsonSchemaGenerator(using SchemaView(schemaView.schemas)).serialize())
+    writeJsonSchema(bh)(using SchemaView(schemaView.schemas))
 
   @Benchmark
   def jsonSchemaFromSchemaView(bh: Blackhole): Unit =
-    bh.consume(JsonSchemaGenerator(using schemaView).serialize())
+    writeJsonSchema(bh)(using schemaView)
 
   @Benchmark
   def shaclFromYaml(bh: Blackhole): Unit =
@@ -80,6 +77,15 @@ class GeneratorBench extends CommonParams {
         SchemaIssues.orThrow(SchemaView.loadSchemaViewFromString(yaml)),
       ).serialize(),
     )
+
+  /** Same setup for JSON schema sinks as in the CLI.
+    */
+  private def writeJsonSchema(bh: Blackhole)(using SchemaView): Unit =
+    writeToStream(
+      JsonSchemaGenerator().generate(),
+      new BlackholeOutputStream(bh),
+      WriterConfig.withIndentionStep(2),
+    )(using JsonSchemaGenerator.codec)
 
   /** Same setup for RDF sinks as in the CLI.
     */

--- a/benchmark/src/eu/neverblink/linkml/benchmark/WarmBench.scala
+++ b/benchmark/src/eu/neverblink/linkml/benchmark/WarmBench.scala
@@ -1,5 +1,6 @@
 package eu.neverblink.linkml.benchmark
 
+import com.github.plokhotnyuk.jsoniter_scala.core.*
 import eu.neverblink.linkml.benchmark.BenchUtil.BlackholeOutputStream
 import eu.neverblink.linkml.generator.jsonschema.JsonSchemaGenerator
 import eu.neverblink.linkml.generator.rdf.{BufferedByteSink, NTriplesRdfSink, RdfUtils}
@@ -58,7 +59,11 @@ class WarmBench extends CommonParams {
   @Benchmark
   def jsonSchema(bh: Blackhole): Unit = {
     // create SchemaView in the benchmark to not use the class cache
-    bh.consume(JsonSchemaGenerator(using SchemaView(schemaDefs)).serialize())
+    writeToStream(
+      JsonSchemaGenerator(using SchemaView(schemaDefs)).generate(),
+      new BlackholeOutputStream(bh),
+      WriterConfig.withIndentionStep(2),
+    )(using JsonSchemaGenerator.codec)
   }
 
   @Benchmark

--- a/cli/src/eu/neverblink/linkml/cli/GenerateImpl.scala
+++ b/cli/src/eu/neverblink/linkml/cli/GenerateImpl.scala
@@ -79,8 +79,8 @@ object JsonSchema extends StreamGenerate[JsonSchemaOptions] {
         JsonSchemaGenerator.Options(
           options.open,
           options.treeRootOverride,
-          treeRootInlineTypeOverride = options.treeRootInlineTypeOverride,
-        )
+          options.treeRootInlineTypeOverride,
+        ),
       ),
       out,
       WriterConfig.withIndentionStep(2),

--- a/cli/src/eu/neverblink/linkml/cli/GenerateImpl.scala
+++ b/cli/src/eu/neverblink/linkml/cli/GenerateImpl.scala
@@ -1,6 +1,7 @@
 package eu.neverblink.linkml.cli
 
 import caseapp.*
+import com.github.plokhotnyuk.jsoniter_scala.core.*
 import eu.neverblink.linkml.generator.erdiagram.ErDiagramGenerator
 import eu.neverblink.linkml.generator.graphql.GraphQlGenerator
 import eu.neverblink.linkml.generator.jsonschema.JsonSchemaGenerator
@@ -67,24 +68,23 @@ final case class JsonSchemaOptions(
     treeRootInlineTypeOverride: Option[String] = None,
 ) extends HasGenerateOptions
 
-object JsonSchema extends StringGenerate[JsonSchemaOptions] {
+object JsonSchema extends StreamGenerate[JsonSchemaOptions] {
   override protected def generatorName: String = "json-schema"
 
-  override protected[cli] def generate(
-      options: JsonSchemaOptions,
-  )(using SchemaView): Iterable[(String, String)] =
-    Seq(
-      (
-        "",
-        JsonSchemaGenerator().serialize(
-          JsonSchemaGenerator.Options(
-            open = options.open,
-            treeRoot = options.treeRootOverride,
-            treeRootInlineType = options.treeRootInlineTypeOverride,
-          ),
-        ),
+  override protected[cli] def generate(options: JsonSchemaOptions, out: OutputStream)(using
+      SchemaView,
+  ): Unit =
+    writeToStream(
+      JsonSchemaGenerator().generate(
+        JsonSchemaGenerator.Options(
+          options.open,
+          options.treeRootOverride,
+          treeRootInlineTypeOverride = options.treeRootInlineTypeOverride,
+        )
       ),
-    )
+      out,
+      WriterConfig.withIndentionStep(2),
+    )(using JsonSchemaGenerator.codec)
 }
 
 // SHACL

--- a/cli/src/eu/neverblink/linkml/generator/rdf/RdfUtils.scala
+++ b/cli/src/eu/neverblink/linkml/generator/rdf/RdfUtils.scala
@@ -7,7 +7,7 @@ import org.eclipse.rdf4j.model.{Value, ValueFactory, IRI as Rdf4jIri, Resource a
 import org.eclipse.rdf4j.rio.helpers.BasicWriterSettings
 import org.eclipse.rdf4j.rio.{RDFFormat, Rio, WriterConfig}
 
-import java.io.{OutputStream, StringWriter}
+import java.io.{FilterOutputStream, OutputStream, StringWriter}
 
 /** An [[RdfSink]] that collects prefixes and triples into an RDF4J [[Model]] and serializes it as
   * pretty-printed Turtle. Building the model and running the RDF4J writer is substantially slower
@@ -105,43 +105,38 @@ object RdfUtils {
 
 /** A fast replacement for java.io.BufferedOutputStream. Not thread-safe.
   */
-class FastBufferedOutputStream(out: OutputStream) extends OutputStream {
+class FastBufferedOutputStream(out: OutputStream) extends FilterOutputStream(out) {
   private inline val capacity = 32768
-  private val buf: Array[Byte] = new Array[Byte](capacity)
+  private val buf = new Array[Byte](capacity)
   private var count = 0
 
   override def write(b: Int): Unit = {
-    val i = count
-    if (i >= buf.length) flushBuffer()
+    var i = count
+    if (i >= capacity) i = flushBuf(i)
     buf(i) = b.toByte
     count = i + 1
   }
 
   override def write(b: Array[Byte], off: Int, len: Int): Unit = {
-    var remaining = len
-    while (remaining > 0) {
-      if (remaining > capacity - count) flushBuffer()
-      val batchSize = java.lang.Math.min(capacity, remaining)
-      System.arraycopy(b, off, buf, count, batchSize)
-      count += batchSize
-      remaining -= batchSize
+    var i = count
+    if (len >= capacity) {
+      count = flushBuf(i)
+      out.write(b, off, len)
+    } else {
+      if (len > capacity - i) i = flushBuf(i)
+      System.arraycopy(b, off, buf, i, len)
+      count = i + len
     }
   }
 
   override def flush(): Unit = {
-    flushBuffer()
+    val i = count
+    if (i > 0) count = flushBuf(i)
     out.flush()
   }
 
-  override def close(): Unit =
-    try flush()
-    finally out.close()
-
-  private def flushBuffer(): Unit = {
-    val remaining = count
-    if (remaining > 0) {
-      out.write(buf, 0, remaining)
-      count = 0
-    }
+  private def flushBuf(len: Int): Int = {
+    out.write(buf, 0, len)
+    0
   }
 }

--- a/cli/src/eu/neverblink/linkml/generator/rdf/RdfUtils.scala
+++ b/cli/src/eu/neverblink/linkml/generator/rdf/RdfUtils.scala
@@ -103,7 +103,13 @@ object RdfUtils {
   }
 }
 
-/** A fast replacement for java.io.BufferedOutputStream. Not thread-safe.
+/** A high-performance, non-thread-safe alternative to `java.io.BufferedOutputStream`.
+  *
+  * This class improves throughput by eliminating synchronization overhead and using a fixed-size
+  * buffer to avoid reallocation.
+  *
+  * @param out
+  *   the underlying output stream to write to.
   */
 class FastBufferedOutputStream(out: OutputStream) extends FilterOutputStream(out) {
   private inline val capacity = 32768

--- a/cli/src/eu/neverblink/linkml/generator/rdf/RdfUtils.scala
+++ b/cli/src/eu/neverblink/linkml/generator/rdf/RdfUtils.scala
@@ -7,7 +7,7 @@ import org.eclipse.rdf4j.model.{Value, ValueFactory, IRI as Rdf4jIri, Resource a
 import org.eclipse.rdf4j.rio.helpers.BasicWriterSettings
 import org.eclipse.rdf4j.rio.{RDFFormat, Rio, WriterConfig}
 
-import java.io.{BufferedOutputStream, OutputStream, StringWriter}
+import java.io.{OutputStream, StringWriter}
 
 /** An [[RdfSink]] that collects prefixes and triples into an RDF4J [[Model]] and serializes it as
   * pretty-printed Turtle. Building the model and running the RDF4J writer is substantially slower
@@ -28,7 +28,7 @@ final class TurtleRdfSink(using vf: ValueFactory = SimpleValueFactory.getInstanc
 
   /** Serialize the collected model as Turtle straight to [[out]]. Flushes but does not close it. */
   def writeTo(out: OutputStream): Unit = {
-    val buffered = new BufferedOutputStream(out)
+    val buffered = new FastBufferedOutputStream(out)
     Rio.write(builder.build(), buffered, RDFFormat.TURTLE, TurtleRdfSink.config)
     buffered.flush()
   }
@@ -100,5 +100,48 @@ object RdfUtils {
     val sink = NTriplesRdfSink(charSink)
     write(sink)
     charSink.flush()
+  }
+}
+
+/** A fast replacement for java.io.BufferedOutputStream. Not thread-safe.
+  */
+class FastBufferedOutputStream(out: OutputStream) extends OutputStream {
+  private inline val capacity = 32768
+  private val buf: Array[Byte] = new Array[Byte](capacity)
+  private var count = 0
+
+  override def write(b: Int): Unit = {
+    val i = count
+    if (i >= buf.length) flushBuffer()
+    buf(i) = b.toByte
+    count = i + 1
+  }
+
+  override def write(b: Array[Byte], off: Int, len: Int): Unit = {
+    var remaining = len
+    while (remaining > 0) {
+      if (remaining > capacity - count) flushBuffer()
+      val batchSize = java.lang.Math.min(capacity, remaining)
+      System.arraycopy(b, off, buf, count, batchSize)
+      count += batchSize
+      remaining -= batchSize
+    }
+  }
+
+  override def flush(): Unit = {
+    flushBuffer()
+    out.flush()
+  }
+
+  override def close(): Unit =
+    try flush()
+    finally out.close()
+
+  private def flushBuffer(): Unit = {
+    val remaining = count
+    if (remaining > 0) {
+      out.write(buf, 0, remaining)
+      count = 0
+    }
   }
 }

--- a/cli/test/src/eu/neverblink/linkml/generator/rdf/FastBufferedOutputStreamSpec.scala
+++ b/cli/test/src/eu/neverblink/linkml/generator/rdf/FastBufferedOutputStreamSpec.scala
@@ -1,0 +1,82 @@
+package eu.neverblink.linkml.generator.rdf
+
+import org.scalatest.wordspec.AnyWordSpec
+import org.scalatest.matchers.should.Matchers
+import java.io.ByteArrayOutputStream
+
+class FastBufferedOutputStreamSpec extends AnyWordSpec with Matchers {
+  class SpyOutputStream extends ByteArrayOutputStream {
+    var flushCount = 0
+    var closeCount = 0
+
+    override def flush(): Unit = {
+      flushCount += 1
+      super.flush()
+    }
+
+    override def close(): Unit = {
+      closeCount += 1
+      super.close()
+    }
+  }
+
+  "A FastBufferedOutputStream" should {
+    "write single bytes and hold them in the buffer until flushed" in {
+      val spy = new SpyOutputStream()
+      val out = new FastBufferedOutputStream(spy)
+      out.write('a'.toInt)
+      out.write('b'.toInt)
+      out.write('c'.toInt)
+      spy.toByteArray shouldBe empty
+      out.flush()
+      spy.toByteArray shouldBe Array('a'.toByte, 'b'.toByte, 'c'.toByte)
+    }
+
+    "automatically flush when capacity (32768) is exceeded by single byte writes" in {
+      val spy = new SpyOutputStream()
+      val out = new FastBufferedOutputStream(spy)
+      val capacity = 32768
+      for (_ <- 1 to capacity) {
+        out.write(1)
+      }
+      spy.toByteArray shouldBe empty
+      out.write(2)
+      spy.toByteArray.length shouldBe capacity
+      spy.toByteArray.forall(_ == 1) shouldBe true
+      out.flush()
+      spy.toByteArray.length shouldBe capacity + 1
+      spy.toByteArray.last shouldBe 2
+    }
+
+    "write a byte array correctly" in {
+      val spy = new SpyOutputStream()
+      val out = new FastBufferedOutputStream(spy)
+      val data = "Hello, ScalaTest!".getBytes
+      out.write(data, 0, data.length)
+      spy.toByteArray shouldBe empty
+      out.flush()
+      spy.toByteArray shouldBe data
+    }
+
+    "delegate flush() to the underlying stream" in {
+      val spy = new SpyOutputStream()
+      val out = new FastBufferedOutputStream(spy)
+      out.write(Seq(1, 2, 3).map(_.toByte).toArray, 0, 3)
+      spy.flushCount shouldBe 0
+      out.flush()
+      spy.flushCount shouldBe 1
+      spy.toByteArray.length shouldBe 3
+    }
+
+    "flush the buffer and delegate close() to the underlying stream" in {
+      val spy = new SpyOutputStream()
+      val out = new FastBufferedOutputStream(spy)
+      out.write(42)
+      spy.closeCount shouldBe 0
+      spy.toByteArray shouldBe empty
+      out.close()
+      spy.toByteArray shouldBe Array(42.toByte)
+      spy.closeCount shouldBe 1
+    }
+  }
+}

--- a/generator/src/eu/neverblink/linkml/generator/jsonschema/JsonSchemaGenerator.scala
+++ b/generator/src/eu/neverblink/linkml/generator/jsonschema/JsonSchemaGenerator.scala
@@ -61,7 +61,7 @@ class JsonSchemaGenerator(using sv: SchemaView) {
     }
     // If a tree root is defined, only include classes reachable from the tree root (pruning).
     // Otherwise, include all classes in the schema view.
-    val query = maybeTreeRoot.foldFast(IncludeAllReachabilityQuery()) { root =>
+    val query = maybeTreeRoot.foldFast(new IncludeAllReachabilityQuery()) { root =>
       sv.derivedReachabilityQuery(Seq(root), true, false)
     }
     // Mutable set this method will add to if it requires a keyless class to be defined in `$defs`

--- a/generator/src/eu/neverblink/linkml/generator/jsonschema/JsonSchemaGenerator.scala
+++ b/generator/src/eu/neverblink/linkml/generator/jsonschema/JsonSchemaGenerator.scala
@@ -224,7 +224,7 @@ class JsonSchemaGenerator(using sv: SchemaView) {
     )
   }
 
-  /** Generate the JSON Schema and serialize it
+  /** Generate the JSON Schema and serialize it into a string value
     *
     * @param options
     *   What to generate. See [[JsonSchemaGenerator.Options]].
@@ -298,7 +298,7 @@ object JsonSchemaGenerator {
       */
     def dictOf: Schema = objectSchema.copy(additionalProperties = new Some(schema))
 
-  private implicit lazy val codec: JsonValueCodec[Schema] = {
+  implicit lazy val codec: JsonValueCodec[Schema] = {
     implicit val schemaLikeCodec: JsonValueCodec[SchemaLike] = new JsonValueCodec {
       override def decodeValue(in: JsonReader, default: SchemaLike): SchemaLike = ???
 

--- a/generator/src/eu/neverblink/linkml/generator/rdf/RdfGenerator.scala
+++ b/generator/src/eu/neverblink/linkml/generator/rdf/RdfGenerator.scala
@@ -1,5 +1,6 @@
 package eu.neverblink.linkml.generator.rdf
 
+import eu.neverblink.linkml.runtime.FastUtils.foreachFast
 import eu.neverblink.linkml.schemaview.SchemaView
 
 /** Base utility class for common operations of generators that output RDF.
@@ -11,7 +12,7 @@ abstract class RdfGenerator {
     */
   protected def blankNode(): BlankNode = {
     blankNodeCounter += 1
-    BlankNode(blankNodeCounter.toString)
+    new BlankNode(blankNodeCounter.toString)
   }
 
   /** Create an RDF list of the provided [[values]] and push it into the [[sink]].
@@ -23,20 +24,27 @@ abstract class RdfGenerator {
     * @return
     *   Head node of the list or `rdf:nil` if [[values]] was empty
     */
-  final def addList(sink: RdfSink, values: Seq[Node]): Resource = {
-    if values.isEmpty then return Rdf.nil
-    val start = blankNode()
-    sink.triple(start, Rdf.first, values.head)
-    var prev = start
-    values.tail.foreach { value =>
-      val cur = blankNode()
-      sink.triple(prev, Rdf.rest, cur)
-      sink.triple(cur, Rdf.first, value)
-      prev = cur
+  final def addList(sink: RdfSink, values: Seq[Node]): Resource =
+    if (values.isEmpty) Rdf.nil
+    else {
+      val start = blankNode()
+      var prev = start
+      values.foreach {
+        var i = 0
+        value =>
+          if (i == 0) {
+            sink.triple(start, Rdf.first, values.head)
+          } else {
+            val cur = blankNode()
+            sink.triple(prev, Rdf.rest, cur)
+            sink.triple(cur, Rdf.first, value)
+            prev = cur
+          }
+          i += 1
+      }
+      sink.triple(prev, Rdf.rest, Rdf.nil)
+      start
     }
-    sink.triple(prev, Rdf.rest, Rdf.nil)
-    start
-  }
 
   /** Create namespace declarations for the root schema in the implicit [[SchemaView]] and push it
     * into the [[sink]].
@@ -46,18 +54,25 @@ abstract class RdfGenerator {
     * @param additional
     *   Format-specific additional prefixes to emit
     * @param sv
-    *   Schemaview to create the namespaces for
+    *   SchemaView to create the namespaces for
     */
   final def addNamespaces(sink: RdfSink, additional: Array[(String, String)])(using
       sv: SchemaView,
   ): Unit = {
-    val toEmit = sv.root.emitPrefixes.toSet ++ sv.root.defaultPrefix
-    sv.root.prefixes.values.toArray
-      .collect {
-        case p if toEmit(p.prefixPrefix) =>
-          (p.prefixPrefix, p.prefixReference.original)
-      }
-      .appendedAll(additional)
-      .distinct.sorted.foreach(sink.namespace)
+    val root = sv.root
+    // use tree-map for sorting prefixes in an alphabetic order
+    val namespaces = new java.util.TreeMap[String, String]
+    // add placeholder value for the default prefix
+    root.defaultPrefix.foreachFast(namespaces.putIfAbsent(_, ""))
+    // add placeholder values for allowed prefixes
+    root.emitPrefixes.foreach(namespaces.putIfAbsent(_, ""))
+    // fill references only allowed to emit prefixes
+    root.prefixes.foreach { kv =>
+      namespaces.computeIfPresent(kv._1, (_, _) => kv._2.prefixReference.original)
+    }
+    // override format-specific prefixes
+    additional.foreach(kv => namespaces.put(kv._1, kv._2))
+    // emit all collected prefixes skipping place-holders
+    namespaces.forEach((k, v) => if (v.length > 0) sink.namespace(k, v))
   }
 }

--- a/generator/src/eu/neverblink/linkml/generator/rdf/RdfGenerator.scala
+++ b/generator/src/eu/neverblink/linkml/generator/rdf/RdfGenerator.scala
@@ -66,7 +66,7 @@ abstract class RdfGenerator {
     root.defaultPrefix.foreachFast(namespaces.putIfAbsent(_, ""))
     // add placeholder values for allowed prefixes
     root.emitPrefixes.foreach(namespaces.putIfAbsent(_, ""))
-    // fill references only allowed to emit prefixes
+    // fill in names for allowed prefixes only
     root.prefixes.foreach { kv =>
       namespaces.computeIfPresent(kv._1, (_, _) => kv._2.prefixReference.original)
     }

--- a/generator/src/eu/neverblink/linkml/generator/scala/ScalaGenerator.scala
+++ b/generator/src/eu/neverblink/linkml/generator/scala/ScalaGenerator.scala
@@ -49,7 +49,7 @@ final class ScalaGenerator(using sv: SchemaView) {
         (cls.slots.map(_.value) ++ cls.attributes.keys ++ cls.slotUsage.keys).map(slotName).toSet
       val prefixResolver = classView.definingPrefixResolver
       className.concat(".scala") -> (
-        if classView.uriStr == "https://w3id.org/linkml/Any" then
+        if classView.isAny then
           typeDef(
             pkg,
             Case.PascalCase(cls.name),

--- a/generator/src/eu/neverblink/linkml/generator/shacl/ShaclGenerator.scala
+++ b/generator/src/eu/neverblink/linkml/generator/shacl/ShaclGenerator.scala
@@ -105,20 +105,10 @@ class ShaclGenerator(using sv: SchemaView) extends RdfGenerator {
       options: ShaclGenerator.Options = ShaclGenerator.Options(),
   ): Unit = {
     import options.{onlyClassesFromRootSchema, open}
-    addNamespaces(
-      sink,
-      Array(
-        ("rdf", "http://www.w3.org/1999/02/22-rdf-syntax-ns#"),
-        ("sh", "http://www.w3.org/ns/shacl#"),
-        ("xsd", "http://www.w3.org/2001/XMLSchema#"),
-        ("rdfs", "http://www.w3.org/2000/01/rdf-schema#"),
-      ),
-    )
-
+    addNamespaces(sink, defaultPrefixes)
     val classes =
-      if onlyClassesFromRootSchema then sv.classes.filter(_._2.definingSchema == sv.root)
+      if (onlyClassesFromRootSchema) sv.classes.filter(_._2.definingSchema == sv.root)
       else sv.classes
-
     classes.values.foreach { c =>
       val classNameIri = new Iri(c.uriStr)
       sink.triple(classNameIri, Rdf.`type`, Shacl.NodeShape)
@@ -129,7 +119,7 @@ class ShaclGenerator(using sv: SchemaView) extends RdfGenerator {
       sink.triple(classNameIri, Shacl.closed, Literal(closed.toString, XmlSchema.boolean))
       val ignoredPropertiesListHead = addList(
         sink,
-        Seq(Rdf.`type`) ++ c.identifier.mapFast(id => new Iri(id.uriStr)),
+        c.identifier.foldFast(Seq(Rdf.`type`))(id => Seq(Rdf.`type`, new Iri(id.uriStr))),
       )
       sink.triple(classNameIri, Shacl.ignoredProperties, ignoredPropertiesListHead)
       c.derivedAttributes.values.foreach {
@@ -143,6 +133,13 @@ class ShaclGenerator(using sv: SchemaView) extends RdfGenerator {
       sink.triple(classNameIri, Shacl.targetClass, classNameIri)
     }
   }
+
+  private val defaultPrefixes = Array(
+    ("rdf", "http://www.w3.org/1999/02/22-rdf-syntax-ns#"),
+    ("sh", "http://www.w3.org/ns/shacl#"),
+    ("xsd", "http://www.w3.org/2001/XMLSchema#"),
+    ("rdfs", "http://www.w3.org/2000/01/rdf-schema#"),
+  )
 }
 
 object ShaclGenerator {

--- a/generator/src/eu/neverblink/linkml/generator/shacl/ShaclGenerator.scala
+++ b/generator/src/eu/neverblink/linkml/generator/shacl/ShaclGenerator.scala
@@ -26,7 +26,7 @@ class ShaclGenerator(using sv: SchemaView) extends RdfGenerator {
     // TODO LNK-129 HACK: Skip the main range if any boolean slot is defined.
     if slotExpression.anyOf.isEmpty then
       slotExpression.range.getOrElseFast(sv.getDefaultRange(slotView.definingSchema))
-        .asInstanceOf[Reference[ElementView[?, ?]]].resolve.foreach {
+        .asInstanceOf[Reference[ElementView[?, ?]]].resolve.foreachFast {
           case typeView: TypeView =>
             val isIri = typeView.isIri || slotExpression.implicitPrefix.isDefined
             if !isIri then
@@ -35,28 +35,27 @@ class ShaclGenerator(using sv: SchemaView) extends RdfGenerator {
             else sink.triple(subject, Shacl.nodeKind, Shacl.IRI)
           case classView: ClassView =>
             val cdUri = classView.uriStr
-            val isLinkmlAny = cdUri == "https://w3id.org/linkml/Any"
-            if (!isLinkmlAny) {
+            if (!"https://w3id.org/linkml/Any".equals(cdUri)) {
               sink.triple(subject, Shacl.`class`, new Iri(cdUri))
               sink.triple(subject, Shacl.nodeKind, Shacl.BlankNodeOrIRI)
             }
           case enumView: EnumView =>
             val permissibleValues =
-              enumView.derivedValues.map(value => {
+              enumView.derivedValues.map { value =>
                 new Iri(value.meaning.uri(using enumView.definingPrefixResolver))
-              })
+              }
             val rdfListHead = addList(sink, permissibleValues)
             sink.triple(subject, Shacl.in, rdfListHead)
           case _ => throw RuntimeException(s"Couldn't map range ${slotExpression.range}")
         }
     // TODO LNK-129: Implement the rest of the boolean slots
     val ors = slotExpression.anyOf.map(curSlotExpression => {
-      val curNode = blankNode()
-      processSlotExpr(sink, slotView, curSlotExpression, curNode)
-      curNode
+      val currentNode = blankNode()
+      processSlotExpr(sink, slotView, curSlotExpression, currentNode)
+      currentNode
     })
     val orListHeadMaybe = addList(sink, ors)
-    if orListHeadMaybe != Rdf.nil then sink.triple(subject, Shacl.or, orListHeadMaybe)
+    if (orListHeadMaybe ne Rdf.nil) sink.triple(subject, Shacl.or, orListHeadMaybe)
   }
 
   /** Generate sh:property triples for a given slot. Produces triples of form
@@ -79,7 +78,7 @@ class ShaclGenerator(using sv: SchemaView) extends RdfGenerator {
     val property = blankNode()
     sink.triple(propertyDomain, Shacl.property, property)
     slot.description.foreachFast { d =>
-      sink.triple(property, Shacl.description, Literal(d, XmlSchema.string))
+      sink.triple(property, Shacl.description, new Literal(d, XmlSchema.string))
     }
     // TODO LNK-129: N-arity has to be done on the top-level-only,
     //  as SHACL boolean operators attached to a PropertyShape have to be NodeShapes
@@ -90,7 +89,7 @@ class ShaclGenerator(using sv: SchemaView) extends RdfGenerator {
     if (slot.required) sink.triple(property, Shacl.minCount, Literal.one)
     sink.triple(property, Shacl.path, new Iri(s.uriStr))
     processSlotExpr(sink, s, slot, property)
-    sink.triple(property, Shacl.order, Literal(order.toString, XmlSchema.integer))
+    sink.triple(property, Shacl.order, new Literal(order.toString, XmlSchema.integer))
   }
 
   /** Generates SHACL shapes and pushes the namespaces and triples into the provided [[RdfSink]].
@@ -107,16 +106,19 @@ class ShaclGenerator(using sv: SchemaView) extends RdfGenerator {
     import options.{onlyClassesFromRootSchema, open}
     addNamespaces(sink, defaultPrefixes)
     val classes =
-      if (onlyClassesFromRootSchema) sv.classes.filter(_._2.definingSchema == sv.root)
+      if (onlyClassesFromRootSchema) sv.classes.filter {
+        val root = sv.root
+        kv => kv._2.definingSchema eq root
+      }
       else sv.classes
     classes.values.foreach { c =>
       val classNameIri = new Iri(c.uriStr)
       sink.triple(classNameIri, Rdf.`type`, Shacl.NodeShape)
       c.cls.description.foreachFast { d =>
-        sink.triple(classNameIri, Rdfs.comment, Literal(d, XmlSchema.string))
+        sink.triple(classNameIri, Rdfs.comment, new Literal(d, XmlSchema.string))
       }
       val closed = !(open || c.cls.`abstract` || c.cls.mixin)
-      sink.triple(classNameIri, Shacl.closed, Literal(closed.toString, XmlSchema.boolean))
+      sink.triple(classNameIri, Shacl.closed, new Literal(closed.toString, XmlSchema.boolean))
       val ignoredPropertiesListHead = addList(
         sink,
         c.identifier.foldFast(Seq(Rdf.`type`))(id => Seq(Rdf.`type`, new Iri(id.uriStr))),
@@ -124,9 +126,9 @@ class ShaclGenerator(using sv: SchemaView) extends RdfGenerator {
       sink.triple(classNameIri, Shacl.ignoredProperties, ignoredPropertiesListHead)
       c.derivedAttributes.values.foreach {
         var order = 0
-        x =>
-          if (!x.inner.identifier) {
-            processSlot(sink, x, order, classNameIri)
+        sv =>
+          if (!sv.slot.identifier) {
+            processSlot(sink, sv, order, classNameIri)
             order += 1
           }
       }

--- a/generator/src/eu/neverblink/linkml/generator/shacl/ShaclGenerator.scala
+++ b/generator/src/eu/neverblink/linkml/generator/shacl/ShaclGenerator.scala
@@ -34,9 +34,8 @@ class ShaclGenerator(using sv: SchemaView) extends RdfGenerator {
               sink.triple(subject, Shacl.nodeKind, Shacl.Literal)
             else sink.triple(subject, Shacl.nodeKind, Shacl.IRI)
           case classView: ClassView =>
-            val cdUri = classView.uriStr
-            if (!"https://w3id.org/linkml/Any".equals(cdUri)) {
-              sink.triple(subject, Shacl.`class`, new Iri(cdUri))
+            if (!classView.isAny) {
+              sink.triple(subject, Shacl.`class`, new Iri(classView.uriStr))
               sink.triple(subject, Shacl.nodeKind, Shacl.BlankNodeOrIRI)
             }
           case enumView: EnumView =>

--- a/generator/src/eu/neverblink/linkml/generator/tableschema/TableSchemaGenerator.scala
+++ b/generator/src/eu/neverblink/linkml/generator/tableschema/TableSchemaGenerator.scala
@@ -56,7 +56,7 @@ class TableSchemaGenerator(using sv: SchemaView) {
         )
         slotView.derivedRange.resolve.get match {
           case cls: ClassView =>
-            if cls.uriStr == "https://w3id.org/linkml/Any" then
+            if cls.isAny then
               base.copy(
                 `type` = types.any,
                 format = "any",

--- a/generator/test/src-jvm/eu/neverblink/linkml/generator/rdfs/RdfsGeneratorSpec.scala
+++ b/generator/test/src-jvm/eu/neverblink/linkml/generator/rdfs/RdfsGeneratorSpec.scala
@@ -264,8 +264,10 @@ class RdfsGeneratorSpec extends AnyWordSpec, Matchers {
         SchemaView.loadSchemaViewFromUri("https://w3id.org/linkml/annotations"),
       )
       val turtle =
-        RdfUtils.toTurtle(RdfsGenerator(using sv)
-            .generate(_, RdfsGenerator.Options(onlyClassesFromRootSchema = true)))
+        RdfUtils.toTurtle(
+          RdfsGenerator(using sv)
+            .generate(_, RdfsGenerator.Options(onlyClassesFromRootSchema = true)),
+        )
       turtle should include("linkml:Annotatable a rdfs:Class")
       turtle should include("linkml:Annotation a rdfs:Class")
       turtle should not include "linkml:Any a rdfs:Class"

--- a/generator/test/src-jvm/eu/neverblink/linkml/generator/scala/ScalaGeneratorCompileSpec.scala
+++ b/generator/test/src-jvm/eu/neverblink/linkml/generator/scala/ScalaGeneratorCompileSpec.scala
@@ -41,12 +41,13 @@ class ScalaGeneratorCompileSpec extends AnyWordSpec, Matchers, ModelCatalogueSpe
       s"generate compilable code for model '${entry.name}'" in {
         processSkip(entry.name, "")
         val dir = os.temp.dir(prefix = "linkml-scala-src")
-        val sources = ScalaGenerator(using entry.model).generate(ScalaGenerator.Options("generated")).map {
-          (name, content) =>
-            val file = dir / name
-            os.write(file, content)
-            file
-        }.toSeq
+        val sources =
+          ScalaGenerator(using entry.model).generate(ScalaGenerator.Options("generated")).map {
+            (name, content) =>
+              val file = dir / name
+              os.write(file, content)
+              file
+          }.toSeq
         sources should not be empty
         val failure = compileScala(sources)
         withClue(s"compiler output:\n${failure.getOrElse("")}\n")(failure shouldBe None)

--- a/generator/test/src-jvm/eu/neverblink/linkml/generator/shacl/ShaclGeneratorSpec.scala
+++ b/generator/test/src-jvm/eu/neverblink/linkml/generator/shacl/ShaclGeneratorSpec.scala
@@ -102,7 +102,9 @@ class ShaclGeneratorSpec extends AnyWordSpec, Matchers {
            |""".stripMargin
       val schemaView = loadWithImports(input)
       val turtle =
-        RdfUtils.toTurtle(ShaclGenerator(using schemaView).generate(_, ShaclGenerator.Options(open = true)))
+        RdfUtils.toTurtle(
+          ShaclGenerator(using schemaView).generate(_, ShaclGenerator.Options(open = true)),
+        )
       val expected =
         """@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
           |@prefix sh: <http://www.w3.org/ns/shacl#> .
@@ -487,8 +489,10 @@ class ShaclGeneratorSpec extends AnyWordSpec, Matchers {
         SchemaView.loadSchemaViewFromUri("https://w3id.org/linkml/annotations"),
       )
       val turtle =
-        RdfUtils.toTurtle(ShaclGenerator(using sv)
-            .generate(_, ShaclGenerator.Options(onlyClassesFromRootSchema = true)))
+        RdfUtils.toTurtle(
+          ShaclGenerator(using sv)
+            .generate(_, ShaclGenerator.Options(onlyClassesFromRootSchema = true)),
+        )
       turtle should include("linkml:Annotatable a sh:NodeShape")
       turtle should include("linkml:Annotation a sh:NodeShape")
       turtle should not include "linkml:Any a sh:NodeShape"

--- a/generator/test/src/eu/neverblink/linkml/generator/erdiagram/ErDiagramGeneratorSpec.scala
+++ b/generator/test/src/eu/neverblink/linkml/generator/erdiagram/ErDiagramGeneratorSpec.scala
@@ -56,7 +56,8 @@ class ErDiagramGeneratorSpec extends AnyWordSpec, Matchers {
     "omit the optional marker when asked, for renderers older than Mermaid 11.16" in {
       given SchemaView = ModelCatalogue.cardinality.model
 
-      val result = ErDiagramGenerator().serialize(ErDiagramGenerator.Options(optionalMarker = false))
+      val result =
+        ErDiagramGenerator().serialize(ErDiagramGenerator.Options(optionalMarker = false))
       Seq(
         "string one",
         "string atMostOne",
@@ -216,7 +217,8 @@ class ErDiagramGeneratorSpec extends AnyWordSpec, Matchers {
     "prune in tree_root mode if requested" in {
       given SchemaView = ModelCatalogue.pruning.model
 
-      val result = ErDiagramGenerator().serialize(ErDiagramGenerator.Options(PruningMode.treeRoot(None)))
+      val result =
+        ErDiagramGenerator().serialize(ErDiagramGenerator.Options(PruningMode.treeRoot(None)))
       result should include("SomeClass {")
       result should not include "NotTreeRootClass"
     }

--- a/generator/test/src/eu/neverblink/linkml/generator/graphql/GraphQlGeneratorSpec.scala
+++ b/generator/test/src/eu/neverblink/linkml/generator/graphql/GraphQlGeneratorSpec.scala
@@ -122,8 +122,6 @@ class GraphQlGeneratorSpec extends AnyWordSpec, Matchers {
     "generate enums" in {
       given SchemaView = ModelCatalogue.`enum`.model
 
-      val id = ModelCatalogue.`enum`.model.root.id.original
-
       val result = GraphQlGenerator().serialize()
       Seq(
         "some_slot: SomeEnum",
@@ -202,7 +200,8 @@ class GraphQlGeneratorSpec extends AnyWordSpec, Matchers {
     "prune in tree_root mode if requested" in {
       given SchemaView = ModelCatalogue.pruning.model
 
-      val result = GraphQlGenerator().serialize(GraphQlGenerator.Options(PruningMode.treeRoot(None)))
+      val result =
+        GraphQlGenerator().serialize(GraphQlGenerator.Options(PruningMode.treeRoot(None)))
       Seq(
         "type SomeClass",
         "interface SomeOtherClass",
@@ -223,7 +222,9 @@ class GraphQlGeneratorSpec extends AnyWordSpec, Matchers {
       given SchemaView = ModelCatalogue.pruning.model
 
       val result =
-        GraphQlGenerator().serialize(GraphQlGenerator.Options(PruningMode.treeRoot(Some("NotTreeRootClass"))))
+        GraphQlGenerator().serialize(
+          GraphQlGenerator.Options(PruningMode.treeRoot(Some("NotTreeRootClass"))),
+        )
       Seq(
         "type NotTreeRootClass",
       ).foreach { snippet =>

--- a/generator/test/src/eu/neverblink/linkml/generator/jsonschema/JsonSchemaGeneratorSpec.scala
+++ b/generator/test/src/eu/neverblink/linkml/generator/jsonschema/JsonSchemaGeneratorSpec.scala
@@ -705,7 +705,9 @@ class JsonSchemaGeneratorSpec extends AnyWordSpec, Matchers {
           ),
         )
 
-        JsonSchemaGenerator().generate(JsonSchemaGenerator.Options(treeRootInlineType = Some("plain")))
+        JsonSchemaGenerator().generate(
+          JsonSchemaGenerator.Options(treeRootInlineType = Some("plain")),
+        )
           .$ref shouldBe Some("#/$defs/C1")
       }
 
@@ -716,7 +718,9 @@ class JsonSchemaGeneratorSpec extends AnyWordSpec, Matchers {
           ),
         )
 
-        val schema = JsonSchemaGenerator().generate(JsonSchemaGenerator.Options(treeRootInlineType = Some("optional")))
+        val schema = JsonSchemaGenerator().generate(
+          JsonSchemaGenerator.Options(treeRootInlineType = Some("optional")),
+        )
 
         schema.oneOf.map(
           _.asInstanceOf[Schema].$ref,
@@ -734,7 +738,9 @@ class JsonSchemaGeneratorSpec extends AnyWordSpec, Matchers {
           ),
         )
 
-        val schema = JsonSchemaGenerator().generate(JsonSchemaGenerator.Options(treeRootInlineType = Some("list")))
+        val schema = JsonSchemaGenerator().generate(
+          JsonSchemaGenerator.Options(treeRootInlineType = Some("list")),
+        )
 
         schema.`type` shouldBe Some(List(SchemaType.Array))
 
@@ -751,7 +757,9 @@ class JsonSchemaGeneratorSpec extends AnyWordSpec, Matchers {
         )
 
         val schema =
-          JsonSchemaGenerator().generate(JsonSchemaGenerator.Options(treeRootInlineType = Some("compact_dict")))
+          JsonSchemaGenerator().generate(
+            JsonSchemaGenerator.Options(treeRootInlineType = Some("compact_dict")),
+          )
 
         schema.additionalProperties.get.asInstanceOf[Schema]
           .$ref shouldBe Some("#/$defs/C1__identifier_optional")
@@ -767,7 +775,9 @@ class JsonSchemaGeneratorSpec extends AnyWordSpec, Matchers {
         )
 
         val schema =
-          JsonSchemaGenerator().generate(JsonSchemaGenerator.Options(treeRootInlineType = Some("simple_dict")))
+          JsonSchemaGenerator().generate(
+            JsonSchemaGenerator.Options(treeRootInlineType = Some("simple_dict")),
+          )
 
         schema.additionalProperties.get.asInstanceOf[Schema]
           .$ref shouldBe Some("#/$defs/C1__simple_dict_value")

--- a/generator/test/src/eu/neverblink/linkml/generator/linkml/LinkMlGeneratorSpec.scala
+++ b/generator/test/src/eu/neverblink/linkml/generator/linkml/LinkMlGeneratorSpec.scala
@@ -13,7 +13,9 @@ class LinkMlGeneratorSpec extends AnyWordSpec, Matchers {
     "inline imports into the schema" in {
       val sv = ModelCatalogue.pruning.model
       val schema =
-        LinkMlGenerator(using sv).generate(LinkMlGenerator.Options(pruningMode = skip, skipClassDerivation = true))
+        LinkMlGenerator(using sv).generate(
+          LinkMlGenerator.Options(pruningMode = skip, skipClassDerivation = true),
+        )
       schema.classes.keys should contain theSameElementsAs Seq(
         "NotTreeRootClass",
         "SomeClass",
@@ -70,7 +72,9 @@ class LinkMlGeneratorSpec extends AnyWordSpec, Matchers {
     "prune unused elements from the schema (root schema)" in {
       val sv = ModelCatalogue.pruning.model
       val schema =
-        LinkMlGenerator(using sv).generate(LinkMlGenerator.Options(pruningMode = schemaRoot, skipClassDerivation = true))
+        LinkMlGenerator(using sv).generate(
+          LinkMlGenerator.Options(pruningMode = schemaRoot, skipClassDerivation = true),
+        )
       schema.classes.keys should contain theSameElementsAs Seq(
         "NotTreeRootClass",
         "SomeClass",
@@ -109,7 +113,8 @@ class LinkMlGeneratorSpec extends AnyWordSpec, Matchers {
 
     "derive classes and prune the schema (tree_root)" in {
       val sv = ModelCatalogue.pruning.model
-      val schema = LinkMlGenerator(using sv).generate(LinkMlGenerator.Options(pruningMode = treeRoot(None)))
+      val schema =
+        LinkMlGenerator(using sv).generate(LinkMlGenerator.Options(pruningMode = treeRoot(None)))
       schema.classes.keys should contain theSameElementsAs Seq(
         "SomeClass",
       )
@@ -128,7 +133,9 @@ class LinkMlGeneratorSpec extends AnyWordSpec, Matchers {
     "derive classes and prune the schema (tree_root override)" in {
       val sv = ModelCatalogue.pruning.model
       val schema =
-        LinkMlGenerator(using sv).generate(LinkMlGenerator.Options(pruningMode = treeRoot(Some("NotTreeRootClass"))))
+        LinkMlGenerator(using sv).generate(
+          LinkMlGenerator.Options(pruningMode = treeRoot(Some("NotTreeRootClass"))),
+        )
       schema.classes.keys should contain theSameElementsAs Seq(
         "NotTreeRootClass",
       )
@@ -207,7 +214,9 @@ class LinkMlGeneratorSpec extends AnyWordSpec, Matchers {
     "prune using tree_root override if no schema tree root" in {
       val sv = ModelCatalogue.treeRootless.model
       val schema =
-        LinkMlGenerator(using sv).generate(LinkMlGenerator.Options(pruningMode = treeRoot(Some("SomeClass"))))
+        LinkMlGenerator(using sv).generate(
+          LinkMlGenerator.Options(pruningMode = treeRoot(Some("SomeClass"))),
+        )
       schema.classes.keys should contain theSameElementsAs Seq(
         "SomeClass",
       )
@@ -334,7 +343,9 @@ class LinkMlGeneratorSpec extends AnyWordSpec, Matchers {
 
       // The same nodes feed the YAML output, which must quote them for the same reason.
       val yaml =
-        LinkMlGenerator(using sv).serialize(LinkMlGenerator.Options(outputFormat = LinkMlGenerator.OutputFormat.yaml))
+        LinkMlGenerator(using sv).serialize(
+          LinkMlGenerator.Options(outputFormat = LinkMlGenerator.OutputFormat.yaml),
+        )
       yaml should include("""title: "123"""")
       yaml should include("""description: "true"""")
       yaml should include("""license: "null"""")
@@ -352,7 +363,9 @@ class LinkMlGeneratorSpec extends AnyWordSpec, Matchers {
           SchemaView.single(LinkMlGenerator(using entry.model).generate())
             .lint() shouldBe empty
           SchemaView.single(
-            LinkMlGenerator(using entry.model).generate(LinkMlGenerator.Options(skipClassDerivation = true)),
+            LinkMlGenerator(using entry.model).generate(
+              LinkMlGenerator.Options(skipClassDerivation = true),
+            ),
           ).lint() shouldBe empty
         }
     }

--- a/generator/test/src/eu/neverblink/linkml/generator/scala/ScalaGeneratorSpec.scala
+++ b/generator/test/src/eu/neverblink/linkml/generator/scala/ScalaGeneratorSpec.scala
@@ -23,7 +23,8 @@ class ScalaGeneratorSpec extends AnyWordSpec, Matchers {
 
     "generate abstract interfaces and implementations for plain classes" in {
       given SchemaView = ModelCatalogue.basic.model
-      val code = ScalaGenerator().generate(ScalaGenerator.Options(testPkg)).toMap.apply("SomeClass.scala")
+      val code =
+        ScalaGenerator().generate(ScalaGenerator.Options(testPkg)).toMap.apply("SomeClass.scala")
       Seq(
         s"package $testPkg",
         "case class SomeClassImpl",
@@ -47,7 +48,8 @@ class ScalaGeneratorSpec extends AnyWordSpec, Matchers {
     "not generate implementations for abstract classes" in {
       given SchemaView = ModelCatalogue.`abstract`.model
 
-      val code = ScalaGenerator().generate(ScalaGenerator.Options(testPkg)).toMap.apply("SomeClass.scala")
+      val code =
+        ScalaGenerator().generate(ScalaGenerator.Options(testPkg)).toMap.apply("SomeClass.scala")
       Seq(
         "abstract class SomeClass",
         "def someOtherSlot: Int",
@@ -69,7 +71,9 @@ class ScalaGeneratorSpec extends AnyWordSpec, Matchers {
     "generate trait interfaces for mixin classes" in {
       given SchemaView = ModelCatalogue.mixin.model
 
-      val code = ScalaGenerator().generate(ScalaGenerator.Options(testPkg)).toMap.apply("SomeOtherClass.scala")
+      val code = ScalaGenerator().generate(ScalaGenerator.Options(testPkg)).toMap.apply(
+        "SomeOtherClass.scala",
+      )
       Seq(
         "trait SomeOtherClass",
         "def someOtherSlot: Int",
@@ -90,7 +94,8 @@ class ScalaGeneratorSpec extends AnyWordSpec, Matchers {
     "generate abstract interfaces with inheritance" in {
       given SchemaView = ModelCatalogue.inheritance.model
 
-      val code = ScalaGenerator().generate(ScalaGenerator.Options(testPkg)).toMap.apply("ChildClass.scala")
+      val code =
+        ScalaGenerator().generate(ScalaGenerator.Options(testPkg)).toMap.apply("ChildClass.scala")
       Seq(
         "abstract class ChildClass extends BaseClass",
       ).foreach { snippet =>
@@ -101,7 +106,8 @@ class ScalaGeneratorSpec extends AnyWordSpec, Matchers {
     "reference other classes" in {
       given SchemaView = ModelCatalogue.reference.model
 
-      val code = ScalaGenerator().generate(ScalaGenerator.Options(testPkg)).toMap.apply("SomeClass.scala")
+      val code =
+        ScalaGenerator().generate(ScalaGenerator.Options(testPkg)).toMap.apply("SomeClass.scala")
       Seq(
         "Option[Reference[SomeOtherClass]]",
       ).foreach { snippet =>
@@ -112,7 +118,8 @@ class ScalaGeneratorSpec extends AnyWordSpec, Matchers {
     "reference multivalued other classes as a list of references" in {
       given SchemaView = ModelCatalogue.multivaluedReference.model
 
-      val code = ScalaGenerator().generate(ScalaGenerator.Options(testPkg)).toMap.apply("SomeClass.scala")
+      val code =
+        ScalaGenerator().generate(ScalaGenerator.Options(testPkg)).toMap.apply("SomeClass.scala")
       Seq(
         "Seq[Reference[SomeOtherClass]]",
       ).foreach { snippet =>
@@ -123,7 +130,8 @@ class ScalaGeneratorSpec extends AnyWordSpec, Matchers {
     "implicitly inline identifier-less classes" in {
       given SchemaView = ModelCatalogue.inlines.implicitInline.model
 
-      val code = ScalaGenerator().generate(ScalaGenerator.Options(testPkg)).toMap.apply("SomeClass.scala")
+      val code =
+        ScalaGenerator().generate(ScalaGenerator.Options(testPkg)).toMap.apply("SomeClass.scala")
       Seq(
         "Option[SomeOtherClassImpl]",
       ).foreach { snippet =>
@@ -134,7 +142,8 @@ class ScalaGeneratorSpec extends AnyWordSpec, Matchers {
     "implicitly inline multivalued other classes (implicitly as compact dict)" in {
       given SchemaView = ModelCatalogue.inlines.implicitInlineAsCompactDict.model
 
-      val code = ScalaGenerator().generate(ScalaGenerator.Options(testPkg)).toMap.apply("SomeClass.scala")
+      val code =
+        ScalaGenerator().generate(ScalaGenerator.Options(testPkg)).toMap.apply("SomeClass.scala")
       Seq(
         "@compactDict",
         "Map[String, SomeOtherClassImpl]",
@@ -146,7 +155,8 @@ class ScalaGeneratorSpec extends AnyWordSpec, Matchers {
     "implicitly inline multivalued other classes (implicitly as list)" in {
       given SchemaView = ModelCatalogue.inlines.implicitInlineAsList.model
 
-      val code = ScalaGenerator().generate(ScalaGenerator.Options(testPkg)).toMap.apply("SomeClass.scala")
+      val code =
+        ScalaGenerator().generate(ScalaGenerator.Options(testPkg)).toMap.apply("SomeClass.scala")
       Seq(
         "Seq[SomeOtherClassImpl]",
       ).foreach { snippet =>
@@ -157,7 +167,8 @@ class ScalaGeneratorSpec extends AnyWordSpec, Matchers {
     "explicitly inline multivalued other classes (implicitly as compact dict)" in {
       given SchemaView = ModelCatalogue.inlines.explicitInlineImplicitlyAsCompactDict.model
 
-      val code = ScalaGenerator().generate(ScalaGenerator.Options(testPkg)).toMap.apply("SomeClass.scala")
+      val code =
+        ScalaGenerator().generate(ScalaGenerator.Options(testPkg)).toMap.apply("SomeClass.scala")
       Seq(
         "@compactDict",
         "Map[String, SomeOtherClassImpl]",
@@ -169,7 +180,8 @@ class ScalaGeneratorSpec extends AnyWordSpec, Matchers {
     "explicitly inline multivalued other classes (implicitly as simple dict)" in {
       given SchemaView = ModelCatalogue.inlines.explicitInlineImplicitlyAsSimpleDict.model
 
-      val code = ScalaGenerator().generate(ScalaGenerator.Options(testPkg)).toMap.apply("SomeClass.scala")
+      val code =
+        ScalaGenerator().generate(ScalaGenerator.Options(testPkg)).toMap.apply("SomeClass.scala")
       Seq(
         "@simpleDict",
         "Map[String, SomeOtherClassImpl]",
@@ -181,7 +193,8 @@ class ScalaGeneratorSpec extends AnyWordSpec, Matchers {
     "explicitly inline multivalued other classes (implicitly as list)" in {
       given SchemaView = ModelCatalogue.inlines.explicitInlineImplicitlyAsList.model
 
-      val code = ScalaGenerator().generate(ScalaGenerator.Options(testPkg)).toMap.apply("SomeClass.scala")
+      val code =
+        ScalaGenerator().generate(ScalaGenerator.Options(testPkg)).toMap.apply("SomeClass.scala")
       Seq(
         "Seq[SomeOtherClassImpl]",
       ).foreach { snippet =>
@@ -192,7 +205,8 @@ class ScalaGeneratorSpec extends AnyWordSpec, Matchers {
     "explicitly inline multivalued other classes (explicitly as list)" in {
       given SchemaView = ModelCatalogue.inlines.explicitInlineList.model
 
-      val code = ScalaGenerator().generate(ScalaGenerator.Options(testPkg)).toMap.apply("SomeClass.scala")
+      val code =
+        ScalaGenerator().generate(ScalaGenerator.Options(testPkg)).toMap.apply("SomeClass.scala")
       Seq(
         "Seq[SomeOtherClassImpl]",
       ).foreach { snippet =>
@@ -205,7 +219,8 @@ class ScalaGeneratorSpec extends AnyWordSpec, Matchers {
       // one has to be typed as the interface, or the generated code does not compile.
       given SchemaView = ModelCatalogue.inlines.inlineAbstract.model
 
-      val code = ScalaGenerator().generate(ScalaGenerator.Options(testPkg)).toMap.apply("Container.scala")
+      val code =
+        ScalaGenerator().generate(ScalaGenerator.Options(testPkg)).toMap.apply("Container.scala")
       Seq(
         "toAbstract: Option[AbstractRange] = None",
         "toMixin: Option[MixinRange] = None",
@@ -645,7 +660,8 @@ class ScalaGeneratorSpec extends AnyWordSpec, Matchers {
 
       given SchemaView = decode(input)
 
-      val code = ScalaGenerator().generate(ScalaGenerator.Options(testPkg)).toMap.apply("SomeClass.scala")
+      val code =
+        ScalaGenerator().generate(ScalaGenerator.Options(testPkg)).toMap.apply("SomeClass.scala")
       Seq(
         ": String",
         ": Seq[Int]",
@@ -671,7 +687,8 @@ class ScalaGeneratorSpec extends AnyWordSpec, Matchers {
 
       given SchemaView = decode(input)
 
-      val code = ScalaGenerator().generate(ScalaGenerator.Options(testPkg)).toMap.apply("SomeEnum.scala")
+      val code =
+        ScalaGenerator().generate(ScalaGenerator.Options(testPkg)).toMap.apply("SomeEnum.scala")
       code shouldBe
         """package eu.neverblink.linkml.generator.scala.test
           |
@@ -723,7 +740,8 @@ class ScalaGeneratorSpec extends AnyWordSpec, Matchers {
 
       given SchemaView = decode(input)
 
-      val code = ScalaGenerator().generate(ScalaGenerator.Options(testPkg)).toMap.apply("SomeEnum.scala")
+      val code =
+        ScalaGenerator().generate(ScalaGenerator.Options(testPkg)).toMap.apply("SomeEnum.scala")
       Seq(
         "sealed trait SomeEnum",
       ).foreach { snippet =>
@@ -746,7 +764,8 @@ class ScalaGeneratorSpec extends AnyWordSpec, Matchers {
 
       given SchemaView = decode(input)
 
-      val code = ScalaGenerator().generate(ScalaGenerator.Options(testPkg)).toMap.apply("SomeEnum.scala")
+      val code =
+        ScalaGenerator().generate(ScalaGenerator.Options(testPkg)).toMap.apply("SomeEnum.scala")
       Seq(
         "trait SomeEnum",
       ).foreach { snippet =>
@@ -755,7 +774,9 @@ class ScalaGeneratorSpec extends AnyWordSpec, Matchers {
     }
 
     "generate an infer() method from equals_expression" in {
-      val code = ScalaGenerator(using ModelCatalogue.equalsExpression.model).generate(ScalaGenerator.Options(testPkg)).toMap.apply("SomeClass.scala")
+      val code = ScalaGenerator(using ModelCatalogue.equalsExpression.model).generate(
+        ScalaGenerator.Options(testPkg),
+      ).toMap.apply("SomeClass.scala")
       Seq(
         // Declared on the interface, narrowed to the implementation type in the impl
         "def infer(): SomeClass\n",
@@ -791,7 +812,9 @@ class ScalaGeneratorSpec extends AnyWordSpec, Matchers {
     }
 
     "generate an infer() method reaching into inlined classes" in {
-      val code = ScalaGenerator(using ModelCatalogue.equalsExpression.model).generate(ScalaGenerator.Options(testPkg)).toMap.apply("SomeClass.scala")
+      val code = ScalaGenerator(using ModelCatalogue.equalsExpression.model).generate(
+        ScalaGenerator.Options(testPkg),
+      ).toMap.apply("SomeClass.scala")
       Seq(
         // Every optional link along the path is unwrapped, the outermost one last
         """fromOptionalNested = inferOptional("from_optional_nested", fromOptionalNested, """ +
@@ -807,7 +830,9 @@ class ScalaGeneratorSpec extends AnyWordSpec, Matchers {
     }
 
     "generate an infer() method that stringifies non-string ranges" in {
-      val code = ScalaGenerator(using ModelCatalogue.equalsExpression.model).generate(ScalaGenerator.Options(testPkg)).toMap.apply("SomeClass.scala")
+      val code = ScalaGenerator(using ModelCatalogue.equalsExpression.model).generate(
+        ScalaGenerator.Options(testPkg),
+      ).toMap.apply("SomeClass.scala")
       Seq(
         """fromNumbers = inferOptional("from_numbers", fromNumbers, """ +
           """stringify(inferenceInput("count", count)) + " items, ratio " + """ +
@@ -857,7 +882,9 @@ class ScalaGeneratorSpec extends AnyWordSpec, Matchers {
     }
 
     "substitute a static enum, which stringifies to its LinkML text" in {
-      val code = ScalaGenerator(using ModelCatalogue.equalsExpression.model).generate(ScalaGenerator.Options(testPkg)).toMap
+      val code = ScalaGenerator(using ModelCatalogue.equalsExpression.model).generate(
+        ScalaGenerator.Options(testPkg),
+      ).toMap
       // The instance is derived from the sealed hierarchy, reading the `@named` text
       code("StatusEnum.scala") should include("sealed abstract class StatusEnum derives Stringify")
       code("StatusEnum.scala") should include("""@named("in progress") case object InProgress""")
@@ -903,14 +930,18 @@ class ScalaGeneratorSpec extends AnyWordSpec, Matchers {
     }
 
     "generate an infer() method that does nothing when there are no expressions" in {
-      val code = ScalaGenerator(using ModelCatalogue.basic.model).generate(ScalaGenerator.Options(testPkg)).toMap.apply("SomeClass.scala")
+      val code = ScalaGenerator(using ModelCatalogue.basic.model).generate(
+        ScalaGenerator.Options(testPkg),
+      ).toMap.apply("SomeClass.scala")
       code should include("def infer(): SomeClassImpl")
       code should include("def infer(): SomeClass\n")
       code should not include "inferOptional"
     }
 
     "generate ifabsent default values for enum-ranged slots" in {
-      val files = ScalaGenerator(using ModelCatalogue.ifabsent.enums.model).generate(ScalaGenerator.Options(testPkg)).toMap
+      val files = ScalaGenerator(using ModelCatalogue.ifabsent.enums.model).generate(
+        ScalaGenerator.Options(testPkg),
+      ).toMap
       val code = files("SomeClass.scala")
       Seq(
         "someSlot: Option[SomeEnum] = Some(SomeEnum.SomeOption)",
@@ -934,7 +965,9 @@ class ScalaGeneratorSpec extends AnyWordSpec, Matchers {
     }
 
     "mark ifabsent default values with @serializeDefault" in {
-      val files = ScalaGenerator(using ModelCatalogue.ifabsent.enums.model).generate(ScalaGenerator.Options(testPkg)).toMap
+      val files = ScalaGenerator(using ModelCatalogue.ifabsent.enums.model).generate(
+        ScalaGenerator.Options(testPkg),
+      ).toMap
       // Drop the indentation, so that the snippets below can be written without it.
       // Done without a regex, as Scala.js has no MULTILINE support below ES2018.
       val code = files("SomeClass.scala").linesIterator.map(_.stripLeading()).mkString("\n")
@@ -951,7 +984,9 @@ class ScalaGeneratorSpec extends AnyWordSpec, Matchers {
     }
 
     "generate an emit_prefixes object" in {
-      val files = ScalaGenerator(using ModelCatalogue.emitPrefixes.model).generate(ScalaGenerator.Options(testPkg)).toMap
+      val files = ScalaGenerator(using ModelCatalogue.emitPrefixes.model).generate(
+        ScalaGenerator.Options(testPkg),
+      ).toMap
       files.keys should contain theSameElementsAs Seq(
         "SomeClass.scala",
         "Prefixes.scala",
@@ -969,7 +1004,8 @@ class ScalaGeneratorSpec extends AnyWordSpec, Matchers {
     "generate Linkml Date and/or Time for dates" in {
       given SchemaView = ModelCatalogue.typed.model
 
-      val code = ScalaGenerator().generate(ScalaGenerator.Options(testPkg)).toMap.apply("Typed.scala")
+      val code =
+        ScalaGenerator().generate(ScalaGenerator.Options(testPkg)).toMap.apply("Typed.scala")
       code should include("dateSlot: LinkmlDate")
     }
 
@@ -1016,7 +1052,9 @@ class ScalaGeneratorSpec extends AnyWordSpec, Matchers {
     "generate all catalogue models without errors" when {
       for entry <- ModelCatalogue.all do
         s"model '${entry.model.root.name}'" in {
-          val files = ScalaGenerator(using entry.model).generate(ScalaGenerator.Options("eu.neverblink.linkml.scala.test"))
+          val files = ScalaGenerator(using entry.model).generate(
+            ScalaGenerator.Options("eu.neverblink.linkml.scala.test"),
+          )
           files should not be empty
           for (_, content) <- files do content should not be ""
         }

--- a/generator/test/src/eu/neverblink/linkml/generator/tableschema/TableSchemaGeneratorSpec.scala
+++ b/generator/test/src/eu/neverblink/linkml/generator/tableschema/TableSchemaGeneratorSpec.scala
@@ -32,7 +32,9 @@ class TableSchemaGeneratorSpec extends AnyWordSpec, Matchers {
 
   "TableSchemaGenerator" should {
     "generate basic fields" in {
-      val td = TableSchemaGenerator(using ModelCatalogue.basic.model).generate(TableSchemaGenerator.Options(None))
+      val td = TableSchemaGenerator(using ModelCatalogue.basic.model).generate(
+        TableSchemaGenerator.Options(None),
+      )
       td.fields should not be empty
       td.fields.map(_.name) should contain theSameElementsAs Seq(
         "some_slot",
@@ -49,14 +51,18 @@ class TableSchemaGeneratorSpec extends AnyWordSpec, Matchers {
     }
 
     "generate references" in {
-      val td = TableSchemaGenerator(using ModelCatalogue.reference.model).generate(TableSchemaGenerator.Options(None))
+      val td = TableSchemaGenerator(using ModelCatalogue.reference.model).generate(
+        TableSchemaGenerator.Options(None),
+      )
       val someSlot = td.fields.head
       someSlot.`type` shouldBe "string"
       someSlot.rdfType shouldBe Some(ModelCatalogue.reference.id + "SomeOtherClass")
     }
 
     "generate types" in {
-      val td = TableSchemaGenerator(using ModelCatalogue.typed.model).generate(TableSchemaGenerator.Options(None))
+      val td = TableSchemaGenerator(using ModelCatalogue.typed.model).generate(
+        TableSchemaGenerator.Options(None),
+      )
       val fieldMap = td.fields.map(fd => fd.name -> fd).toMap
 
       fieldMap("stringSlot").`type` shouldBe "string"
@@ -79,7 +85,9 @@ class TableSchemaGeneratorSpec extends AnyWordSpec, Matchers {
     }
 
     "generate uri format" in {
-      val td = TableSchemaGenerator(using ModelCatalogue.uri.model).generate(TableSchemaGenerator.Options(None))
+      val td = TableSchemaGenerator(using ModelCatalogue.uri.model).generate(
+        TableSchemaGenerator.Options(None),
+      )
       val fieldMap = td.fields.map(fd => fd.name -> fd).toMap
       fieldMap("some_slot").`type` shouldBe "string"
       fieldMap("some_slot").format shouldBe "uri"
@@ -92,7 +100,9 @@ class TableSchemaGeneratorSpec extends AnyWordSpec, Matchers {
 
     "generate inlines" in {
       val td =
-        TableSchemaGenerator(using ModelCatalogue.inlines.explicitInline.model).generate(TableSchemaGenerator.Options(None))
+        TableSchemaGenerator(using ModelCatalogue.inlines.explicitInline.model).generate(
+          TableSchemaGenerator.Options(None),
+        )
       val someSlot = td.fields.head
       someSlot.`type` shouldBe "object"
       someSlot.rdfType shouldBe Some(ModelCatalogue.inlines.explicitInline.id + "SomeOtherClass")
@@ -100,7 +110,9 @@ class TableSchemaGeneratorSpec extends AnyWordSpec, Matchers {
 
     "generate array inlines" in {
       val td =
-        TableSchemaGenerator(using ModelCatalogue.inlines.explicitInlineList.model).generate(TableSchemaGenerator.Options(None))
+        TableSchemaGenerator(using ModelCatalogue.inlines.explicitInlineList.model).generate(
+          TableSchemaGenerator.Options(None),
+        )
       val someSlot = td.fields.head
       someSlot.`type` shouldBe "array"
       someSlot.rdfType shouldBe Some(
@@ -109,19 +121,25 @@ class TableSchemaGeneratorSpec extends AnyWordSpec, Matchers {
     }
 
     "generate any" in {
-      val td = TableSchemaGenerator(using ModelCatalogue.anything.model).generate(TableSchemaGenerator.Options(None))
+      val td = TableSchemaGenerator(using ModelCatalogue.anything.model).generate(
+        TableSchemaGenerator.Options(None),
+      )
       val someSlot = td.fields.head
       someSlot.`type` shouldBe "any"
     }
 
     "generate any for unknown types" in {
-      val td = TableSchemaGenerator(using ModelCatalogue.externalType.model).generate(TableSchemaGenerator.Options(None))
+      val td = TableSchemaGenerator(using ModelCatalogue.externalType.model).generate(
+        TableSchemaGenerator.Options(None),
+      )
       val someSlot = td.fields.head
       someSlot.`type` shouldBe "any"
     }
 
     "generate enum values" in {
-      val td = TableSchemaGenerator(using ModelCatalogue.`enum`.model).generate(TableSchemaGenerator.Options(None))
+      val td = TableSchemaGenerator(using ModelCatalogue.`enum`.model).generate(
+        TableSchemaGenerator.Options(None),
+      )
       val someSlot = td.fields.head
       someSlot.`type` shouldBe "string"
       someSlot.constraints.get.`enum`.get should contain theSameElementsAs Seq(
@@ -132,7 +150,9 @@ class TableSchemaGeneratorSpec extends AnyWordSpec, Matchers {
     }
 
     "generate type constraints" in {
-      val td = TableSchemaGenerator(using ModelCatalogue.constraints.model).generate(TableSchemaGenerator.Options(None))
+      val td = TableSchemaGenerator(using ModelCatalogue.constraints.model).generate(
+        TableSchemaGenerator.Options(None),
+      )
 
       val fieldMap = td.fields.map(fd => fd.name -> fd).toMap
       val intConstraints = fieldMap("intSlot").constraints.get
@@ -148,7 +168,9 @@ class TableSchemaGeneratorSpec extends AnyWordSpec, Matchers {
 
     "allow tree root overriding" in {
       val td =
-        TableSchemaGenerator(using ModelCatalogue.treeRootless.model).generate(TableSchemaGenerator.Options(Some("SomeClass")))
+        TableSchemaGenerator(using ModelCatalogue.treeRootless.model).generate(
+          TableSchemaGenerator.Options(Some("SomeClass")),
+        )
       td.fields should not be empty
       td.fields.map(_.name) should contain theSameElementsAs Seq(
         "some_slot",
@@ -174,7 +196,8 @@ class TableSchemaGeneratorSpec extends AnyWordSpec, Matchers {
       val emptyMaterialized = writeToString(TableDescriptor())
       for model <- ModelCatalogue.all do
         s"model '${model.name}'" in {
-          val res = TableSchemaGenerator(using model.model).serialize(TableSchemaGenerator.Options(None))
+          val res =
+            TableSchemaGenerator(using model.model).serialize(TableSchemaGenerator.Options(None))
           res should not be empty
           res should not be emptyMaterialized
         }

--- a/runtime/src/eu/neverblink/linkml/runtime/UriOrCurie.scala
+++ b/runtime/src/eu/neverblink/linkml/runtime/UriOrCurie.scala
@@ -71,8 +71,8 @@ trait PrefixResolver {
 }
 
 final class BasicPrefixResolver(schemaId: String) extends PrefixResolver {
-  private val prefixToUri = new java.util.HashMap[String, String]
-  private val uriToPrefix = new java.util.HashMap[String, String]
+  private val prefixToUri = new java.util.HashMap[String, String](64, 0.5f)
+  private val uriToPrefix = new java.util.HashMap[String, String](64, 0.5f)
 
   def add(prefix: String, uri: String): Unit = {
     val u = new java.net.URI(uri)
@@ -82,6 +82,11 @@ final class BasicPrefixResolver(schemaId: String) extends PrefixResolver {
     ) normalizedUri = normalizedUri.concat("/")
     prefixToUri.put(prefix, normalizedUri)
     uriToPrefix.put(normalizedUri, prefix)
+  }
+
+  def addAll(other: BasicPrefixResolver): Unit = {
+    prefixToUri.putAll(other.prefixToUri)
+    uriToPrefix.putAll(other.uriToPrefix)
   }
 
   override def resolvePrefix(prefix: String): Option[String] = Option(prefixToUri.get(prefix))

--- a/schemaview/src/eu/neverblink/linkml/schemaview/Closure.scala
+++ b/schemaview/src/eu/neverblink/linkml/schemaview/Closure.scala
@@ -117,30 +117,34 @@ object Closure {
     *   builder.
     * @param useHashCode
     *   A flag that allows using `hashCode` calls of `T` values for the performance optimization.
+    * @param toUniqueValue
+    *   A function that transforms starting and computable values to unique ones for performance
+    *   optimization when the useHashCode is true
     * @return
     *   The computed closure, packaged in the collection type `C[T]`.
     */
-  def get[T, C[_]](
+  def get[T, C[_], K](
       start: Iterable[T],
       function: T => Iterable[T],
       reflexive: Boolean,
       resultBuilder: mutable.Builder[T, C[T]] = Vector.newBuilder[T],
       useHashCode: Boolean = false,
+      toUniqueValue: T => K = identity,
   ): C[T] = {
     // Stack for Depth-First Search traversal
     val todo = new mutable.ArrayDeque[T]
     if (useHashCode) {
       // Optimization: We can use a fast HashSet for visited checks.
-      val visited = new mutable.HashSet[T]
+      val visited = new mutable.HashSet[K]
       start.foreach { s =>
-        if (visited.add(s)) {
+        if (visited.add(toUniqueValue(s))) {
           todo.addOne(s)
           if (reflexive) resultBuilder.addOne(s)
         }
       }
       while (todo.nonEmpty) {
         function(todo.removeLast()).foreach { neighbor =>
-          if (visited.add(neighbor)) {
+          if (visited.add(toUniqueValue(neighbor))) {
             todo.addOne(neighbor)
             resultBuilder.addOne(neighbor)
           }

--- a/schemaview/src/eu/neverblink/linkml/schemaview/CollectionForm.scala
+++ b/schemaview/src/eu/neverblink/linkml/schemaview/CollectionForm.scala
@@ -1,7 +1,5 @@
 package eu.neverblink.linkml.schemaview
 
-import eu.neverblink.linkml.metamodel.SlotDefinition
-
 /** Multivalued inlining form of a class, e.g. SimpleDict */
 sealed trait CollectionForm
 
@@ -39,19 +37,22 @@ object CollectionForm {
     *   The [[CollectionForm]] applicable for this specific class
     */
   def of(classView: ClassView): CollectionForm = {
-    val slots = classView.derivedAttributes.values.map(_.slot).toSeq
-
-    if !slots.exists(isIdOrKey) then return ListOnly
-    val key = slots.filter(isIdOrKey).head
-    if slots.size == 2 then {
-      val value = slots.find(_.name != key.name).get
-      return SimpleDict(key.name, value.name)
+    val slots = classView.derivedAttributes.values
+    slots.find(sv => {
+      val slot = sv.slot
+      slot.key || slot.identifier
+    }) match {
+      case Some(key) =>
+        val keyName = key.name
+        if (slots.size == 2) {
+          val value = slots.find(_.name != keyName).get
+          new SimpleDict(keyName, value.name)
+        } else if slots.count(_.slot.required) == 2 then {
+          val value = slots.find(slot => slot.name != keyName && slot.slot.required).get
+          new SimpleDict(keyName, value.name)
+        } else new CompactDict(keyName)
+      case _ => ListOnly
     }
-    if slots.count(_.required) == 2 then {
-      val value = slots.find(slot => slot.name != key.name && slot.required).get
-      return SimpleDict(key.name, value.name)
-    }
-    CompactDict(key.name)
   }
 
   /** Infer the possible collection forms of a slot's range if it is a class, or a fallback
@@ -60,9 +61,8 @@ object CollectionForm {
     * @return
     *   The [[CollectionForm]] applicable for the slot's range
     */
-  def ofRange(slot: SlotView): CollectionForm = {
-    val range = slot.derivedRange
-    range.resolve(using slot.sv).get match {
+  def ofRange(slot: SlotView): CollectionForm =
+    slot.derivedRange.resolve(using slot.sv).get match {
       case cls: ClassView => of(cls)
       case _ =>
         // Let's be lax here, `inlined:true` does not make sense on non-classes,
@@ -70,7 +70,4 @@ object CollectionForm {
         // TODO LNK-27: But we should have this as a warning if possible
         ListOnly
     }
-  }
-
-  private def isIdOrKey(slot: SlotDefinition): Boolean = slot.key || slot.identifier
 }

--- a/schemaview/src/eu/neverblink/linkml/schemaview/ElementView.scala
+++ b/schemaview/src/eu/neverblink/linkml/schemaview/ElementView.scala
@@ -171,7 +171,7 @@ final case class ClassView(cls: ClassDefinition, definingSchema: SchemaDefinitio
   /** @return
     *   true if this class should be treated as an `Any`
     */
-  def isAny: Boolean = uriStr == "https://w3id.org/linkml/Any"
+  def isAny: Boolean = "https://w3id.org/linkml/Any".equals(uriStr)
 
   /** The collection form of this class, checking whether dict inlines are applicable.
     */

--- a/schemaview/src/eu/neverblink/linkml/schemaview/ElementView.scala
+++ b/schemaview/src/eu/neverblink/linkml/schemaview/ElementView.scala
@@ -108,7 +108,7 @@ final case class ClassView(cls: ClassDefinition, definingSchema: SchemaDefinitio
     // a SlotView (if the slot is defined as a top-level slot). The source is used
     // for default prefix and range resolution according to the original schema file.
     // See: https://linkml.io/linkml-model/latest/docs/specification/04derived-schemas/#function-applicable-slots
-    ancestors(true).foreach { anc =>
+    ancestorsWithSelf.foreach { anc =>
       val keys = anc.cls.attributes.keysIterator
       while (keys.hasNext) {
         val name = keys.next()
@@ -177,22 +177,10 @@ final case class ClassView(cls: ClassDefinition, definingSchema: SchemaDefinitio
     */
   lazy val collectionForm: CollectionForm = CollectionForm.of(this)
 
-  /** Get and dereference the direct parents (mixins + inheritance) of this class
-    *
-    * @return
-    *   Direct parents of the class, mixins before inheritance
+  /** Direct parents (mixins + inheritance) of this class
     */
-  def parents: Seq[ClassView] = getParents(this)
-
-  /** Get the subject type for this class, if possible. Uses the class' identifier slot's range.
-    * @return
-    *   The subject type, or None if the class does not have an identifier
-    */
-  def subjectType: Option[SubjectType] = identifierView.mapFast(_.subjectType)
-
-  private def getParents(view: ClassView): Seq[ClassView] = {
+  lazy val parents: Seq[ClassView] = {
     val parents = new ListBuffer[ClassView]
-    val cls = view.cls
     cls.mixins.foreach { r =>
       sv.resolve(r.asInstanceOf[Reference[ClassView]]).foreachFast(parents.addOne)
     }
@@ -202,16 +190,17 @@ final case class ClassView(cls: ClassDefinition, definingSchema: SchemaDefinitio
     parents.toList
   }
 
-  /** Get and dereference all the ancestors (transitive parents) of this class.
-    *
-    * @param reflexive
-    *   Whether to include the class itself in the result
-    * @return
-    *   Ancestors of the class in LinkML's "depth-first" order -
-    *   `ancestors(x) = x.mixins, x.isA, ancestors(x.isA), ancestors(x.mixins)`
+  /** Ancestors of the class in LinkML's "depth-first" order, starting from self:
+    * `ancestors(x) = x, x.mixins, x.isA, ancestors(x.isA), ancestors(x.mixins)`
     */
-  def ancestors(reflexive: Boolean): Iterable[ClassView] =
-    Closure.get(this, getParents, reflexive)
+  lazy val ancestorsWithSelf: Iterable[ClassView] =
+    Closure.get(Seq(this), _.parents, true, Vector.newBuilder, true, _.cls.name)
+
+  /** Get the subject type for this class, if possible. Uses the class' identifier slot's range.
+    * @return
+    *   The subject type, or None if the class does not have an identifier
+    */
+  def subjectType: Option[SubjectType] = identifierView.mapFast(_.subjectType)
 
   /** Get the slots that are directly defined in this class.
     */
@@ -233,10 +222,11 @@ final case class ClassView(cls: ClassDefinition, definingSchema: SchemaDefinitio
     * @return
     *   True if the slot comes from class attributes, false otherwise
     */
-  def isSlotFromAttributes(slotRef: Reference[SlotDefinition]): Boolean = {
-    val name = slotRef.value
-    ancestors(true).exists(anc => anc.cls.attributes.keys.exists(_.equals(name)))
-  }
+  def isSlotFromAttributes(slotRef: Reference[SlotDefinition]): Boolean =
+    ancestorsWithSelf.exists {
+      val name = slotRef.value
+      anc => anc.cls.attributes.contains(name)
+    }
 
   /** Derive a slot for a class, taking into account the `slotUsage` and `attributes` for the class
     * and its ancestors, as well as the schema top-level slots and its ancestors.
@@ -267,19 +257,20 @@ final case class ClassView(cls: ClassDefinition, definingSchema: SchemaDefinitio
     sv.resolve(slotRef.asInstanceOf[Reference[SlotView]]).foreachFast { (resolved: SlotView) =>
       // Note this is a bit off-spec, but it's a pretty reasonable
       if (!isSlotFromAttributes(slotRef)) {
-        currentSlot =
-          currentSlot.combineWith(resolved.slot.asInstanceOf[SlotDefinitionImpl], sv.combineRange)
-        for slotAncestor <- resolved.ancestors(false) do {
-          currentSlot = currentSlot.combineInherited(
-            slotAncestor.asInstanceOf[SlotDefinitionImpl],
-            sv.combineRange,
-          )
+        resolved.ancestorsWithSelf.foreach {
+          var i = 0
+          ancestorSlotView =>
+            currentSlot =
+              val slotDef = ancestorSlotView.slot.asInstanceOf[SlotDefinitionImpl]
+              if (i > 0) currentSlot.combineInherited(slotDef, sv.combineRange)
+              else currentSlot.combineWith(slotDef, sv.combineRange)
+            i += 1
         }
       }
     }
     val finalSlot = currentSlot.copy(
       name = slotRef.value,
-      slotUri = Some(
+      slotUri = new Some(
         SlotView.uri(
           currentSlot.slotUri,
           slotRef.value,
@@ -310,10 +301,9 @@ final case class ClassView(cls: ClassDefinition, definingSchema: SchemaDefinitio
     *   used instead of checking the class extensions.
     */
   def treeRootInlineType(overrideType: Option[String]): InlineType =
-    val value = overrideType.orElseFast {
+    overrideType.orElseFast {
       cls.extensions.get("tree_root_as").mapFast(_.extensionValue.value.strip)
-    }
-    value.mapFast(v =>
+    }.mapFast { v =>
       Case.camelCase(v) match {
         case "plain" => InlineType.plain
         case "optional" => InlineType.optional
@@ -342,8 +332,8 @@ final case class ClassView(cls: ClassDefinition, definingSchema: SchemaDefinitio
               s"Class '$name' has unknown 'tree_root_as' extension value: '$v'"
             else s"Class '$name' has unknown 'tree_root_as' override value: '$v'"
           })
-      },
-    ).getOrElseFast(InlineType.plain)
+      }
+    }.getOrElseFast(InlineType.plain)
 
   /** Materialize this [[ClassView]] into a derived [[ClassDefinition]]. This inlines all slots as
     * attributes, and clears any inheritance slots. Additionally, sets the class uri using
@@ -385,36 +375,24 @@ final case class SlotView(slot: SlotDefinition, definingSchema: SchemaDefinition
   def implicitPrefixReference: Option[String] =
     slot.implicitPrefix.flatMapFast(definingPrefixResolver.resolvePrefix)
 
-  /** Get and dereference the direct parents (mixins + inheritance) of this slot
-    *
-    * @return
-    *   Direct parents of the slot, mixins before inheritance
+  /** Direct parents (mixins + inheritance) of this slot
     */
-  def parents: Iterable[SlotDefinition] = getParents(slot)
-
-  private def getParents(slot: SlotDefinition): Iterable[SlotDefinition] = {
-    val parents = new ListBuffer[SlotDefinition]
+  lazy val parents: Iterable[SlotView] = {
+    val parents = new ListBuffer[SlotView]
     slot.mixins.foreach { r =>
-      sv.resolve(r).foreachFast(parents.addOne)
+      sv.resolve(r.asInstanceOf[Reference[SlotView]]).foreachFast(parents.addOne)
     }
     slot.isA.foreachFast { r =>
-      sv.resolve(r).foreachFast { cv =>
-        parents.addOne(cv)
-      }
+      sv.resolve(r.asInstanceOf[Reference[SlotView]]).foreachFast(parents.addOne)
     }
     parents.toList
   }
 
-  /** Get and dereference all the ancestors (transitive parents) of this slot.
-    *
-    * @param reflexive
-    *   Whether to include the slot itself in the result
-    * @return
-    *   Ancestors of the slot in LinkML's "depth-first" order -
-    *   `ancestors(x) = x.mixins, x.isA, ancestors(x.isA), ancestors(x.mixins)`
+  /** Ancestors of the slot in LinkML's "depth-first" order, starting from self:
+    * `ancestors(x) = x, x.mixins, x.isA, ancestors(x.isA), ancestors(x.mixins)`
     */
-  def ancestors(reflexive: Boolean): Iterable[SlotDefinition] =
-    Closure.get(slot, getParents, reflexive)
+  lazy val ancestorsWithSelf: Iterable[SlotView] =
+    Closure.get(Seq(this), _.parents, true, Vector.newBuilder, true, _.slot.name)
 
   /** Test whether this slot is declared as inlined, or is implicitly inlined as its range is a
     * type, enum, or class without an identifier

--- a/schemaview/src/eu/neverblink/linkml/schemaview/SchemaReachabilityQuery.scala
+++ b/schemaview/src/eu/neverblink/linkml/schemaview/SchemaReachabilityQuery.scala
@@ -30,7 +30,7 @@ sealed abstract class SchemaReachabilityQuery(using sv: SchemaView) {
   /** Lazily computed set of [[TaggedReference]]s that are reachable for the default implementation
     * of [[reachable()]]
     */
-  protected lazy val resolved: Set[TaggedReference]
+  protected def resolved: Set[TaggedReference]
 
   /** Shared method for collecting the [[TaggedReference]]s for a slot's range/domains.
     */
@@ -39,16 +39,16 @@ sealed abstract class SchemaReachabilityQuery(using sv: SchemaView) {
       results: mutable.ArrayBuffer[TaggedReference],
   ): Unit = {
     slot.slot.anyOf.foreach { anyOfNode =>
-      anyOfNode.range.foreach { rangeNode =>
-        rangeNode.resolve.foreach(el => results.addOne((ElementTypeTag(el), el.name)))
+      anyOfNode.range.foreachFast { rangeNode =>
+        rangeNode.resolve.foreachFast(el => results.addOne((ElementTypeTag(el), el.name)))
       }
     }
-    slot.derivedRange.resolve.foreach { resolvedRange =>
+    slot.derivedRange.resolve.foreachFast { resolvedRange =>
       val el = resolvedRange.inner
       results.addOne((ElementTypeTag(el), el.name))
     }
-    slot.slot.domain.foreach { domainNode =>
-      domainNode.resolve.foreach(el => results.addOne((ElementTypeTag(el), el.name)))
+    slot.slot.domain.foreachFast { domainNode =>
+      domainNode.resolve.foreachFast(el => results.addOne((ElementTypeTag(el), el.name)))
     }
   }
 }
@@ -58,7 +58,7 @@ sealed abstract class SchemaReachabilityQuery(using sv: SchemaView) {
 final class IncludeAllReachabilityQuery(using SchemaView) extends SchemaReachabilityQuery {
   override def reachable(element: Element): Boolean = true
   override def reachable(element: ElementView[?, ?]): Boolean = true
-  protected lazy val resolved: Set[TaggedReference] = Set.empty
+  protected val resolved: Set[TaggedReference] = Set.empty
 }
 
 /** Reachability query for a derived schema (resolved inheritance, all slots inlined to class
@@ -89,39 +89,31 @@ final class DerivedReachabilityQuery(
   )
 
   private def walk(current: TaggedReference): Iterable[TaggedReference] = {
-    val tag = current.tag
-    val name = current.value
     val result = new mutable.ArrayBuffer[TaggedReference]
-    tag match {
-      case ElementTypeTag.classDef =>
-        val classView = sv.classes(name)
-        classView.derivedAttributes.values.foreach {
-          // if the classes are going to be derived, then we can simply skip to the ranges of derived attributes
-          case sv if !inlinedOnly || sv.derivedInlined => collectSlotRefs(sv, result)
-          case _ =>
-        }
-        if (includeClassAncestors) {
-          classView.parents.foreach(anc => result.addOne((classDef, anc.name)))
-        }
-      case ElementTypeTag.typeDef =>
-        val type_ = sv.types(name)._type
-        type_.typeof.foreach { tr =>
-          tr.resolve.foreachFast { td =>
-            result.addOne((typeDef, td.name))
-          }
-        }
-        type_.unionOf.foreach { tr =>
-          tr.resolve.foreachFast { td =>
-            result.addOne((typeDef, td.name))
-          }
-        }
-      case ElementTypeTag.enumDef =>
-        sv.enums(name)._enum.inherits.foreach { er =>
-          er.resolve.foreachFast { ed =>
-            result.addOne((enumDef, ed.name))
-          }
-        }
-      case _ =>
+    val name = current.value
+    val tag = current.tag
+    if (tag eq ElementTypeTag.classDef) {
+      val classView = sv.classes(name)
+      classView.derivedAttributes.values.foreach {
+        // if the classes are going to be derived, then we can simply skip to the ranges of derived attributes
+        case sv if !inlinedOnly || sv.derivedInlined => collectSlotRefs(sv, result)
+        case _ =>
+      }
+      if (includeClassAncestors) {
+        classView.parents.foreach(anc => result.addOne((classDef, anc.name)))
+      }
+    } else if (tag eq ElementTypeTag.typeDef) {
+      val type_ = sv.types(name)._type
+      type_.typeof.foreach { tr =>
+        tr.resolve.foreachFast(td => result.addOne((typeDef, td.name)))
+      }
+      type_.unionOf.foreach { tr =>
+        tr.resolve.foreachFast(td => result.addOne((typeDef, td.name)))
+      }
+    } else if (tag eq ElementTypeTag.enumDef) {
+      sv.enums(name)._enum.inherits.foreach { er =>
+        er.resolve.foreachFast(ed => result.addOne((enumDef, ed.name)))
+      }
     }
     result
   }
@@ -148,57 +140,48 @@ final class UnderivedReachabilityQuery(
   )
 
   private def walk(current: TaggedReference): Iterable[TaggedReference] =
-    val tag = current.tag
-    val name = current.value
     val result = new mutable.ArrayBuffer[TaggedReference]
-    tag match {
-      case ElementTypeTag.classDef =>
-        val classView = sv.classes(name)
-        classView.ancestors(reflexive = false).foreach { anc =>
-          result.addOne((classDef, anc.cls.name))
-        }
-        val cls = classView.cls
-        cls.slots.foreach(sr => result.addOne((slotDef, sr.value)))
-        // The *ranges* of class-defined slots (attributes, slot_usage)
-        val definingSchema = classView.definingSchema
-        cls.attributes.values.foreach { sd =>
-          collectSlotRefs(SlotView(sd, definingSchema), result)
-        }
-        cls.slotUsage.values.foreach { sd =>
-          collectSlotRefs(SlotView(sd, definingSchema), result)
-        }
-      case ElementTypeTag.typeDef =>
-        val type_ = sv.types(name)._type
-        type_.typeof.foreach { tr =>
-          tr.resolve.foreachFast { td =>
-            result.addOne((typeDef, td.name))
-          }
-        }
-        type_.unionOf.foreach { tr =>
-          tr.resolve.foreachFast { td =>
-            result.addOne((typeDef, td.name))
-          }
-        }
-      case ElementTypeTag.slotDef =>
-        val slotView = sv.slotDefinitions(name)
-        slotView.slot.isA.foreach { sr =>
-          sr.resolve.foreachFast { sd =>
-            result.addOne((slotDef, sd.name))
-          }
-        }
-        slotView.slot.mixins.foreach { sr =>
-          sr.resolve.foreachFast { sd =>
-            result.addOne((slotDef, sd.name))
-          }
-        }
-        collectSlotRefs(slotView, result)
-      case ElementTypeTag.enumDef =>
-        sv.enums(name)._enum.inherits.foreach { er =>
-          er.resolve.foreachFast { ed =>
-            result.addOne((enumDef, ed.name))
-          }
-        }
-      case _ =>
+    val name = current.value
+    val tag = current.tag
+    if (tag eq ElementTypeTag.classDef) {
+      val classView = sv.classes(name)
+      classView.ancestorsWithSelf.foreach {
+        var i = 0
+        anc =>
+          if (i > 0) result.addOne((classDef, anc.cls.name))
+          i += 1
+      }
+      val cls = classView.cls
+      cls.slots.foreach(sr => result.addOne((slotDef, sr.value)))
+      // The *ranges* of class-defined slots (attributes, slot_usage)
+      val definingSchema = classView.definingSchema
+      cls.attributes.values.foreach { sd =>
+        collectSlotRefs(new SlotView(sd, definingSchema), result)
+      }
+      cls.slotUsage.values.foreach { sd =>
+        collectSlotRefs(new SlotView(sd, definingSchema), result)
+      }
+    } else if (tag eq ElementTypeTag.typeDef) {
+      val type_ = sv.types(name)._type
+      type_.typeof.foreach { tr =>
+        tr.resolve.foreachFast(td => result.addOne((typeDef, td.name)))
+      }
+      type_.unionOf.foreach { tr =>
+        tr.resolve.foreachFast(td => result.addOne((typeDef, td.name)))
+      }
+    } else if (tag eq ElementTypeTag.slotDef) {
+      val slotView = sv.slotDefinitions(name)
+      slotView.slot.isA.foreach { sr =>
+        sr.resolve.foreachFast(sd => result.addOne((slotDef, sd.name)))
+      }
+      slotView.slot.mixins.foreach { sr =>
+        sr.resolve.foreachFast(sd => result.addOne((slotDef, sd.name)))
+      }
+      collectSlotRefs(slotView, result)
+    } else if (tag eq ElementTypeTag.enumDef) {
+      sv.enums(name)._enum.inherits.foreach { er =>
+        er.resolve.foreachFast(ed => result.addOne((enumDef, ed.name)))
+      }
     }
     result
 }

--- a/schemaview/src/eu/neverblink/linkml/schemaview/SchemaValidator.scala
+++ b/schemaview/src/eu/neverblink/linkml/schemaview/SchemaValidator.scala
@@ -19,11 +19,11 @@ final class SchemaValidator(using sv: SchemaView) {
 
   /** Location of an issue that pertains to a class of the root schema. */
   private def classLocation(className: String): IssueLocationImpl =
-    at(s"/classes/$className")
+    at("/classes/".concat(className))
 
   /** Location of an issue that pertains to the root schema as a whole. */
   private def rootLocation: IssueLocationImpl =
-    IssueLocationImpl(schemaId = new Some(sv.root.id))
+    new IssueLocationImpl(schemaId = new Some(sv.root.id))
 
   // TODO: warn about shadowing
 
@@ -44,7 +44,7 @@ final class SchemaValidator(using sv: SchemaView) {
     macroResult.unknownReferences.map(ref =>
       // A dangling 'string' reference nearly always means 'linkml:types' was not imported, so it
       // gets its own issue type with a hint.
-      if ref.referenceValue == "string" then UnknownStringReferenceImpl(location = at(ref.path))
+      if ref.referenceValue == "string" then new UnknownStringReferenceImpl(location = at(ref.path))
       else
         new UnknownReferenceImpl(
           location = at(ref.path),
@@ -64,10 +64,10 @@ final class SchemaValidator(using sv: SchemaView) {
     schemas.foreach {
       val seen = new util.HashMap[Uri, SchemaDefinition](schemas.size << 1, 0.5f)
       s1 =>
-        val s2 = seen.getOrDefault(s1.id, s1)
-        if (s1 != s2) { // TODO LNK-154 Robust file system importing
+        val s2 = seen.putIfAbsent(s1.id, s1)
+        if ((s2 ne null) && !s2.equals(s1)) { // TODO LNK-154 Robust file system importing
           clashes.addOne(
-            new SchemaIdClashImpl(location = IssueLocationImpl(schemaId = new Some(s1.id))),
+            new SchemaIdClashImpl(location = new IssueLocationImpl(schemaId = new Some(s1.id))),
           )
         }
     }
@@ -78,7 +78,7 @@ final class SchemaValidator(using sv: SchemaView) {
     */
   private lazy val undefinedDefaultRange: Option[SchemaWarning] =
     if isDefaultRangeAllowed then None
-    else new Some(UndefinedDefaultRangeImpl(location = rootLocation))
+    else new Some(new UndefinedDefaultRangeImpl(location = rootLocation))
 
   /** Any `range` slots pointing at invalid elements in the schema. */
   lazy val invalidRangeTypes: Seq[SchemaFatal] =
@@ -95,24 +95,21 @@ final class SchemaValidator(using sv: SchemaView) {
     // Python implementation only looks at the root schema, not the imports:
     // tree_roots = [c for c in schema_view.all_classes(imports=False).values() if c.tree_root]
     // if len(tree_roots) > 0: # -> validation error
-    val treeRoots = sv.root.classes.values.filter(_.treeRoot).toSeq
+    val treeRoots = sv.root.classes.values.collect { case x if x.treeRoot => x.name }.toSeq
     if treeRoots.size > 1 then
       new Some(
-        MultipleTreeRootsImpl(
+        new MultipleTreeRootsImpl(
           location = rootLocation,
-          classNames = treeRoots.map(_.name),
+          classNames = treeRoots,
         ),
       )
     else None
   }
 
   /** Warning when there does not exist a `tree_root` class, None otherwise */
-  private lazy val noTreeRoot: Option[SchemaWarning] = {
-    val treeRoots = sv.root.classes.values.filter(_.treeRoot)
-    if treeRoots.isEmpty then new Some(NoTreeRootClassImpl(location = rootLocation))
-    else None
-
-  }
+  private lazy val noTreeRoot: Option[SchemaWarning] =
+    if (sv.root.classes.values.exists(_.treeRoot)) None
+    else new Some(new NoTreeRootClassImpl(location = rootLocation))
 
   /** Errors for each class with multiple identifier/key slots, empty if all classes have correct
     * identifier/key slots
@@ -152,7 +149,7 @@ final class SchemaValidator(using sv: SchemaView) {
   /** Errors for classes, types, and enums that have non-unique names
     */
   private def nonUniqueName(name: String, usedFor: String): SchemaError =
-    NonUniqueNameImpl(location = rootLocation, elementName = name, usedFor = usedFor)
+    new NonUniqueNameImpl(location = rootLocation, elementName = name, usedFor = usedFor)
 
   private lazy val nonUniqueNames: Seq[SchemaError] = {
     val errors = Seq.newBuilder[SchemaError]
@@ -288,7 +285,7 @@ final class SchemaValidator(using sv: SchemaView) {
     sv.classes.values.foldLeft(Seq.newBuilder[SchemaWarning]) { (acc, cls) =>
       // Collect all slot names that are applicable to this class definition.
       val applicableSlotNames = new util.HashSet[String]
-      cls.ancestors(true).foreach { anc =>
+      cls.ancestorsWithSelf.foreach { anc =>
         val keys = anc.cls.attributes.keysIterator
         while (keys.hasNext) applicableSlotNames.add(keys.next())
         val slots = anc.cls.slots.iterator
@@ -316,9 +313,7 @@ final class SchemaValidator(using sv: SchemaView) {
   ): Option[SchemaError] = {
     slotDefinition.implicitPrefix match {
       case Some(prefix) if prefixResolver.resolvePrefix(prefix).isEmpty =>
-        new Some(
-          undefinedPrefix(prefix, s"$locationPrefix/${slotDefinition.name}/implicit_prefix"),
-        )
+        new Some(undefinedPrefix(prefix, s"$locationPrefix/${slotDefinition.name}/implicit_prefix"))
       case _ => None
     }
   }

--- a/schemaview/src/eu/neverblink/linkml/schemaview/SchemaView.scala
+++ b/schemaview/src/eu/neverblink/linkml/schemaview/SchemaView.scala
@@ -388,8 +388,6 @@ object SchemaView {
     *   The URI of the schema to load. This can be a URL starting with "https://", "http://", or a
     *   file path.
     *
-    * @param doImportLoading
-    *   A boolean flag indicating whether to load the imports of the schema. Defaults to true.
     * @param importer
     *   An importer of schema imports. Default is [[FileSystemImporter]] that reads from the file
     *   system.

--- a/schemaview/src/eu/neverblink/linkml/schemaview/SchemaView.scala
+++ b/schemaview/src/eu/neverblink/linkml/schemaview/SchemaView.scala
@@ -132,10 +132,9 @@ final case class SchemaView(schemas: Seq[SchemaDefinition]) extends ReferenceRes
     */
   def getDefaultPrefix(schema: SchemaDefinition): String = {
     val prefixResolver = prefixResolvers(schema.id)
-    val prefixRef = schema.defaultPrefix.flatMapFast { prefix =>
+    schema.defaultPrefix.flatMapFast { prefix =>
       schema.prefixes.get(prefix)
-    }
-    prefixRef.foldFast {
+    }.foldFast {
       val uri = schema.id.uri(using prefixResolver)
       val len = uri.length
       if (len > 0) {
@@ -216,22 +215,22 @@ final case class SchemaView(schemas: Seq[SchemaDefinition]) extends ReferenceRes
     // yes, it's inefficient, quadratic, whatever
     // there is a proper algorithm for this, but I don't feel like implementing it right now, since only RDFS uses this
     if views.isEmpty then return Seq.empty
-    var commonAncestors = views.head.ancestors(true).map(_.name).toSet
-
+    var commonAncestors = views.head.ancestorsWithSelf.map(_.name).toSet
     views.tail.foreach { cls =>
-      val current = cls.ancestors(true).map(_.name).toSet
+      val current = cls.ancestorsWithSelf.map(_.name).toSet
       commonAncestors = commonAncestors.intersect(current)
     }
-
     val lowestCommon = mutable.HashSet[String]()
     commonAncestors.foreach(lowestCommon.add)
     commonAncestors.foreach { commonAnc =>
       val cls = Reference[ClassView](commonAnc).resolve.get
-      cls.ancestors(false).foreach { anc =>
-        lowestCommon.remove(anc.name)
+      cls.ancestorsWithSelf.foreach {
+        var i = 0
+        anc =>
+          if (i > 0) lowestCommon.remove(anc.name)
+          i += 1
       }
     }
-
     lowestCommon.toSeq.map(Reference[ClassView](_).resolve.get)
   }
 
@@ -324,9 +323,11 @@ object SchemaView {
     * @param uri
     *   The URI of the schema to load. This can be a URL starting with "https://", "http://", or a
     *   file path.
+    *
     * @param importer
     *   An importer of schema imports. Default is [[FileSystemImporter]] that reads from the file
     *   system.
+    *
     * @return
     *   The schema view loaded from the specified URI.
     */
@@ -347,6 +348,7 @@ object SchemaView {
     *   system. Note that the importer will be used with an empty base URI, so it should be able to
     *   handle absolute URIs in imports, or you should provide a custom importer that can handle
     *   them.
+    *
     * @return
     */
   def loadSchemaViewFromString(
@@ -367,7 +369,9 @@ object SchemaView {
       load: => Either[Seq[SchemaFatal], SchemaView],
   ): Either[Seq[SchemaFatal], SchemaView] =
     try load
-    catch { case ex if NonFatal(ex) => new Left(Seq(unexpectedError(ex))) }
+    catch {
+      case ex if NonFatal(ex) => new Left(Seq(unexpectedError(ex)))
+    }
 
   private def unexpectedError(ex: Throwable): UnexpectedErrorImpl = {
     val msg = ex.getMessage
@@ -383,11 +387,13 @@ object SchemaView {
     * @param uri
     *   The URI of the schema to load. This can be a URL starting with "https://", "http://", or a
     *   file path.
+    *
     * @param doImportLoading
     *   A boolean flag indicating whether to load the imports of the schema. Defaults to true.
     * @param importer
     *   An importer of schema imports. Default is [[FileSystemImporter]] that reads from the file
     *   system.
+    *
     * @return
     *   The sequence of schema definitions loaded from the specified URI, with the main schema first
     *   followed by imports in the order they are declared in the schema, with imports of imports
@@ -470,6 +476,7 @@ object SchemaView {
     * @param importer
     *   An importer of schema imports. Default is [[FileSystemImporter]] that reads from the file
     *   system.
+    *
     * @return
     *   The schema definition combined with loaded imports.
     */
@@ -486,12 +493,12 @@ object SchemaView {
       importer: Importer,
       visited: mutable.Set[String],
   ): Either[ImportFailure, Seq[SchemaDefinition]] = {
-    given PrefixResolver = createPrefixResolver(schema)
+    val prefixResolver = createPrefixResolver(schema)
     // Short-circuits on the first import that cannot be loaded.
-    schema.imports.foldLeft[Either[ImportFailure, Seq[SchemaDefinition]]](Right(Seq())) {
+    schema.imports.foldLeft[Either[ImportFailure, Seq[SchemaDefinition]]](new Right(Nil)) {
       (acc, uoc) =>
         acc.flatMap { loadedSoFar =>
-          var sUri = uoc.uri.stripPrefix("./")
+          var sUri = uoc.uri(using prefixResolver).stripPrefix("./")
           if (baseUri.nonEmpty && !sUri.contains("://") && !sUri.startsWith("urn:"))
             sUri = baseUri + PlatformSpecificUtils.separator + sUri
           loadSchemasInternal(sUri, true, importer, visited).map(loadedSoFar ++ _)
@@ -504,31 +511,33 @@ object SchemaView {
     */
   private def createPrefixResolver(forSchema: SchemaDefinition): BasicPrefixResolver = {
     val prefixResolver = new BasicPrefixResolver(forSchema.id.original)
-    Prefixes.map.foreach { (prefix, uri) => prefixResolver.add(prefix, uri) }
-    if (forSchema.defaultCuriMaps.contains("semweb_context")) {
-      Array(
-        ("rdf", "http://www.w3.org/1999/02/22-rdf-syntax-ns#"),
-        ("rdfs", "http://www.w3.org/2000/01/rdf-schema#"),
-        ("owl", "http://www.w3.org/2002/07/owl#"),
-        ("xsd", "http://www.w3.org/2001/XMLSchema#"),
-        ("dc", "http://purl.org/dc/terms/"),
-        ("dcterms", "http://purl.org/dc/terms/"),
-        ("faldo", "http://biohackathon.org/resource/faldo#"),
-        ("foaf", "http://xmlns.com/foaf/0.1/"),
-        ("oa", "http://www.w3.org/ns/oa#"),
-        ("idot", "http://identifiers.org/"),
-        ("void", "http://rdfs.org/ns/void#"),
-        ("prov", "http://www.w3.org/ns/prov#"),
-        ("dcat", "http://www.w3.org/ns/dcat#"),
-      ).foreach { case (prefix, uri) =>
-        prefixResolver.add(prefix, uri)
-      }
+    prefixResolver.addAll {
+      if (forSchema.defaultCuriMaps.contains("semweb_context")) {
+        linkmlWithSemWebContextPrefixResolver
+      } else linkmlPrefixResolver
     }
+    forSchema.prefixes.values.foreach { prefix =>
+      prefixResolver.add(prefix.prefixPrefix, prefix.prefixReference.original)
+    }
+    prefixResolver
+  }
 
-    forSchema.prefixes.values.foreach(prefix =>
-      prefixResolver.add(prefix.prefixPrefix, prefix.prefixReference.original),
-    )
-
+  private lazy val linkmlPrefixResolver = {
+    val prefixResolver = new BasicPrefixResolver("emit_prefixes")
+    Prefixes.map.foreach((prefix, uri) => prefixResolver.add(prefix, uri))
+    prefixResolver
+  }
+  private lazy val linkmlWithSemWebContextPrefixResolver = {
+    val prefixResolver = new BasicPrefixResolver("emit_prefixes+semweb_context")
+    prefixResolver.addAll(linkmlPrefixResolver)
+    prefixResolver.add("dc", "http://purl.org/dc/terms/")
+    prefixResolver.add("faldo", "http://biohackathon.org/resource/faldo#")
+    prefixResolver.add("foaf", "http://xmlns.com/foaf/0.1/")
+    prefixResolver.add("oa", "http://www.w3.org/ns/oa#")
+    prefixResolver.add("idot", "http://identifiers.org/")
+    prefixResolver.add("void", "http://rdfs.org/ns/void#")
+    prefixResolver.add("prov", "http://www.w3.org/ns/prov#")
+    prefixResolver.add("dcat", "http://www.w3.org/ns/dcat#")
     prefixResolver
   }
 }

--- a/schemaview/src/eu/neverblink/linkml/schemaview/SubjectType.scala
+++ b/schemaview/src/eu/neverblink/linkml/schemaview/SubjectType.scala
@@ -19,7 +19,4 @@ enum SubjectType:
     * @return
     *   true if this type should be an RDF IRI
     */
-  def isIri: Boolean = this match {
-    case SubjectType.base => false
-    case _ => true
-  }
+  def isIri: Boolean = this ne SubjectType.base

--- a/schemaview/test/src/eu/neverblink/linkml/schemaview/SchemaViewSpec.scala
+++ b/schemaview/test/src/eu/neverblink/linkml/schemaview/SchemaViewSpec.scala
@@ -94,20 +94,9 @@ class SchemaViewSpec extends AnyWordSpec, Matchers {
       )
     }
 
-    "find the ancestors of a class" in {
-      Reference[ClassView]("class_child").resolve.get
-        .ancestors(false).map(_.cls).toSeq should contain theSameElementsInOrderAs Seq(
-        mixin,
-        classParent,
-        parentMixin1,
-        parentMixin2,
-        classGrandparent,
-      )
-    }
-
     "find the ancestors of a class (reflexive)" in {
       Reference[ClassView]("class_child").resolve.get
-        .ancestors(true).map(_.cls).toSeq should contain theSameElementsInOrderAs Seq(
+        .ancestorsWithSelf.map(_.cls).toSeq should contain theSameElementsInOrderAs Seq(
         classChild,
         mixin,
         classParent,
@@ -119,7 +108,8 @@ class SchemaViewSpec extends AnyWordSpec, Matchers {
 
     "find the ancestors of a class in correct order" in {
       Reference[ClassView]("class_mixin_inheritance").resolve.get
-        .ancestors(false).map(_.cls).toSeq should contain theSameElementsInOrderAs Seq(
+        .ancestorsWithSelf.map(_.cls).toSeq should contain theSameElementsInOrderAs Seq(
+        classWithMixinInheritance, // self
         mixinChild, // .mixins[0]
         classParent, // .is_a
         parentMixin1, // is_a.mixins[0]
@@ -131,22 +121,14 @@ class SchemaViewSpec extends AnyWordSpec, Matchers {
 
     "find the parents of a slot" in {
       Reference[SlotView]("slot3").resolve.get
-        .parents.toSeq should contain theSameElementsInOrderAs Seq(
+        .parents.map(_.slot).toSeq should contain theSameElementsInOrderAs Seq(
         slotParent,
-      )
-    }
-
-    "find the ancestors of a slot" in {
-      Reference[SlotView]("slot3").resolve.get
-        .ancestors(false).toSeq should contain theSameElementsInOrderAs Seq(
-        slotParent,
-        slotGrandparent,
       )
     }
 
     "find the ancestors of a slot (reflexive)" in {
       Reference[SlotView]("slot3").resolve.get
-        .ancestors(true).toSeq should contain theSameElementsInOrderAs Seq(
+        .ancestorsWithSelf.map(_.slot).toSeq should contain theSameElementsInOrderAs Seq(
         slot3,
         slotParent,
         slotGrandparent,

--- a/validation/test/src-jvm/eu/neverblink/linkml/validation/CodecCoverageSpec.scala
+++ b/validation/test/src-jvm/eu/neverblink/linkml/validation/CodecCoverageSpec.scala
@@ -70,7 +70,7 @@ class CodecCoverageSpec extends AnyWordSpec, Matchers {
 
       val stale = (inCodec -- inSchema).toSeq.sorted
       withClue(
-        s"Codec.issueCodec dispatches on types that the schema no longer declares: " +
+        "Codec.issueCodec dispatches on types that the schema no longer declares: " +
           s"${stale.mkString(", ")}. ",
       )(stale shouldBe empty)
     }


### PR DESCRIPTION
A bunch of improvements are here:
- Fix of Schema ID clash validation
- More efficient YAML parsing and serialization (already merged in a separated PR from @scala-steward)
- More efficient serialization of generated SHACL and JSON schemas 
- More efficient calculation of ancestors for deep hierarchies and creation of prefix resolvers
- Memorization of on-demand calculated parents and ancestors for classes and slots
- Reducing other redundant calculations during SchemaView building and accessing
- Code clean up

Below are benchmark results using OpenJDK 25 on MacBook

Before:
```txt
Benchmark                                          (schema)   Mode  Cnt     Score     Error  Units
GeneratorBench.jsonSchemaFromSchemaView      cgmes-core.yml  thrpt    5  1360.389 ±  22.171  ops/s
GeneratorBench.jsonSchemaFromSchemaView  cgmes-dynamics.yml  thrpt    5   621.861 ± 100.306  ops/s
GeneratorBench.jsonSchemaFromSchemaView         TC57CIM.yml  thrpt    5    74.267 ±   3.491  ops/s
GeneratorBench.jsonSchemaFromSchemas         cgmes-core.yml  thrpt    5   464.679 ±  14.251  ops/s
GeneratorBench.jsonSchemaFromSchemas     cgmes-dynamics.yml  thrpt    5   193.958 ±   4.603  ops/s
GeneratorBench.jsonSchemaFromSchemas            TC57CIM.yml  thrpt    5    23.210 ±   0.656  ops/s
GeneratorBench.jsonSchemaFromYaml            cgmes-core.yml  thrpt    5   218.276 ±  12.030  ops/s
GeneratorBench.jsonSchemaFromYaml        cgmes-dynamics.yml  thrpt    5    60.539 ±   2.172  ops/s
GeneratorBench.jsonSchemaFromYaml               TC57CIM.yml  thrpt    5    10.676 ±   0.299  ops/s
GeneratorBench.linkmlFromSchemaView          cgmes-core.yml  thrpt    5   398.900 ±   5.109  ops/s
GeneratorBench.linkmlFromSchemaView      cgmes-dynamics.yml  thrpt    5   178.183 ±   3.678  ops/s
GeneratorBench.linkmlFromSchemaView             TC57CIM.yml  thrpt    5    22.085 ±   1.012  ops/s
GeneratorBench.linkmlFromSchemas             cgmes-core.yml  thrpt    5   265.609 ±   4.279  ops/s
GeneratorBench.linkmlFromSchemas         cgmes-dynamics.yml  thrpt    5   114.339 ±   5.793  ops/s
GeneratorBench.linkmlFromSchemas                TC57CIM.yml  thrpt    5    14.499 ±   0.600  ops/s
GeneratorBench.linkmlFromYaml                cgmes-core.yml  thrpt    5   154.888 ±   1.850  ops/s
GeneratorBench.linkmlFromYaml            cgmes-dynamics.yml  thrpt    5    47.496 ±   1.395  ops/s
GeneratorBench.linkmlFromYaml                   TC57CIM.yml  thrpt    5     8.245 ±   0.286  ops/s
GeneratorBench.shaclFromSchemaView           cgmes-core.yml  thrpt    5   318.142 ±   2.887  ops/s
GeneratorBench.shaclFromSchemaView       cgmes-dynamics.yml  thrpt    5   231.916 ±  38.815  ops/s
GeneratorBench.shaclFromSchemaView              TC57CIM.yml  thrpt    5    26.496 ±   0.676  ops/s
GeneratorBench.shaclFromSchemas              cgmes-core.yml  thrpt    5   225.081 ±   3.913  ops/s
GeneratorBench.shaclFromSchemas          cgmes-dynamics.yml  thrpt    5   137.361 ±   3.495  ops/s
GeneratorBench.shaclFromSchemas                 TC57CIM.yml  thrpt    5    17.163 ±   0.301  ops/s
GeneratorBench.shaclFromYaml                 cgmes-core.yml  thrpt    5   146.229 ±   2.909  ops/s
GeneratorBench.shaclFromYaml             cgmes-dynamics.yml  thrpt    5    53.511 ±   1.309  ops/s
GeneratorBench.shaclFromYaml                    TC57CIM.yml  thrpt    5     8.936 ±   0.084  ops/s
```

After:
```txt
Benchmark                                          (schema)   Mode  Cnt     Score    Error  Units
GeneratorBench.jsonSchemaFromSchemaView      cgmes-core.yml  thrpt    5  1361.545 ±  2.927  ops/s
GeneratorBench.jsonSchemaFromSchemaView  cgmes-dynamics.yml  thrpt    5   727.171 ±  9.462  ops/s
GeneratorBench.jsonSchemaFromSchemaView         TC57CIM.yml  thrpt    5    89.839 ±  0.240  ops/s
GeneratorBench.jsonSchemaFromSchemas         cgmes-core.yml  thrpt    5   520.443 ± 12.550  ops/s
GeneratorBench.jsonSchemaFromSchemas     cgmes-dynamics.yml  thrpt    5   217.352 ±  2.156  ops/s
GeneratorBench.jsonSchemaFromSchemas            TC57CIM.yml  thrpt    5    24.964 ±  0.258  ops/s
GeneratorBench.jsonSchemaFromYaml            cgmes-core.yml  thrpt    5   246.631 ±  1.562  ops/s
GeneratorBench.jsonSchemaFromYaml        cgmes-dynamics.yml  thrpt    5    66.551 ±  1.301  ops/s
GeneratorBench.jsonSchemaFromYaml               TC57CIM.yml  thrpt    5    11.798 ±  0.638  ops/s
GeneratorBench.linkmlFromSchemaView          cgmes-core.yml  thrpt    5   412.122 ±  3.019  ops/s
GeneratorBench.linkmlFromSchemaView      cgmes-dynamics.yml  thrpt    5   182.743 ±  2.313  ops/s
GeneratorBench.linkmlFromSchemaView             TC57CIM.yml  thrpt    5    22.560 ±  0.456  ops/s
GeneratorBench.linkmlFromSchemas             cgmes-core.yml  thrpt    5   271.341 ±  4.950  ops/s
GeneratorBench.linkmlFromSchemas         cgmes-dynamics.yml  thrpt    5   116.270 ±  1.410  ops/s
GeneratorBench.linkmlFromSchemas                TC57CIM.yml  thrpt    5    14.914 ±  0.595  ops/s
GeneratorBench.linkmlFromYaml                cgmes-core.yml  thrpt    5   169.447 ±  2.549  ops/s
GeneratorBench.linkmlFromYaml            cgmes-dynamics.yml  thrpt    5    51.306 ±  2.397  ops/s
GeneratorBench.linkmlFromYaml                   TC57CIM.yml  thrpt    5     8.662 ±  0.613  ops/s
GeneratorBench.shaclFromSchemaView           cgmes-core.yml  thrpt    5   324.097 ±  1.038  ops/s
GeneratorBench.shaclFromSchemaView       cgmes-dynamics.yml  thrpt    5   242.098 ± 21.699  ops/s
GeneratorBench.shaclFromSchemaView              TC57CIM.yml  thrpt    5    27.618 ±  0.325  ops/s
GeneratorBench.shaclFromSchemas              cgmes-core.yml  thrpt    5   232.191 ±  1.768  ops/s
GeneratorBench.shaclFromSchemas          cgmes-dynamics.yml  thrpt    5   141.919 ±  1.044  ops/s
GeneratorBench.shaclFromSchemas                 TC57CIM.yml  thrpt    5    17.553 ±  0.303  ops/s
GeneratorBench.shaclFromYaml                 cgmes-core.yml  thrpt    5   156.467 ±  1.277  ops/s
GeneratorBench.shaclFromYaml             cgmes-dynamics.yml  thrpt    5    58.190 ±  1.379  ops/s
GeneratorBench.shaclFromYaml                    TC57CIM.yml  thrpt    5     9.689 ±  0.299  ops/s
```