### PR TITLE
skill: Remove version tags to improve versioning

### DIFF
--- a/.agents/.claude-plugin/plugin.json
+++ b/.agents/.claude-plugin/plugin.json
@@ -1,6 +1,5 @@
 {
   "name": "linkml",
-  "version": "0.1.0",
   "description": "Author, validate, review and release LinkML schemas with the linkml-scala CLI. Covers schema authoring, bootstrapping from RDFS/OWL/SHACL/JSON Schema/XSD or sample data, modelling-quality review, instance-data validation, and GitHub Actions setup. Auto-load for any task involving a LinkML schema.",
   "author": {
     "name": "NeverBlink",

--- a/.agents/.codex-plugin/plugin.json
+++ b/.agents/.codex-plugin/plugin.json
@@ -1,6 +1,5 @@
 {
   "name": "linkml",
-  "version": "0.1.0",
   "description": "Author, validate, review and release LinkML schemas with the linkml-scala CLI. Covers schema authoring, bootstrapping from RDFS/OWL/SHACL/JSON Schema/XSD or sample data, modelling-quality review, instance-data validation, and GitHub Actions setup. Auto-load for any task involving a LinkML schema.",
   "author": {
     "name": "NeverBlink",

--- a/.agents/README.md
+++ b/.agents/README.md
@@ -72,5 +72,15 @@ documented schema that does not validate fails CI. It also rejects frontmatter o
 Skills spec, Claude-Code-only syntax that Codex cannot interpret, and links that go nowhere. Both
 run in the `skills-check` job of [`checks.yml`](../.github/workflows/checks.yml).
 
+Version numbers are checked too. The requirement in
+[`990-install.md`](skills/linkml/990-install.md) is a feature floor, so it moves only when the
+skill starts relying on something newer — but every restatement of it, here included, has to
+move with it. The install commands deliberately name no version at all (`mise use --pin`
+resolves the newest release and records it), so there is no number left to go stale.
+
+Neither plugin manifest carries a `version`. Both Claude Code and Codex treat a declared version
+as the cache key, so a fixed one pins every user to the copy they first installed. Left out,
+Claude Code falls back to the commit SHA and picks up each change to this directory.
+
 There is deliberately **no** bundled CLI reference and no validator-issue catalogue: `--help` and
 the validator's own messages are self-describing, so a copy would only rot.

--- a/.agents/check.py
+++ b/.agents/check.py
@@ -1,14 +1,17 @@
 #!/usr/bin/env python3
 """Check the agent skills are well-formed and that every schema example still works.
 
-Two independent passes:
+Three independent passes:
 
 1. **Structure** - each skill has a SKILL.md whose frontmatter stays inside the six fields
    of the Agent Skills spec (anything else breaks portability to Codex and to the
    claude.ai Skills API), whose `name` matches its directory, and whose body avoids
    Claude-Code-only syntax that Codex cannot interpret.
 
-2. **Examples** - every ```yaml block in every SKILL.md and reference is fed to
+2. **Versions** - the required CLI version is declared once and repeated consistently, and
+   no install command names a version older than it. See `check_versions`.
+
+3. **Examples** - every ```yaml block in every SKILL.md and reference is fed to
    `linkml-scala validate --strict`. A documented schema that does not validate teaches
    an agent to write broken schemas, so this is a hard failure.
 
@@ -86,6 +89,13 @@ STUBS = {
 errors: list[str] = []
 stats = {"files": 0, "blocks": 0, "links": 0}
 
+# `Requirement: **0.12.0 or newer**` - the one authoritative declaration, restated in prose
+# elsewhere as `0.12.0 or newer`. The last pattern catches a hardcoded install pin, which the
+# install docs deliberately no longer carry.
+REQUIREMENT_RE = re.compile(r"Requirement: \*\*(\d+\.\d+\.\d+) or newer\*\*")
+RESTATEMENT_RE = re.compile(r"(\d+\.\d+\.\d+) or newer")
+INSTALL_PIN_RE = re.compile(r"linkml-scala@v(\d+\.\d+\.\d+)")
+
 
 def fail(where: object, message: str) -> None:
     errors.append(f"{where}: {message}")
@@ -157,6 +167,52 @@ def check_links(md: Path) -> None:
         stats["links"] += 1
         if not (md.parent / target).exists():
             fail(rel, f"links to {target}, which does not exist")
+
+
+# -------------------------------------------------------------------------- versions
+
+
+def parse_version(text: str) -> tuple[int, ...]:
+    return tuple(int(part) for part in text.split("."))
+
+
+def check_versions(texts: dict[Path, str]) -> None:
+    """The declared minimum must not disagree with itself, and nothing may install below it.
+
+    The minimum is a feature floor - `validate --format json` does not exist before it - so it
+    moves only when the skill starts relying on something newer, and every restatement of it
+    has to move at the same time.
+
+    No install command should name a version at all: `mise use --pin` resolves the newest
+    release and records it, so the docs never carry a number that can go stale. A hardcoded
+    `@vX.Y.Z` that creeps back in is caught here only if it is below the floor.
+    """
+    declared: dict[Path, str] = {}
+    for path, text in texts.items():
+        match = REQUIREMENT_RE.search(text)
+        if match:
+            declared[path] = match.group(1)
+    if len(declared) != 1:
+        where = ", ".join(str(path.relative_to(REPO)) for path in declared) or "no file"
+        fail("check.py", f"`Requirement: **X.Y.Z or newer**` must appear once; found it in {where}")
+        return
+    source, minimum = next(iter(declared.items()))
+
+    for path, text in texts.items():
+        for restated in sorted(set(RESTATEMENT_RE.findall(text))):
+            if restated != minimum:
+                fail(
+                    path.relative_to(REPO),
+                    f"says '{restated} or newer', but {source.relative_to(REPO)} requires {minimum}",
+                )
+
+    for path, text in texts.items():
+        for pin in sorted(set(INSTALL_PIN_RE.findall(text))):
+            if parse_version(pin) < parse_version(minimum):
+                fail(
+                    path.relative_to(REPO),
+                    f"installs linkml-scala@v{pin}, below the required minimum {minimum}",
+                )
 
 
 # -------------------------------------------------------------------------- examples
@@ -259,11 +315,17 @@ def main() -> int:
         print("no skills found", file=sys.stderr)
         return 1
 
-    # Structure and links do not need the CLI, so they always run.
+    # Structure, links and versions do not need the CLI, so they always run.
+    docs: list[Path] = []
     for skill_dir in skill_dirs:
         check_structure(skill_dir)
         for md in sorted(skill_dir.glob("*.md")):
             check_links(md)
+            docs.append(md)
+
+    # The README restates the requirement for a human reader, so it drifts with the skill.
+    docs.append(AGENTS / "README.md")
+    check_versions({doc: doc.read_text() for doc in docs if doc.is_file()})
 
     if shutil.which("linkml-scala") is None:
         missing = "linkml-scala not on PATH - the schema example pass did not run"

--- a/.agents/skills/linkml/990-install.md
+++ b/.agents/skills/linkml/990-install.md
@@ -16,11 +16,11 @@ Works on Linux, macOS and Windows, records the version in a file you commit, and
 `sudo`. Requires [mise](https://mise.jdx.dev/getting-started.html).
 
 ```shell
-mise use 'ubi:NeverBlink-OSS/linkml-scala@v0.12.0'
+mise use --pin 'ubi:NeverBlink-OSS/linkml-scala'
 ```
 
-This writes the pin into `mise.toml`. Everyone who runs `mise install` in that repo then gets
-byte-identical tooling.
+This installs the newest release and writes the exact version it resolved into `mise.toml`.
+Everyone who runs `mise install` in that repo then gets byte-identical tooling.
 
 ## Option 2 — the install script
 

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -11,7 +11,6 @@
   "plugins": [
     {
       "name": "linkml",
-      "version": "0.1.0",
       "description": "Author, validate, review and release LinkML schemas with the linkml-scala CLI. Covers schema authoring, bootstrapping from RDFS/OWL/SHACL/JSON Schema/XSD or sample data, modelling-quality review, instance-data validation, and GitHub Actions setup. Auto-load for any task involving a LinkML schema.",
       "author": {
         "name": "NeverBlink",


### PR DESCRIPTION
In the AI software era, packages (skills) have version tags that actually make user experience _worse_, because of how broken the Codex and Claude Code clients are.

If you remove the version tags, the skill will update just fine.

