### PR TITLE
BUG: Update build.mill pom settings

### DIFF
--- a/build.mill
+++ b/build.mill
@@ -516,7 +516,7 @@ trait CommonModule
     organization = "eu.neverblink.linkml",
     url = "https://github.com/NeverBlink-OSS/linkml-scala",
     licenses = Seq(License.`Apache-2.0`),
-    versionControl = VersionControl.github("NeverBlink-OSS", "NeverBlink-OSS"),
+    versionControl = VersionControl.github("NeverBlink-OSS", "linkml-scala"),
     Seq(
       Developer(
         id = "NeverBlink",


### PR DESCRIPTION
It looks like maven central for this project is setting source control to https://github.com/NeverBlink-OSS/NeverBlink-OSS instead of https://github.com/NeverBlink-OSS/linkml-scala.

I believe the version control is in charge of the scm connection setting.

potentially fixes [Issue 174](https://github.com/NeverBlink-OSS/linkml-scala/issues/174)