### PR TITLE
Shared library & Python improvements

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -70,6 +70,11 @@ jobs:
         if: runner.os == 'Windows'
         uses: ilammy/msvc-dev-cmd@v1 # Required by GraalVM Native Image on Windows to find cl.exe
 
+      - name: Setup Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: '3.10'
+
       - name: Build Native Executable with Mill
         shell: bash
         run: |
@@ -100,43 +105,6 @@ jobs:
           name: linkml-scala-${{ matrix.os }}
           path: out/cli/jvm/nativeImage.dest/*
 
-  nativelib-compile:
-    name: Build shared library on ${{ matrix.os }}
-    runs-on: ${{ matrix.os }}
-    strategy:
-      fail-fast: false
-      matrix:
-        # Oldest available image per platform, so the libraries stay usable on older systems.
-        os: [macos-14, macos-15-intel, ubuntu-22.04, ubuntu-22.04-arm, windows-latest]
-    steps:
-      - name: Checkout Repository
-        uses: actions/checkout@v7
-
-      # See the note in aot-compile.
-      - name: Relocate the coursier archive cache
-        shell: bash
-        run: echo "COURSIER_ARCHIVE_CACHE=${{ runner.temp }}/cs-arc" >> "$GITHUB_ENV"
-
-      - name: Cache Dependencies
-        uses: coursier/cache-action@v8
-
-      - name: Setup JVM
-        uses: actions/setup-java@v5
-        with:
-          distribution: temurin
-          java-version: 17 # The minimal JDK version for Scala Next
-
-      - name: Setup MSVC (Windows only)
-        if: runner.os == 'Windows'
-        uses: ilammy/msvc-dev-cmd@v1 # Required by GraalVM Native Image on Windows to find cl.exe
-
-      - name: Setup Python
-        uses: actions/setup-python@v6
-        with:
-          python-version: '3.10'
-
-      # Doubles as the smoke test: pythonTest builds the library, then exercises every generator
-      # and the validator through it on this platform.
       - name: Build Shared Library and Test the Python Bindings
         shell: bash
         run: |
@@ -147,7 +115,8 @@ jobs:
           fi
 
       # The archive is what people actually download, so build it here and check a C program can
-      # compile against it and run.
+      # compile against it and run. This is the only place the Windows import library and the
+      # macOS dylib get tested.
       - name: Check the Release Archive Works from C
         shell: bash
         run: |
@@ -182,7 +151,6 @@ jobs:
       attestations: write # Required to record the provenance attestation on the repo
     needs:
       - aot-compile
-      - nativelib-compile
       - jar-assemble
 
     steps:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -146,6 +146,27 @@ jobs:
             ./mill nativelib.pythonTest
           fi
 
+      # The archive is what people actually download, so build it here and check a C program can
+      # compile against it and run.
+      - name: Check the Release Archive Works from C
+        shell: bash
+        run: |
+          version="${GITHUB_REF_NAME#v}"
+          case "${{ matrix.os }}" in
+          macos-14) platform=macos-arm64 ;;
+          macos-15-intel) platform=macos-x86_64 ;;
+          ubuntu-22.04) platform=linux-x86_64 ;;
+          ubuntu-22.04-arm) platform=linux-arm64 ;;
+          windows-latest) platform=windows-x86_64 ;;
+          esac
+          nativelib/package.sh "$version" "$platform" out/nativelib/sharedLibrary.dest dist
+          if [ "$RUNNER_OS" == "Windows" ]; then
+            unzip -q "dist/linkml-scala-lib-$platform.zip" -d dist
+          else
+            tar -xzf "dist/linkml-scala-lib-$platform.tar.gz" -C dist
+          fi
+          nativelib/smoke.sh "dist/liblinkml-scala-$version-$platform"
+
       - name: Upload Shared Library
         uses: actions/upload-artifact@v7
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -100,6 +100,58 @@ jobs:
           name: linkml-scala-${{ matrix.os }}
           path: out/cli/jvm/nativeImage.dest/*
 
+  nativelib-compile:
+    name: Build shared library on ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        # Oldest available image per platform, so the libraries stay usable on older systems.
+        os: [macos-14, macos-15-intel, ubuntu-22.04, ubuntu-22.04-arm, windows-latest]
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v7
+
+      # See the note in aot-compile.
+      - name: Relocate the coursier archive cache
+        shell: bash
+        run: echo "COURSIER_ARCHIVE_CACHE=${{ runner.temp }}/cs-arc" >> "$GITHUB_ENV"
+
+      - name: Cache Dependencies
+        uses: coursier/cache-action@v8
+
+      - name: Setup JVM
+        uses: actions/setup-java@v5
+        with:
+          distribution: temurin
+          java-version: 17 # The minimal JDK version for Scala Next
+
+      - name: Setup MSVC (Windows only)
+        if: runner.os == 'Windows'
+        uses: ilammy/msvc-dev-cmd@v1 # Required by GraalVM Native Image on Windows to find cl.exe
+
+      - name: Setup Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: '3.10'
+
+      # Doubles as the smoke test: pythonTest builds the library, then exercises every generator
+      # and the validator through it on this platform.
+      - name: Build Shared Library and Test the Python Bindings
+        shell: bash
+        run: |
+          if [ "$RUNNER_OS" == "Windows" ]; then
+            ./mill.bat nativelib.pythonTest
+          else
+            ./mill nativelib.pythonTest
+          fi
+
+      - name: Upload Shared Library
+        uses: actions/upload-artifact@v7
+        with:
+          name: linkml-nativelib-${{ matrix.os }}
+          path: out/nativelib/sharedLibrary.dest/*
+
   publish:
     name: Publish to Maven and GitHub
     runs-on: ubuntu-latest
@@ -109,6 +161,7 @@ jobs:
       attestations: write # Required to record the provenance attestation on the repo
     needs:
       - aot-compile
+      - nativelib-compile
       - jar-assemble
 
     steps:
@@ -144,6 +197,26 @@ jobs:
           gzip -9 -k linkml-scala-linux-arm64 &
           gzip -9 -k linkml-scala-windows-x86_64.exe &
           wait
+
+      - name: Download Shared Libraries
+        uses: actions/download-artifact@v8
+        with:
+          pattern: linkml-nativelib-*
+          path: nativelib-builds
+
+      # Packaged here rather than on each runner so every archive is built by the same tar/zip.
+      # The layout is the usual include/ + lib/ install prefix, see nativelib/package.sh.
+      - name: Package Shared Libraries
+        run: |
+          version="${GITHUB_REF_NAME#v}"
+          package() {
+            nativelib/package.sh "$version" "$2" "nativelib-builds/linkml-nativelib-$1" .
+          }
+          package macos-14          macos-arm64
+          package macos-15-intel    macos-x86_64
+          package ubuntu-22.04      linux-x86_64
+          package ubuntu-22.04-arm  linux-arm64
+          package windows-latest    windows-x86_64
 
       # See: docs/verifying_downloads.md
       - name: Generate Checksums

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -120,11 +120,12 @@ jobs:
           # The oldest Python the bindings support.
           python-version: '3.10'
 
-      - name: Regenerate the Python bindings and check they are committed
+      - name: Regenerate the bindings and check they are committed
         run: |
-          ./mill --no-server pyBindings
+          ./mill --no-server bindings
           git diff --exit-code -- python/linkml_scala/_generated.py \
-            || (echo "python/linkml_scala/_generated.py is stale – run ./mill pyBindings and commit the result"; exit 1)
+            nativelib/src/eu/neverblink/linkml/nativelib/LinkMlCGenerators.java \
+            || (echo "generated bindings are stale – run ./mill bindings and commit the result"; exit 1)
 
       - name: Build the shared library and run the Python binding tests
         run: ./mill --no-server nativelib.pythonTest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -86,4 +86,48 @@ jobs:
           MILL_SONATYPE_USERNAME: ${{ secrets.SONATYPE_USERNAME }}
           MILL_SONATYPE_PASSWORD: ${{ secrets.SONATYPE_PASSWORD }}
         run: |
-          ./mill mill.javalib.SonatypeCentralPublishModule/    
+          ./mill mill.javalib.SonatypeCentralPublishModule/
+
+  nativelib:
+    name: Shared library and Python bindings
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        shell: bash
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+
+      # Matters most here: the native-image build pulls a ~360 MB GraalVM tarball and unpacks it
+      # to ~1 GB, and both copies would otherwise land in the cache. See checks.yml.
+      - name: Relocate the coursier archive cache
+        shell: bash
+        run: echo "COURSIER_ARCHIVE_CACHE=${{ runner.temp }}/cs-arc" >> "$GITHUB_ENV"
+
+      - name: Cache dependencies
+        uses: coursier/cache-action@v8
+
+      - name: Setup JVM
+        uses: actions/setup-java@v5
+        with:
+          distribution: temurin
+          java-version: 25
+
+      - name: Setup Python
+        uses: actions/setup-python@v6
+        with:
+          # The oldest Python the bindings support.
+          python-version: '3.10'
+
+      - name: Build the shared library and run the Python binding tests
+        run: ./mill --no-server nativelib.pythonTest
+
+      - name: Check that the release archive builds and a C program links against it
+        run: |
+          nativelib/package.sh 0.0.0-ci linux-x86_64 out/nativelib/sharedLibrary.dest dist
+          tar -xzf dist/linkml-scala-lib-linux-x86_64.tar.gz -C dist
+          prefix="$PWD/dist/liblinkml-scala-0.0.0-ci-linux-x86_64"
+          gcc nativelib/smoke.c -o dist/smoke \
+            $(PKG_CONFIG_PATH="$prefix" pkg-config --cflags --libs linkml-scala)
+          LD_LIBRARY_PATH="$prefix/lib" dist/smoke    

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -114,11 +114,18 @@ jobs:
           distribution: temurin
           java-version: 25
 
-      - name: Setup Python
+      - name: Setup the oldest supported Python
+        id: python-oldest
         uses: actions/setup-python@v6
         with:
-          # The oldest Python the bindings support.
           python-version: '3.10'
+
+      # Deliberately unpinned: test with newest Python stable
+      - name: Setup the newest Python
+        id: python-newest
+        uses: actions/setup-python@v6
+        with:
+          python-version: '3.x'
 
       - name: Regenerate the bindings and check they are committed
         run: |
@@ -127,7 +134,14 @@ jobs:
             nativelib/src/eu/neverblink/linkml/nativelib/LinkMlCGenerators.java \
             || (echo "generated bindings are stale – run ./mill bindings and commit the result"; exit 1)
 
-      - name: Build the shared library and run the Python binding tests
+      - name: Build the shared library and test the bindings on the oldest supported Python
+        env:
+          PYTHON: ${{ steps.python-oldest.outputs.python-path }}
+        run: ./mill --no-server nativelib.pythonTest
+
+      - name: Test the bindings on the newest Python
+        env:
+          PYTHON: ${{ steps.python-newest.outputs.python-path }}
         run: ./mill --no-server nativelib.pythonTest
 
       # Builds the release archive, then compiles and runs a C program against the unpacked copy.

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -123,11 +123,17 @@ jobs:
       - name: Build the shared library and run the Python binding tests
         run: ./mill --no-server nativelib.pythonTest
 
-      - name: Check that the release archive builds and a C program links against it
+      # Builds the release archive, then compiles and runs a C program against the unpacked copy.
+      - name: Check that the release archive works from C
         run: |
           nativelib/package.sh 0.0.0-ci linux-x86_64 out/nativelib/sharedLibrary.dest dist
           tar -xzf dist/linkml-scala-lib-linux-x86_64.tar.gz -C dist
+          nativelib/smoke.sh dist/liblinkml-scala-0.0.0-ci-linux-x86_64
+
+      - name: Check that the pkg-config file resolves
+        run: |
           prefix="$PWD/dist/liblinkml-scala-0.0.0-ci-linux-x86_64"
-          gcc nativelib/smoke.c -o dist/smoke \
-            $(PKG_CONFIG_PATH="$prefix" pkg-config --cflags --libs linkml-scala)
-          LD_LIBRARY_PATH="$prefix/lib" dist/smoke    
+          flags=$(PKG_CONFIG_PATH="$prefix" pkg-config --cflags --libs linkml-scala)
+          echo "pkg-config: $flags"
+          gcc nativelib/smoke.c -o dist/smoke-pc $flags
+          LD_LIBRARY_PATH="$prefix/lib" dist/smoke-pc    

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -120,6 +120,12 @@ jobs:
           # The oldest Python the bindings support.
           python-version: '3.10'
 
+      - name: Regenerate the Python bindings and check they are committed
+        run: |
+          ./mill --no-server pyBindings
+          git diff --exit-code -- python/linkml_scala/_generated.py \
+            || (echo "python/linkml_scala/_generated.py is stale – run ./mill pyBindings and commit the result"; exit 1)
+
       - name: Build the shared library and run the Python binding tests
         run: ./mill --no-server nativelib.pythonTest
 

--- a/.gitignore
+++ b/.gitignore
@@ -46,3 +46,6 @@ ui/dist/
 __pycache__/
 # The shared library the Python bindings load, put there by `./mill nativelib.installPythonLib`
 /python/linkml_scala/_lib/
+
+# Shared library release archives, from nativelib/package.sh
+/dist/

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ For Java, Scala, Kotlin and other JVM languages, LinkML-Scala is available on **
 
 It starts up immediately and runs fast, even on extra-large LinkML models. **[See the installation instructions.](#cli-tool-installation)**
 
-It's also possible to compile LinkML-Scala to a native shared library for use in Rust, C, C++, and other languages. [Let us know](https://github.com/NeverBlink-OSS/linkml-scala/discussions) if you would like to see this feature!
+We also have experimental [Python and native bindings](docs/python_bindings.md), so you can use LinkML-Scala from Python, C, C++, or Rust.
 
 ### 🛡️ Consistent, reliable, and with great error reporting
 

--- a/README.md
+++ b/README.md
@@ -180,7 +180,8 @@ const jsonSchema = LinkML.jsonSchema(view);
 
 Load a schema with `loadFromString` (from YAML text) or `loadFromPath` (from a path in the
 import map, immune to cyclic imports involving the root), then run `jsonSchema`, `shacl`,
-`rdfs`, `linkml`, `scala`, `tableSchema`, or `lint` against the returned handle.
+`rdfs`, `linkml`, `scala`, `tableSchema`, `graphQl`, `erDiagram`, or `lint` against the returned
+handle.
 See [generator/npm/README.md](generator/npm/README.md) for details.
 
 ## JVM library

--- a/benchmark/src/warm_bench_scala.py
+++ b/benchmark/src/warm_bench_scala.py
@@ -1,0 +1,86 @@
+import argparse
+import glob
+import statistics
+import time
+import sys
+from multiprocessing import Pool
+
+import linkml_scala
+
+# The linkml_scala counterpart of warm_bench.py: same generators, same output format, so the two
+# can be compared line for line.
+#
+# Loads the schemas outside the measured code, as the Python version does. Unlike that one, the
+# loading happens inside the worker: a loaded schema is a handle into a GraalVM isolate rather than
+# a Python object, so it cannot be pickled across to a forked process.
+
+GENERATORS = {
+    "LinkmlScala.jsonSchema": lambda schema: schema.json_schema(),
+    "LinkmlScala.shacl": lambda schema: schema.shacl(),
+}
+
+
+def bench_generator(fn, model: str, warmup: int, iterations: int) -> list[float]:
+    with linkml_scala.load_file(model) as schema:
+        for _ in range(warmup):
+            GENERATORS[fn](schema)
+
+        samples = []
+        for _ in range(iterations):
+            start = time.perf_counter()
+            GENERATORS[fn](schema)
+            samples.append(time.perf_counter() - start)
+        return samples
+
+
+def bench_forks(fn, model: str, warmup: int, iterations: int, forks: int) -> list[float]:
+    with Pool(1, maxtasksperchild=1) as pool:
+        results = [
+            pool.apply(bench_generator, args=(fn, model, warmup, iterations))
+            for i in range(forks)
+        ]
+    return [el for run in results for el in run]
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Benchmark linkml-scala generators, excluding schema loading/parsing.",
+    )
+    parser.add_argument(
+        "--models-glob",
+        default="benchmark/resources/linkml-datasets/*/main.yaml",
+        help="Glob pattern for schema files to benchmark (default: %(default)s)",
+    )
+    parser.add_argument("--warmup", type=int, default=5, help="Warmup iterations per generator")
+    parser.add_argument("--iterations", type=int, default=10, help="Measured iterations per generator")
+    parser.add_argument("--forks", type=int, default=5, help="Number of forks to run in parallel")
+    args = parser.parse_args()
+
+    models = sorted(glob.glob(args.models_glob))
+    if not models:
+        raise SystemExit(f"No schemas matched glob: {args.models_glob}")
+
+    print(f"{'Benchmark':<30}{'(model)':<30}{'Mode':<10}{'Cnt':<10}{'Score':>12}{'Error':>12}{'Units':>10}")
+    for model in models:
+        # A dataset laid out as <name>/main.yaml is named for its directory; a plain file is named
+        # for the file itself.
+        parts = model.split("/")
+        name = parts[-2] if parts[-1] in ("main.yaml", "main.yml") else parts[-1].rsplit(".", 1)[0]
+        print(f"Processing {name}", file=sys.stderr)
+
+        for gen_name, fn in GENERATORS.items():
+            samples = bench_forks(gen_name, model, args.warmup, args.iterations, args.forks)
+            # Throughput per sample (ops/s); stdev assumes the per-sample throughput is normally
+            # distributed around the mean.
+            ops = [1.0 / s for s in samples]
+            stdev = statistics.stdev(ops) if len(ops) > 1 else 0.0
+            print(
+                f"{gen_name:<30}{name:<30}{'thrpt':<10}{args.iterations * args.forks:<10}"
+                f"{statistics.mean(ops):>12.4f}"
+                f"{stdev:>12.4f}"
+                f"{'ops/s':>10}",
+            )
+
+
+if __name__ == "__main__":
+    main()

--- a/build.mill
+++ b/build.mill
@@ -27,7 +27,7 @@ import com.carlosedp.aliases.*
 import mill.contrib.buildinfo.BuildInfo
 import com.sun.net.httpserver.SimpleFileServer
 import mill.api.Evaluator
-import millbuild.{NpmPackage, TsDefsGen}
+import millbuild.{NpmPackage, PyBindingsGen, TsDefsGen}
 
 import java.net.InetSocketAddress
 
@@ -450,6 +450,15 @@ object cli extends Module {
   }
 }
 
+/** Regenerate the Python bindings' generator methods from each generator's `Options` case class.
+  * Run after changing any of them. See mill-build/src/PyBindingsGen.scala.
+  */
+def pyBindings(args: String*) = Task.Command(exclusive = true) {
+  val root = mill.api.BuildCtx.workspaceRoot
+  val generated = PyBindingsGen(path => os.read(root / os.RelPath(path)))
+  os.write.over(root / "python" / "linkml_scala" / "_generated.py", generated)
+}
+
 /** LinkML compiled to a native shared library with a C ABI, and the Python bindings that sit on top
   * of it. See docs/python_bindings.md.
   *
@@ -473,6 +482,8 @@ object nativelib extends ScalaModule, ScalafmtModule, ScalafixModule, NativeImag
     */
   override def compileMvnDeps = Seq(
     mvn"org.graalvm.sdk:nativeimage:25.0.1",
+    // WordFactory, for the null pointer the C error out-params are cleared to.
+    mvn"org.graalvm.sdk:word:25.0.1",
   )
 
   def scalacOptions = Seq(

--- a/build.mill
+++ b/build.mill
@@ -27,7 +27,7 @@ import com.carlosedp.aliases.*
 import mill.contrib.buildinfo.BuildInfo
 import com.sun.net.httpserver.SimpleFileServer
 import mill.api.Evaluator
-import millbuild.{NpmPackage, PyBindingsGen, TsDefsGen}
+import millbuild.{CApiGen, NpmPackage, PyBindingsGen, TsDefsGen}
 
 import java.net.InetSocketAddress
 
@@ -321,6 +321,9 @@ object generator extends Module {
       override def forkEnv = super.forkEnv() ++ Map(
         "LINKML_BENCHMARK_SCHEMAS" -> benchmarkSchemas().path.toString,
         "LINKML_MERMAID_VALIDATOR" -> mermaidDir.toString,
+        // BindingCoverageSpec reads the repository's own sources to check every generator is
+        // reachable from every binding.
+        "LINKML_REPO_ROOT" -> mill.api.BuildCtx.workspaceRoot.toString,
       ) ++
         sys.env.view.filterKeys(Set("PATH", "CI")).toMap
     }
@@ -450,13 +453,18 @@ object cli extends Module {
   }
 }
 
-/** Regenerate the Python bindings' generator methods from each generator's `Options` case class.
-  * Run after changing any of them. See mill-build/src/PyBindingsGen.scala.
+/** Regenerate the C and Python bindings from mill-build/src/Entrypoints.scala and each generator's
+  * `Options` case class. Run after adding a generator or an option.
   */
-def pyBindings(args: String*) = Task.Command(exclusive = true) {
+def bindings(args: String*) = Task.Command(exclusive = true) {
   val root = mill.api.BuildCtx.workspaceRoot
-  val generated = PyBindingsGen(path => os.read(root / os.RelPath(path)))
-  os.write.over(root / "python" / "linkml_scala" / "_generated.py", generated)
+  def read(path: String): String = os.read(root / os.RelPath(path))
+  os.write.over(root / "python" / "linkml_scala" / "_generated.py", PyBindingsGen(read))
+  os.write.over(
+    root / "nativelib" / "src" / "eu" / "neverblink" / "linkml" / "nativelib" /
+      "LinkMlCGenerators.java",
+    CApiGen(read),
+  )
 }
 
 /** LinkML compiled to a native shared library with a C ABI, and the Python bindings that sit on top

--- a/build.mill
+++ b/build.mill
@@ -321,9 +321,6 @@ object generator extends Module {
       override def forkEnv = super.forkEnv() ++ Map(
         "LINKML_BENCHMARK_SCHEMAS" -> benchmarkSchemas().path.toString,
         "LINKML_MERMAID_VALIDATOR" -> mermaidDir.toString,
-        // BindingCoverageSpec reads the repository's own sources to check every generator is
-        // reachable from every binding.
-        "LINKML_REPO_ROOT" -> mill.api.BuildCtx.workspaceRoot.toString,
       ) ++
         sys.env.view.filterKeys(Set("PATH", "CI")).toMap
     }

--- a/build.mill
+++ b/build.mill
@@ -552,12 +552,16 @@ object nativelib extends ScalaModule, ScalafmtModule, ScalafixModule, NativeImag
   }
 
   /** Run the Python binding's test suite against a freshly installed library. Requires Python 3.10+
-    * on the PATH.
+    * on the PATH, or `PYTHON` pointing at one.
     */
   def pythonTest(args: String*) = Task.Command(exclusive = true) {
     installPythonLib()()
+    val python = sys.env.getOrElse(
+      "PYTHON",
+      if _root_.scala.util.Properties.isWin then "python" else "python3",
+    )
     os.call(
-      ("python3", "-m", "unittest", "discover", "-s", "python", "-v"),
+      (python, "-m", "unittest", "discover", "-s", "python", "-v"),
       cwd = mill.api.BuildCtx.workspaceRoot,
       stdout = os.Inherit,
       stderr = os.Inherit,

--- a/cli/src/eu/neverblink/linkml/cli/GenerateImpl.scala
+++ b/cli/src/eu/neverblink/linkml/cli/GenerateImpl.scala
@@ -37,7 +37,12 @@ object Scala extends StringGenerate[ScalaOptions] {
   override protected[cli] def generate(
       options: ScalaOptions,
   )(using SchemaView): Iterable[(String, String)] =
-    ScalaGenerator().generate(options.`package`, options.generateEmitPrefixes)
+    ScalaGenerator().generate(
+      ScalaGenerator.Options(
+        `package` = options.`package`,
+        generateEmitPrefixes = options.generateEmitPrefixes,
+      ),
+    )
 }
 
 // JSON Schema
@@ -72,9 +77,11 @@ object JsonSchema extends StringGenerate[JsonSchemaOptions] {
       (
         "",
         JsonSchemaGenerator().serialize(
-          options.open,
-          options.treeRootOverride,
-          treeRootInlineTypeOverride = options.treeRootInlineTypeOverride,
+          JsonSchemaGenerator.Options(
+            open = options.open,
+            treeRoot = options.treeRootOverride,
+            treeRootInlineType = options.treeRootInlineTypeOverride,
+          ),
         ),
       ),
     )
@@ -110,7 +117,13 @@ object Shacl extends StreamGenerate[ShaclOptions] {
     if !RdfOutput.write(
         out,
         options.format,
-        ShaclGenerator().generate(_, options.open, options.onlyClassesFromRootSchema),
+        ShaclGenerator().generate(
+          _,
+          ShaclGenerator.Options(
+            open = options.open,
+            onlyClassesFromRootSchema = options.onlyClassesFromRootSchema,
+          ),
+        ),
       )
     then err(RdfOutput.unknownFormat(options.format))
 }
@@ -141,7 +154,10 @@ object Rdfs extends StreamGenerate[RdfsOptions] {
     if !RdfOutput.write(
         out,
         options.format,
-        RdfsGenerator().generate(_, options.onlyClassesFromRootSchema),
+        RdfsGenerator().generate(
+          _,
+          RdfsGenerator.Options(onlyClassesFromRootSchema = options.onlyClassesFromRootSchema),
+        ),
       )
     then err(RdfOutput.unknownFormat(options.format))
 }
@@ -207,9 +223,11 @@ object LinkMl extends StringGenerate[LinkMlOptions] {
       (
         "",
         LinkMlGenerator().serialize(
-          skipClassDerivation = options.skipDerivation,
-          pruningMode = options.pruning.resolvedPruningMode,
-          outputFormat = format,
+          LinkMlGenerator.Options(
+            pruningMode = options.pruning.resolvedPruningMode,
+            skipClassDerivation = options.skipDerivation,
+            outputFormat = format,
+          ),
         ),
       ),
     )
@@ -234,7 +252,7 @@ object TableSchema extends StringGenerate[TableSchemaOptions] {
       options: TableSchemaOptions,
   )(using SchemaView): Iterable[(String, String)] =
     Seq(
-      ("", TableSchemaGenerator().serialize(options.treeRoot)),
+      ("", TableSchemaGenerator().serialize(TableSchemaGenerator.Options(options.treeRoot))),
     )
 }
 
@@ -260,7 +278,12 @@ object GraphQl extends StringGenerate[GraphQlOptions] {
       options: GraphQlOptions,
   )(using SchemaView): Iterable[(String, String)] =
     Seq(
-      ("", GraphQlGenerator().serialize(options.pruning.resolvedPruningMode)),
+      (
+        "",
+        GraphQlGenerator().serialize(
+          GraphQlGenerator.Options(options.pruning.resolvedPruningMode),
+        ),
+      ),
     )
 }
 
@@ -296,8 +319,10 @@ object ErDiagram extends StringGenerate[ErDiagramOptions] {
       (
         "",
         ErDiagramGenerator().serialize(
-          options.pruning.resolvedPruningMode,
-          options.optionalMarker,
+          ErDiagramGenerator.Options(
+            pruningMode = options.pruning.resolvedPruningMode,
+            optionalMarker = options.optionalMarker,
+          ),
         ),
       ),
     )

--- a/docs/python_bindings.md
+++ b/docs/python_bindings.md
@@ -23,7 +23,7 @@ A schema is parsed once and reused across generators, the same way the [JavaScri
 
 ## Building it
 
-You need JDK 17+ (Mill downloads GraalVM itself) and Python 3.10 or newer, tested on 3.13. Then:
+You need JDK 17+ (Mill downloads GraalVM itself) and Python 3.10 or newer. Then:
 
 ```shell
 ./mill nativelib.installPythonLib
@@ -102,7 +102,7 @@ not: a schema can load and still have things to say about it.
 schema.json_schema(open=False, tree_root=None, tree_root_inline_type=None, indentation_step=2)
 schema.shacl(open=False, only_classes_from_root_schema=False)
 schema.rdfs(only_classes_from_root_schema=False)
-schema.linkml(pruning_mode="treeRoot", tree_root=None, skip_class_derivation=False, output_format="yaml")
+schema.linkml(pruning_mode="skip", tree_root=None, skip_class_derivation=False, output_format="yaml")
 schema.table_schema(tree_root=None)
 schema.graphql(pruning_mode="schema", tree_root=None)
 schema.er_diagram(pruning_mode="schema", tree_root=None, optional_marker=True)

--- a/docs/python_bindings.md
+++ b/docs/python_bindings.md
@@ -48,6 +48,10 @@ Run the tests with:
 If you keep the library somewhere else, point `LINKML_SCALA_LIB` at the file (or at the directory
 holding it).
 
+Each release also attaches a prebuilt archive per platform, `linkml-scala-lib-<os>-<arch>`, laid out
+as a normal install prefix – `include/`, `lib/` and a pkg-config file – so C, C++ and Rust callers can
+use the same library. [`nativelib/smoke.c`](../nativelib/smoke.c) is a worked example in C.
+
 ## How it works
 
 The library exports two C functions, and everything goes through them as JSON:
@@ -149,8 +153,8 @@ Python package takes 450 ms.
 
 ## TODO
 
-1. `pyproject.toml` and a wheel per platform, with the library bundled as package data, built in the
-   existing release workflow next to the native CLI binaries.
+1. `pyproject.toml` and a wheel per platform, with the library bundled as package data. The release
+   workflow already builds and attaches the library itself; only the pip side is missing.
 2. Type stubs, or type hints good enough to not need them. The reports are plain dicts today; a
    `TypedDict` generated from `validation-report.yaml` would be better, and would help the
    TypeScript bindings too (see [#127](https://github.com/NeverBlink-OSS/linkml-scala/issues/127)).

--- a/docs/python_bindings.md
+++ b/docs/python_bindings.md
@@ -54,23 +54,31 @@ use the same library. [`nativelib/smoke.c`](../nativelib/smoke.c) is a worked ex
 
 ## How it works
 
-The library exports two C functions, and everything goes through them as JSON:
+We export one function per operation:
 
 ```c
-char* linkml_call(graal_isolatethread_t*, char*);   // JSON request in, JSON response out
-void  linkml_free(graal_isolatethread_t*, char*);   // release a response
+char* linkml_shacl      (graal_isolatethread_t*, long long handle, const char* opts, char** err);
+char* linkml_json_schema(graal_isolatethread_t*, long long handle, const char* opts, char** err);
+/* rdfs, linkml, table_schema, graphql, er_diagram, scala, lint – same shape */
+
+long long linkml_load_file(graal_isolatethread_t*, const char* path,
+                           const char* opts, char** report, char** err);
+void      linkml_close    (graal_isolatethread_t*, long long handle);
+void      linkml_free     (graal_isolatethread_t*, char*);
 ```
 
-```json
-{"op": "generate", "handle": 7, "generator": "shacl", "options": {"open": true}}
-{"ok": true, "output": "<https://example.org/Person> <...#type> <...#NodeShape> .\n..."}
+Conventions:
+
+**Options are one JSON string, and may be NULL.** Options are the part that changes as generators grow, so keeping them out of the signatures keeps the ABI stable. NULL means "use defaults":
+
+```c
+char *shacl = linkml_shacl(thread, handle, NULL, &err);               /* defaults */
+char *open  = linkml_shacl(thread, handle, "{\"open\":true}", &err);  /* one option */
 ```
 
-The ops are `version`, `load`, `generate`, `lint` and `close`. Keeping it to one function means the C
-ABI does not change when a generator gains an option – only the JSON inside the call does. A loaded
-schema is an integer handle into a table on the Scala side.
+**Failure is NULL plus a message.** A generator returns NULL and writes the reason to `*err`. Loading returns handle 0 and writes a validation report to `*report`. All returned strings must be freed by the caller with `linkml_free`.
 
-Python creates one GraalVM isolate per process and attaches each calling thread to it on first use.
+A loaded schema is an integer handle.
 
 ## The API
 
@@ -91,19 +99,20 @@ not: a schema can load and still have things to say about it.
 ### Generating
 
 ```python
-schema.json_schema(open=False, tree_root=None, tree_root_inline_type=None)
+schema.json_schema(open=False, tree_root=None, tree_root_inline_type=None, indentation_step=2)
 schema.shacl(open=False, only_classes_from_root_schema=False)
 schema.rdfs(only_classes_from_root_schema=False)
-schema.linkml(skip_derivation=False, pruning_mode="skip", tree_root=None, format="yaml")
+schema.linkml(pruning_mode="treeRoot", tree_root=None, skip_class_derivation=False, output_format="yaml")
 schema.table_schema(tree_root=None)
-schema.graphql(pruning_mode="skip", tree_root=None)
-schema.er_diagram(pruning_mode="skip", tree_root=None, optional_marker=True)
-schema.scala(package, generate_emit_prefixes=True)  # -> {filename: source}
+schema.graphql(pruning_mode="schema", tree_root=None)
+schema.er_diagram(pruning_mode="schema", tree_root=None, optional_marker=True)
+schema.scala(package="eu.neverblink.linkml.metamodel", generate_emit_prefixes=True)
 ```
 
-Every one of these returns a string, except `scala()`, which returns a filename-to-source dict. The
-options match the CLI's flags, including the defaults – note that `pruning_mode` defaults to `"skip"`
-here and in the CLI, but to `"treeRoot"` in the JavaScript bindings.
+All arguments are keyword-only. Every one returns a string, except `scala()`, which returns a
+filename-to-source dict.
+
+**These are generated, not written.** Each method mirrors the `Options` case class of the generator it calls – `ShaclGenerator.Options` and so on – so the names, types, defaults and docstrings are whatever the Scala declares. See [`mill-build/src/PyBindingsGen.scala`](../mill-build/src/PyBindingsGen.scala).
 
 ### Validating
 
@@ -121,35 +130,7 @@ if you are loading many schemas.
 
 ## How fast is it?
 
-Rough estimates, based on a few local runs.
-
-**Binding overhead.** On `tests/resources/models/inheritance/model.yaml`, against shelling out to the
-native CLI binary:
-
-| | Time |
-|---|---|
-| CLI subprocess, JSON Schema | 4.2 ms |
-| Bindings, JSON Schema (schema already loaded) | <0.05 ms |
-| Bindings, load + JSON Schema | 0.5 ms |
-| CLI subprocess, 6 generators (reparses each time) | 24.8 ms |
-| Bindings, 6 generators from one load | 0.9 ms |
-
-The gap is mostly process startup and reparsing the schema per invocation, both of which the bindings
-avoid. The JSON round trip does not show up at this scale.
-
-**Against LinkML (Python).** A synthetic 300-class schema, generated from scratch each time:
-
-| | LinkML (Python) | Bindings | |
-|---|---|---|---|
-| JSON Schema | 204 ms | 11 ms | 18× |
-| SHACL | 363 ms | 13 ms | 28× |
-
-In line with [the existing benchmarks](benchmarks.md), which is what you would hope for: it is the
-same generator code.
-
-**Startup.** `import linkml_scala` takes 10 ms, and the first load – which also creates the isolate –
-another 13 ms for the LinkML metamodel. For comparison, importing two generators from the `linkml`
-Python package takes 450 ms.
+TODO
 
 ## TODO
 

--- a/docs/python_bindings.md
+++ b/docs/python_bindings.md
@@ -139,4 +139,3 @@ TODO
 2. Type stubs, or type hints good enough to not need them. The reports are plain dicts today; a
    `TypedDict` generated from `validation-report.yaml` would be better, and would help the
    TypeScript bindings too (see [#127](https://github.com/NeverBlink-OSS/linkml-scala/issues/127)).
-3. A raw path for large outputs that skips JSON string escaping, if it ever shows up in a profile. Or a custom simple serialization format with prepended length (pseudo-Protobuf).

--- a/docs/python_bindings.md
+++ b/docs/python_bindings.md
@@ -130,7 +130,25 @@ if you are loading many schemas.
 
 ## How fast is it?
 
-TODO
+Note: these are rough numbers on a Ryzen 7900 workstation. Full benchmark is still pending. See: [benchmark code](../benchmark/src), [datasets](../benchmark/resources/schemas).
+
+Here we measured only the time to generate the output, not the time to load the schema. The Python side is LinkML 1.11.1, and the Scala side is LinkML-Scala 975f65a, v0.13.1-15-g975f65a.
+
+### JSON Schema
+
+| Dataset          | Size   | linkml (Python) | linkml_scala |  Speedup |
+|------------------|--------|----------------:|-------------:|---------:|
+| `TC57CIM`        | 2.9 MB |        7,413 ms |      55.2 ms | **134×** |
+| `cgmes-dynamics` | 812 KB |          952 ms |       5.5 ms | **174×** |
+| `cgmes-core`     | 196 KB |          471 ms |       3.7 ms | **126×** |
+
+### SHACL
+
+| Dataset          | Size   | linkml (Python) | linkml_scala | Speedup |
+|------------------|--------|----------------:|-------------:|--------:|
+| `TC57CIM`        | 2.9 MB |       17,699 ms |       188 ms | **94×** |
+| `cgmes-dynamics` | 812 KB |        2,039 ms |      20.8 ms | **98×** |
+| `cgmes-core`     | 196 KB |        1,196 ms |      15.0 ms | **80×** |
 
 ## TODO
 

--- a/generator/npm/README.md
+++ b/generator/npm/README.md
@@ -82,6 +82,7 @@ Load a schema into a `SchemaView` handle (see above), then pass that handle to a
 | `scala(view, packageName)`                                           | `Record<string, string>` | filename → generated Scala                                   |
 | `tableSchema(view, treeRoot?)`                                       | `string` | Frictionless Table Schema (JSON)                             |
 | `graphQl(view, pruningMode?, treeRoot?)`                             | `string` | GraphQL                                                      |
+| `erDiagram(view, pruningMode?, treeRoot?, optionalMarker?)`          | `string` | Mermaid entity relationship diagram                          |
 | `lint(view, inferMessages?)`                                         | `object` | `SchemaValidationReport` (JSON)                              |
 
 See [`index.d.ts`](./index.d.ts) for full type signatures.

--- a/generator/src-js/eu/neverblink/linkml/js/LinkMlJsApi.scala
+++ b/generator/src-js/eu/neverblink/linkml/js/LinkMlJsApi.scala
@@ -152,7 +152,9 @@ object LinkMlJsApi {
       open: Boolean = false,
       treeRootOverride: js.UndefOr[String] = js.undefined,
   ): String =
-    JsonSchemaGenerator(using schema.underlying).serialize(open, treeRootOverride.toOption)
+    JsonSchemaGenerator(using schema.underlying).serialize(
+      JsonSchemaGenerator.Options(open = open, treeRoot = treeRootOverride.toOption),
+    )
 
   /** Generate SHACL shapes (in N-Triples format) from a loaded LinkML schema.
     *
@@ -176,8 +178,7 @@ object LinkMlJsApi {
     val sink = new StringSink
     ShaclGenerator(using schema.underlying).generate(
       NTriplesRdfSink(sink),
-      open,
-      onlyClassesFromRootSchema,
+      ShaclGenerator.Options(open = open, onlyClassesFromRootSchema = onlyClassesFromRootSchema),
     )
     sink.result
   }
@@ -195,7 +196,10 @@ object LinkMlJsApi {
       schema: SchemaViewJs,
       `package`: String,
   ): js.Dictionary[String] =
-    ScalaGenerator(using schema.underlying).generate(`package`).toMap.toJSDictionary
+    ScalaGenerator(using schema.underlying)
+      .generate(ScalaGenerator.Options(`package` = `package`))
+      .toMap
+      .toJSDictionary
 
   /** Generate RDFS from a loaded LinkML schema.
     *
@@ -215,7 +219,7 @@ object LinkMlJsApi {
     val sink = new StringSink
     RdfsGenerator(using schema.underlying).generate(
       NTriplesRdfSink(sink),
-      onlyClassesFromRootSchema,
+      RdfsGenerator.Options(onlyClassesFromRootSchema = onlyClassesFromRootSchema),
     )
     sink.result
   }
@@ -256,9 +260,11 @@ object LinkMlJsApi {
       case s => throw RuntimeException(s"Unknown output format: $s")
     }
     LinkMlGenerator(using schema.underlying).serialize(
-      skipClassDerivation = skipDerivation,
-      pruningMode = mode,
-      outputFormat = format,
+      LinkMlGenerator.Options(
+        pruningMode = mode,
+        skipClassDerivation = skipDerivation,
+        outputFormat = format,
+      ),
     )
   }
 
@@ -275,7 +281,9 @@ object LinkMlJsApi {
       schema: SchemaViewJs,
       treeRoot: js.UndefOr[String] = js.undefined,
   ): String =
-    TableSchemaGenerator(using schema.underlying).serialize(treeRoot.toOption)
+    TableSchemaGenerator(using schema.underlying).serialize(
+      TableSchemaGenerator.Options(treeRoot.toOption),
+    )
 
   /** Generate a GraphQL Schema from a loaded LinkML schema. Only types/interfaces/scalar/enums,
     * queries must be provided for a specific implementation.
@@ -298,7 +306,7 @@ object LinkMlJsApi {
       treeRoot: js.UndefOr[String] = js.undefined,
   ): String =
     GraphQlGenerator(using schema.underlying).serialize(
-      PruningMode(pruningMode, treeRoot.toOption),
+      GraphQlGenerator.Options(PruningMode(pruningMode, treeRoot.toOption)),
     )
 
   /** Generate a Mermaid entity relationship diagram from a loaded LinkML schema. Classes become
@@ -327,8 +335,10 @@ object LinkMlJsApi {
       optionalMarker: Boolean = true,
   ): String =
     ErDiagramGenerator(using schema.underlying).serialize(
-      PruningMode(pruningMode, treeRoot.toOption),
-      optionalMarker,
+      ErDiagramGenerator.Options(
+        pruningMode = PruningMode(pruningMode, treeRoot.toOption),
+        optionalMarker = optionalMarker,
+      ),
     )
 
   /** Lint a loaded LinkML schema, finding problems that may cause issues when using the model. This

--- a/generator/src/eu/neverblink/linkml/generator/erdiagram/ErDiagramGenerator.scala
+++ b/generator/src/eu/neverblink/linkml/generator/erdiagram/ErDiagramGenerator.scala
@@ -16,17 +16,13 @@ final class ErDiagramGenerator(using sv: SchemaView) {
 
   /** Generate the ER diagram model.
     *
-    * @param pruningMode
-    *   How to prune the generated entities, schemaRoot by default (classes reachable from any
-    *   element defined in the root schema).
-    * @param optionalMarker
-    *   Whether to mark optional attributes with a trailing `?` on their type. Works since Mermaid
-    *   11.16.
+    * @param options
+    *   What to generate. See [[ErDiagramGenerator.Options]].
     */
   def generate(
-      pruningMode: PruningMode = schemaRoot,
-      optionalMarker: Boolean = true,
+      options: ErDiagramGenerator.Options = ErDiagramGenerator.Options(),
   ): ErDiagram = {
+    import options.{optionalMarker, pruningMode}
     val query = pruningMode.derivedQuery(false, true)
 
     val classes = sv.classes.values
@@ -47,18 +43,13 @@ final class ErDiagramGenerator(using sv: SchemaView) {
 
   /** Generate the ER diagram and serialize it as Mermaid.
     *
-    * @param pruningMode
-    *   How to prune the generated entities, schemaRoot by default (classes reachable from any
-    *   element defined in the root schema).
-    * @param optionalMarker
-    *   Whether to mark optional attributes with a trailing `?` on their type, which requires
-    *   Mermaid 11.16 or newer.
+    * @param options
+    *   What to generate. See [[ErDiagramGenerator.Options]].
     */
   def serialize(
-      pruningMode: PruningMode = schemaRoot,
-      optionalMarker: Boolean = true,
+      options: ErDiagramGenerator.Options = ErDiagramGenerator.Options(),
   ): String =
-    generate(pruningMode, optionalMarker).print
+    generate(options).print
 
   /** Slots of a class sorted by `rank`, then by name. */
   private def sortedAttributes(cv: ClassView): Seq[AttributeView] =
@@ -312,4 +303,22 @@ private[erdiagram] object ErName {
   def label(raw: String): String =
     // A `WORD` is `"[^"]*"`, so only the quote itself has to go.
     "\"" + defuseDirection(raw).replace('"', '\'').map(c => if c.isControl then ' ' else c) + "\""
+}
+
+object ErDiagramGenerator {
+
+  /** Options for [[ErDiagramGenerator]].
+    *
+    * @param pruningMode
+    *   How to prune the generated entities, schemaRoot by default (classes reachable from any
+    *   element defined in the root schema).
+    *
+    * @param optionalMarker
+    *   Whether to mark optional attributes with a trailing `?` on their type, which requires
+    *   Mermaid 11.16 or newer.
+    */
+  final case class Options(
+      pruningMode: PruningMode = schemaRoot,
+      optionalMarker: Boolean = true,
+  )
 }

--- a/generator/src/eu/neverblink/linkml/generator/graphql/GraphQlGenerator.scala
+++ b/generator/src/eu/neverblink/linkml/generator/graphql/GraphQlGenerator.scala
@@ -14,14 +14,13 @@ class GraphQlGenerator(using sv: SchemaView) {
 
   /** Generate the GraphQL definitions which use custom directives for rdf interop.
     *
-    * @param pruningMode
-    *   How to prune the generated definitions, schemaRoot by default (elements reachable from any
-    *   root schema defined elements) to omit unnecessary linkml:types scalar definitions.
+    * @param options
+    *   What to generate. See [[GraphQlGenerator.Options]].
     */
   def generate(
-      pruningMode: PruningMode = schemaRoot,
+      options: GraphQlGenerator.Options = GraphQlGenerator.Options(),
   ): Iterable[GraphQlDefinition] = {
-    val query = pruningMode.derivedQuery(false, true)
+    val query = options.pruningMode.derivedQuery(false, true)
 
     val reachableClasses = sv.classes.values
       .filter(query.reachable)
@@ -112,21 +111,30 @@ class GraphQlGenerator(using sv: SchemaView) {
   /** Generate and serialize the GraphQL definitions, along with the linkml directives for rdf
     * interop.
     *
-    * @param pruningMode
-    *   How to prune the generated definitions, schemaRoot by default (elements reachable from any
-    *   root schema defined elements) to omit unnecessary linkml:types scalar definitions.
+    * @param options
+    *   What to generate. See [[GraphQlGenerator.Options]].
     */
   def serialize(
-      pruningMode: PruningMode = schemaRoot,
+      options: GraphQlGenerator.Options = GraphQlGenerator.Options(),
   ): String = {
     indent"""# GENERATED FROM LINKML
             |
-            |${generate(pruningMode).map(_.print.strip()).mkString("\n\n")}
+            |${generate(options).map(_.print.strip()).mkString("\n\n")}
             |""".stripMargin
   }
 }
 
 object GraphQlGenerator {
+
+  /** Options for [[GraphQlGenerator]].
+    *
+    * @param pruningMode
+    *   How to prune the generated definitions, schemaRoot by default (elements reachable from any
+    *   root schema defined elements) to omit unnecessary linkml:types scalar definitions.
+    */
+  final case class Options(
+      pruningMode: PruningMode = schemaRoot,
+  )
 
   /** Remap a runtime type to a GraphQL built-in scalar, if possible.
     */

--- a/generator/src/eu/neverblink/linkml/generator/jsonschema/JsonSchemaGenerator.scala
+++ b/generator/src/eu/neverblink/linkml/generator/jsonschema/JsonSchemaGenerator.scala
@@ -46,22 +46,16 @@ class JsonSchemaGenerator(using sv: SchemaView) {
 
   /** Generate the JSON Schema, but keep it in the [[Schema]] model
     *
-    * @param open
-    *   Whether the generated JSON Schema should allow `additionalProperties` for classes
-    * @param treeRootOverride
-    *   If defined, override the schema `tree_root` class with the one provided
-    * @param treeRootInlineTypeOverride
-    *   If defined, override the `tree_root_as` extension of the tree root class with the one
-    *   provided.
+    * @param options
+    *   What to generate. See [[JsonSchemaGenerator.Options]].
     * @return
     *   JSON Schema in the [[Schema]] model
     */
   final def generate(
-      open: Boolean = false,
-      treeRootOverride: Option[String] = None,
-      treeRootInlineTypeOverride: Option[String] = None,
+      options: JsonSchemaGenerator.Options = JsonSchemaGenerator.Options(),
   ): Schema = {
-    val maybeTreeRoot = sv.treeRootWithOverride(treeRootOverride) match {
+    import options.{open, treeRootInlineType => treeRootInlineTypeOverride}
+    val maybeTreeRoot = sv.treeRootWithOverride(options.treeRoot) match {
       case Success(value) => value
       case Failure(exception) => throw exception
     }
@@ -232,28 +226,40 @@ class JsonSchemaGenerator(using sv: SchemaView) {
 
   /** Generate the JSON Schema and serialize it
     *
-    * @param open
-    *   Whether the generated JSON Schema should allow `additionalProperties` for classes
-    * @param treeRootOverride
-    *   If defined, override the schema `tree_root` class with the one provided
-    * @param indentationStep
-    *   number of spaces in pretty print indentation of JSON Schema
+    * @param options
+    *   What to generate. See [[JsonSchemaGenerator.Options]].
     * @return
     *   Serialized JSON Schema
     */
   final def serialize(
-      open: Boolean = false,
-      treeRootOverride: Option[String] = None,
-      indentationStep: Int = 2,
-      treeRootInlineTypeOverride: Option[String] = None,
+      options: JsonSchemaGenerator.Options = JsonSchemaGenerator.Options(),
   ): String =
     writeToString(
-      generate(open, treeRootOverride, treeRootInlineTypeOverride),
-      WriterConfig.withIndentionStep(indentationStep),
+      generate(options),
+      WriterConfig.withIndentionStep(options.indentationStep),
     )
 }
 
 object JsonSchemaGenerator {
+
+  /** Options for [[JsonSchemaGenerator]].
+    *
+    * @param open
+    *   Whether the generated JSON Schema should allow `additionalProperties` for classes.
+    * @param treeRoot
+    *   If defined, override the schema `tree_root` class with the one provided.
+    * @param treeRootInlineType
+    *   If defined, override the `tree_root_as` extension of the tree root class with the one
+    *   provided. One of `plain`, `optional`, `list`, `compact_dict`, `simple_dict`.
+    * @param indentationStep
+    *   Number of spaces in pretty print indentation of the serialized JSON Schema.
+    */
+  final case class Options(
+      open: Boolean = false,
+      treeRoot: Option[String] = None,
+      treeRootInlineType: Option[String] = None,
+      indentationStep: Int = 2,
+  )
 
   /** Translate the [[RuntimeType]] of the provided type view into the appropriate JSON Schema.
     * Provides formats for date-times and URI/CURIE.

--- a/generator/src/eu/neverblink/linkml/generator/linkml/LinkMlGenerator.scala
+++ b/generator/src/eu/neverblink/linkml/generator/linkml/LinkMlGenerator.scala
@@ -111,7 +111,7 @@ object LinkMlGenerator {
     *   Output serialization format to use.
     */
   final case class Options(
-      pruningMode: PruningMode = PruningMode.treeRoot(None),
+      pruningMode: PruningMode = PruningMode.skip,
       skipClassDerivation: Boolean = false,
       outputFormat: OutputFormat = yaml,
   )

--- a/generator/src/eu/neverblink/linkml/generator/linkml/LinkMlGenerator.scala
+++ b/generator/src/eu/neverblink/linkml/generator/linkml/LinkMlGenerator.scala
@@ -12,17 +12,15 @@ class LinkMlGenerator(using sv: SchemaView) {
   /** Generate a derived [[SchemaDefinition]] based on the provided [[SchemaView]]. Merges imports,
     * runs class derivation and if a `tree_root` class is present, prunes the schema to only include
     * the reachable elements.
-    * @param pruningMode
-    *   Method to use for schema definition pruning
-    * @param skipClassDerivation
-    *   If true, will not derive classes and instead copy them as-is.
+    * @param options
+    *   What to generate. See [[LinkMlGenerator.Options]].
     * @return
     *   The derived [[SchemaDefinition]]
     */
   def generate(
-      pruningMode: PruningMode = PruningMode.treeRoot(None),
-      skipClassDerivation: Boolean = false,
+      options: LinkMlGenerator.Options = LinkMlGenerator.Options(),
   ): SchemaDefinitionImpl = {
+    import options.{pruningMode, skipClassDerivation}
     val query =
       if (skipClassDerivation) pruningMode.underivedQuery()
       else pruningMode.derivedQuery(false, false)
@@ -87,27 +85,37 @@ class LinkMlGenerator(using sv: SchemaView) {
     *
     * Merges imports, runs class derivation and if a `tree_root` class is present, prunes the schema
     * to only include the reachable elements.
-    * @param pruningMode
-    *   Method to use for schema definition pruning
-    * @param skipClassDerivation
-    *   If true, will not derive classes and instead copy them as-is.
-    * @param outputFormat
-    *   Output serialization format to use
+    * @param options
+    *   What to generate. See [[LinkMlGenerator.Options]].
     * @return
     *   The derived [[SchemaDefinition]]
     */
   def serialize(
-      pruningMode: PruningMode = PruningMode.treeRoot(None),
-      skipClassDerivation: Boolean = false,
-      outputFormat: OutputFormat = yaml,
+      options: LinkMlGenerator.Options = LinkMlGenerator.Options(),
   ): String = {
-    val node = Codec.codec.encode(generate(pruningMode, skipClassDerivation))
-    if (outputFormat == json) JsonUtil.yamlToJson(node)
+    val node = Codec.codec.encode(generate(options))
+    if (options.outputFormat == json) JsonUtil.yamlToJson(node)
     else node.asYaml
   }
 }
 
 object LinkMlGenerator {
+
+  /** Options for [[LinkMlGenerator]].
+    *
+    * @param pruningMode
+    *   Method to use for schema definition pruning.
+    * @param skipClassDerivation
+    *   If true, will not derive classes and instead copy them as-is.
+    * @param outputFormat
+    *   Output serialization format to use.
+    */
+  final case class Options(
+      pruningMode: PruningMode = PruningMode.treeRoot(None),
+      skipClassDerivation: Boolean = false,
+      outputFormat: OutputFormat = yaml,
+  )
+
   // TODO LNK-48: Don't do these horrible casts
   extension (inline classDef: ClassDefinition)
     private inline def impl: ClassDefinitionImpl = classDef.asInstanceOf

--- a/generator/src/eu/neverblink/linkml/generator/rdfs/RdfsGenerator.scala
+++ b/generator/src/eu/neverblink/linkml/generator/rdfs/RdfsGenerator.scala
@@ -46,13 +46,14 @@ class RdfsGenerator(using sv: SchemaView) extends RdfGenerator {
   /** Generates RDF Schema and pushes the namespaces and triples into the provided [[RdfSink]].
     * @param sink
     *   The sink that receives namespace declarations and triples.
-    * @param onlyClassesFromRootSchema
-    *   Whether to include only classes and enums from the root schema (turned off by default).
+    * @param options
+    *   What to generate. See [[RdfsGenerator.Options]].
     */
   final def generate(
       sink: RdfSink,
-      onlyClassesFromRootSchema: Boolean = false,
+      options: RdfsGenerator.Options = RdfsGenerator.Options(),
   ): Unit = {
+    import options.onlyClassesFromRootSchema
     addNamespaces(
       sink,
       Array(
@@ -132,4 +133,18 @@ class RdfsGenerator(using sv: SchemaView) extends RdfGenerator {
       }
     }
   }
+}
+
+object RdfsGenerator {
+
+  /** Options for [[RdfsGenerator]].
+    *
+    * @param onlyClassesFromRootSchema
+    *   Whether to include only classes and enums from the root schema (turned off by default). This
+    *   is useful if you intend to generate RDFS for each schema file separately, and you don't need
+    *   the imported classes to be included.
+    */
+  final case class Options(
+      onlyClassesFromRootSchema: Boolean = false,
+  )
 }

--- a/generator/src/eu/neverblink/linkml/generator/scala/ScalaGenerator.scala
+++ b/generator/src/eu/neverblink/linkml/generator/scala/ScalaGenerator.scala
@@ -14,14 +14,18 @@ final class ScalaGenerator(using sv: SchemaView) {
   import CombineFunction.*
 
   /** Generate Scala counterparts of all LinkML model elements: Classes, Types and Enums.
-    * @param pkg
-    *   Scala package to generate the classes in
+    * @param options
+    *   What to generate. See [[ScalaGenerator.Options]].
     * @return
     *   Tuples of form (file name, file content) for all elements in the LinkML model
     */
-  def generate(pkg: String, emitEmitPrefixes: Boolean = true): Iterable[(String, String)] =
+  def generate(
+      options: ScalaGenerator.Options = ScalaGenerator.Options(),
+  ): Iterable[(String, String)] = {
+    val pkg = options.`package`
     generateClasses(pkg) ++ generateEnums(pkg) ++ generateTypeDefinitions(pkg)
-      ++ (if emitEmitPrefixes then generateEmitPrefixes(pkg) else None)
+      ++ (if options.generateEmitPrefixes then generateEmitPrefixes(pkg) else None)
+  }
 
   /** Generate Scala counterparts of LinkML classes: case classe implementations for instantiable
     * classes, abstract class interfaces for non-mixin classes, traits for mixins, with LinkML
@@ -474,6 +478,18 @@ final class ScalaGenerator(using sv: SchemaView) {
 }
 
 object ScalaGenerator {
+
+  /** Options for [[ScalaGenerator]].
+    *
+    * @param package
+    *   Scala package to generate the classes in.
+    * @param generateEmitPrefixes
+    *   Whether to generate a `Prefixes` object holding the model's `emit_prefixes`.
+    */
+  final case class Options(
+      `package`: String = "eu.neverblink.linkml.metamodel",
+      generateEmitPrefixes: Boolean = true,
+  )
 
   /** Contains all information necessary for generating a Scala class/trait file analogous to a
     * LinkML [[ClassDefinition]]

--- a/generator/src/eu/neverblink/linkml/generator/shacl/ShaclGenerator.scala
+++ b/generator/src/eu/neverblink/linkml/generator/shacl/ShaclGenerator.scala
@@ -97,18 +97,14 @@ class ShaclGenerator(using sv: SchemaView) extends RdfGenerator {
     *
     * @param sink
     *   The sink that receives namespace declarations and triples.
-    * @param enforceOpenShapes
-    *   A flag that enforces all shapes to be open (turned off by default)
-    * @param onlyClassesFromRootSchema
-    *   Whether to include only classes from the root schema (turned off by default). This is useful
-    *   if you intend to generate SHACL shapes for each schema file separately, and you don't need
-    *   the imported classes to be included in the generated SHACL shapes.
+    * @param options
+    *   What to generate. See [[ShaclGenerator.Options]].
     */
   final def generate(
       sink: RdfSink,
-      enforceOpenShapes: Boolean = false,
-      onlyClassesFromRootSchema: Boolean = false,
+      options: ShaclGenerator.Options = ShaclGenerator.Options(),
   ): Unit = {
+    import options.{onlyClassesFromRootSchema, open}
     addNamespaces(
       sink,
       Array(
@@ -129,7 +125,7 @@ class ShaclGenerator(using sv: SchemaView) extends RdfGenerator {
       c.cls.description.foreachFast { d =>
         sink.triple(classNameIri, Rdfs.comment, Literal(d, XmlSchema.string))
       }
-      val closed = !(enforceOpenShapes || c.cls.`abstract` || c.cls.mixin)
+      val closed = !(open || c.cls.`abstract` || c.cls.mixin)
       sink.triple(classNameIri, Shacl.closed, Literal(closed.toString, XmlSchema.boolean))
       val ignoredPropertiesListHead = addList(
         sink,
@@ -147,4 +143,22 @@ class ShaclGenerator(using sv: SchemaView) extends RdfGenerator {
       sink.triple(classNameIri, Shacl.targetClass, classNameIri)
     }
   }
+}
+
+object ShaclGenerator {
+
+  /** Options for [[ShaclGenerator]].
+    *
+    * @param open
+    *   Whether the generated shapes should be open, allowing properties the schema does not mention
+    *   (turned off by default).
+    * @param onlyClassesFromRootSchema
+    *   Whether to include only classes from the root schema (turned off by default). This is useful
+    *   if you intend to generate SHACL shapes for each schema file separately, and you don't need
+    *   the imported classes to be included in the generated SHACL shapes.
+    */
+  final case class Options(
+      open: Boolean = false,
+      onlyClassesFromRootSchema: Boolean = false,
+  )
 }

--- a/generator/src/eu/neverblink/linkml/generator/tableschema/TableSchemaGenerator.scala
+++ b/generator/src/eu/neverblink/linkml/generator/tableschema/TableSchemaGenerator.scala
@@ -35,14 +35,15 @@ class TableSchemaGenerator(using sv: SchemaView) {
 
   /** Generate the Table Schema
     *
-    * @param treeRootOverride
-    *   If defined, override the schema `tree_root` class with the one provided
-    *
+    * @param options
+    *   What to generate. See [[TableSchemaGenerator.Options]].
     * @return
     *   Generated Table Schema (Table Descriptor)
     */
-  def generate(treeRootOverride: Option[String] = None): TableDescriptor = {
-    val root: ClassView = sv.treeRootWithOverride(treeRootOverride)
+  def generate(
+      options: TableSchemaGenerator.Options = TableSchemaGenerator.Options(),
+  ): TableDescriptor = {
+    val root: ClassView = sv.treeRootWithOverride(options.treeRoot)
       .get.getOrElseFast(throw RuntimeException("No tree root - can't generate table schema"))
     val fields =
       for slotView <- root.derivedAttributes.values.toSeq.sortBy(s => (s.slot.rank, s.slot.name))
@@ -123,19 +124,31 @@ class TableSchemaGenerator(using sv: SchemaView) {
 
   /** Generate the Table Schema and serialize
     *
-    * @param treeRootOverride
-    *   If defined, override the schema `tree_root` class with the one provided
+    * @param options
+    *   What to generate. See [[TableSchemaGenerator.Options]].
     * @return
     *   Generated Table Schema (Table Descriptor)
     */
-  def serialize(treeRootOverride: Option[String] = None): String =
+  def serialize(
+      options: TableSchemaGenerator.Options = TableSchemaGenerator.Options(),
+  ): String =
     writeToString(
-      generate(treeRootOverride),
+      generate(options),
       WriterConfig.withIndentionStep(2),
     )(using TableSchemaGenerator.tableDescriptorCodec)
 }
 
 object TableSchemaGenerator {
+
+  /** Options for [[TableSchemaGenerator]].
+    *
+    * @param treeRoot
+    *   If defined, override the schema `tree_root` class with the one provided.
+    */
+  final case class Options(
+      treeRoot: Option[String] = None,
+  )
+
   private[tableschema] implicit val tableDescriptorCodec: JsonValueCodec[TableDescriptor] =
     JsonCodecMaker.make(
       CodecMakerConfig.withEncodingOnly(true)

--- a/generator/test/src-jvm/eu/neverblink/linkml/generator/BenchmarkSchemaSpec.scala
+++ b/generator/test/src-jvm/eu/neverblink/linkml/generator/BenchmarkSchemaSpec.scala
@@ -104,7 +104,9 @@ class BenchmarkSchemaSpec extends AnyWordSpec, Matchers {
           "LinkML (YAML) output parses as YAML" in {
             assume(!skip.contains((name, "linkml-yaml")), skip.getOrElse((name, "linkml-yaml"), ""))
             assertParsesAsYaml(
-              LinkMlGenerator(using sv).serialize(outputFormat = LinkMlGenerator.OutputFormat.yaml),
+              LinkMlGenerator(using sv).serialize(
+                LinkMlGenerator.Options(outputFormat = LinkMlGenerator.OutputFormat.yaml),
+              ),
             )
           }
 
@@ -112,13 +114,15 @@ class BenchmarkSchemaSpec extends AnyWordSpec, Matchers {
             assume(!skip.contains((name, "linkml-json")), skip.getOrElse((name, "linkml-json"), ""))
             assertParsesAsJson(
               name,
-              LinkMlGenerator(using sv).serialize(outputFormat = LinkMlGenerator.OutputFormat.json),
+              LinkMlGenerator(using sv).serialize(
+                LinkMlGenerator.Options(outputFormat = LinkMlGenerator.OutputFormat.json),
+              ),
             )
           }
 
           "ER diagram output is a well-formed Mermaid document" in {
             assume(!skip.contains((name, "er-diagram")), skip.getOrElse((name, "er-diagram"), ""))
-            val diagram = ErDiagramGenerator(using sv).serialize(PruningMode.skip)
+            val diagram = ErDiagramGenerator(using sv).serialize(ErDiagramGenerator.Options(PruningMode.skip))
             diagram should include("erDiagram")
             withClue("output has no entities: ") {
               diagram.linesIterator.count(_.startsWith("  ")) should be > 0
@@ -127,7 +131,7 @@ class BenchmarkSchemaSpec extends AnyWordSpec, Matchers {
 
           "Scala output is non-empty" in {
             assume(!skip.contains((name, "scala")), skip.getOrElse((name, "scala"), ""))
-            val files = ScalaGenerator(using sv).generate("eu.neverblink.linkml.generated").toSeq
+            val files = ScalaGenerator(using sv).generate(ScalaGenerator.Options("eu.neverblink.linkml.generated")).toSeq
             files should not be empty
             files.foreach { case (fileName, contents) =>
               withClue(s"generated Scala file '$fileName' is empty: ") {

--- a/generator/test/src-jvm/eu/neverblink/linkml/generator/BenchmarkSchemaSpec.scala
+++ b/generator/test/src-jvm/eu/neverblink/linkml/generator/BenchmarkSchemaSpec.scala
@@ -122,7 +122,8 @@ class BenchmarkSchemaSpec extends AnyWordSpec, Matchers {
 
           "ER diagram output is a well-formed Mermaid document" in {
             assume(!skip.contains((name, "er-diagram")), skip.getOrElse((name, "er-diagram"), ""))
-            val diagram = ErDiagramGenerator(using sv).serialize(ErDiagramGenerator.Options(PruningMode.skip))
+            val diagram =
+              ErDiagramGenerator(using sv).serialize(ErDiagramGenerator.Options(PruningMode.skip))
             diagram should include("erDiagram")
             withClue("output has no entities: ") {
               diagram.linesIterator.count(_.startsWith("  ")) should be > 0
@@ -131,7 +132,9 @@ class BenchmarkSchemaSpec extends AnyWordSpec, Matchers {
 
           "Scala output is non-empty" in {
             assume(!skip.contains((name, "scala")), skip.getOrElse((name, "scala"), ""))
-            val files = ScalaGenerator(using sv).generate(ScalaGenerator.Options("eu.neverblink.linkml.generated")).toSeq
+            val files = ScalaGenerator(using sv).generate(
+              ScalaGenerator.Options("eu.neverblink.linkml.generated"),
+            ).toSeq
             files should not be empty
             files.foreach { case (fileName, contents) =>
               withClue(s"generated Scala file '$fileName' is empty: ") {
@@ -176,5 +179,6 @@ object BenchmarkSchemaSpec {
     "nmdc_microbiome" -> "linkml-yaml" -> "TODO LNK-167",
     "nmdc_microbiome" -> "linkml-json" -> "TODO LNK-167",
     "nmdc_microbiome" -> "er-diagram" -> "TODO LNK-167",
+    "cdm" -> "linkml-yaml" -> "LNK-185: unpruned output does not parse back with scala-yaml",
   )
 }

--- a/generator/test/src-jvm/eu/neverblink/linkml/generator/BindingCoverageSpec.scala
+++ b/generator/test/src-jvm/eu/neverblink/linkml/generator/BindingCoverageSpec.scala
@@ -40,7 +40,42 @@ class BindingCoverageSpec extends AnyWordSpec, Matchers {
       .sorted
   }
 
+  /** The commands the CLI actually registers. A `generate` command that exists but is not in this
+    * list cannot be run, so the list is what matters rather than the file defining it.
+    */
+  private def cliCommands(root: os.Path): Set[String] = {
+    val app = os.read(root / "cli" / "src" / "eu" / "neverblink" / "linkml" / "cli" / "App.scala")
+    val block = "override def commands: Seq\\[Command\\[\\?\\]\\] = Seq\\(([^)]*)\\)".r
+      .findFirstMatchIn(app)
+      .map(_.group(1))
+      .getOrElse(fail("could not find the command list in App.scala"))
+    block.split(',').map(_.trim).filter(_.nonEmpty).toSet
+  }
+
+  /** The generator ids offered by the playground's target list. */
+  private def playgroundTargets(root: os.Path): Set[String] =
+    "id: \"(\\w+)\"".r
+      .findAllMatchIn(os.read(root / "ui" / "targets.ts"))
+      .map(_.group(1))
+      .toSet
+
   "every generator" should {
+    "be registered as a CLI command" in {
+      val root = repoRoot.getOrElse(cancel("LINKML_REPO_ROOT is not set"))
+      val registered = cliCommands(root)
+      // The CLI names its commands after the generator, minus the suffix: ShaclGenerator -> Shacl.
+      val missing = generators(root).map(_.stripSuffix("Generator")).filterNot(registered)
+      withClue("add a Generate command and register it in App.scala: ")(missing shouldBe empty)
+    }
+
+    "be offered by the playground" in {
+      val root = repoRoot.getOrElse(cancel("LINKML_REPO_ROOT is not set"))
+      val targets = playgroundTargets(root)
+      // The playground drives the JS API, so its target ids are the facade's method names.
+      val missing = jsMethods(root).filterNot(targets)
+      withClue("add a target to ui/targets.ts, then run ./mill uiCheck: ")(missing shouldBe empty)
+    }
+
     "be listed in the shared entry-point table" in {
       val root = repoRoot.getOrElse(cancel("LINKML_REPO_ROOT is not set"))
       val table = os.read(root / "mill-build" / "src" / "Entrypoints.scala")

--- a/generator/test/src-jvm/eu/neverblink/linkml/generator/BindingCoverageSpec.scala
+++ b/generator/test/src-jvm/eu/neverblink/linkml/generator/BindingCoverageSpec.scala
@@ -1,0 +1,120 @@
+package eu.neverblink.linkml.generator
+
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
+
+/** Checks that every generator is reachable from every binding.
+  *
+  * It reads the repository's own sources, so it needs to know where the checkout is;
+  * `generator.jvm.test.forkEnv` passes `LINKML_REPO_ROOT`.
+  */
+class BindingCoverageSpec extends AnyWordSpec, Matchers {
+
+  private val repoRoot: Option[os.Path] =
+    sys.env.get("LINKML_REPO_ROOT").map(os.Path(_)).filter(os.exists)
+
+  /** Every generator in the generator module: a `*Generator.scala` declaring an `Options` case
+    * class. The `Options` is what makes it a public generator rather than an internal helper.
+    */
+  private def generators(root: os.Path): Seq[String] = {
+    val dir = root / "generator" / "src" / "eu" / "neverblink" / "linkml" / "generator"
+    os.walk(dir)
+      .filter(p => p.last.endsWith("Generator.scala"))
+      .filter(p => os.read(p).contains("final case class Options("))
+      .map(_.last.stripSuffix(".scala"))
+      .sorted
+  }
+
+  /** The JavaScript facade's public methods that operate on a loaded schema, which is every
+    * generator plus `lint`. Read from the facade because the JS names are not derivable from the
+    * generator names.
+    */
+  private def jsMethods(root: os.Path): Seq[String] = {
+    val facade = os.read(
+      root / "generator" / "src-js" / "eu" / "neverblink" / "linkml" / "js" / "LinkMlJsApi.scala",
+    )
+    "def (\\w+)\\(\\s*schema: SchemaViewJs".r
+      .findAllMatchIn(facade)
+      .map(_.group(1))
+      .toSeq
+      .sorted
+  }
+
+  "every generator" should {
+    "be listed in the shared entry-point table" in {
+      val root = repoRoot.getOrElse(cancel("LINKML_REPO_ROOT is not set"))
+      val table = os.read(root / "mill-build" / "src" / "Entrypoints.scala")
+      val missing = generators(root).filterNot(name => table.contains(s"\"$name\""))
+      withClue(
+        "add a row to mill-build/src/Entrypoints.scala, then run ./mill bindings: ",
+      )(missing shouldBe empty)
+    }
+
+    "be exposed by the JavaScript facade" in {
+      val root = repoRoot.getOrElse(cancel("LINKML_REPO_ROOT is not set"))
+      val facade =
+        os.read(
+          root / "generator" / "src-js" / "eu" / "neverblink" / "linkml" / "js" / "LinkMlJsApi.scala",
+        )
+      val missing = generators(root).filterNot(facade.contains)
+      withClue("add a method to LinkMlJsApi.scala, then run ./mill uiTypes: ")(
+        missing shouldBe empty,
+      )
+    }
+
+    "be exposed by the native library's Scala facade" in {
+      val root = repoRoot.getOrElse(cancel("LINKML_REPO_ROOT is not set"))
+      val facade = os.read(
+        root / "nativelib" / "src" / "eu" / "neverblink" / "linkml" / "nativelib" /
+          "LinkMlNativeApi.scala",
+      )
+      val missing = generators(root).filterNot(facade.contains)
+      withClue("add a method to LinkMlNativeApi.scala: ")(missing shouldBe empty)
+    }
+
+    "be exposed as a C entry point" in {
+      val root = repoRoot.getOrElse(cancel("LINKML_REPO_ROOT is not set"))
+      val generated = os.read(
+        root / "nativelib" / "src" / "eu" / "neverblink" / "linkml" / "nativelib" /
+          "LinkMlCGenerators.java",
+      )
+      // Generated from the table, so this catches a stale checked-in copy rather than a missing row.
+      val exported = "@CEntryPoint\\(name = \"(\\w+)\"\\)".r.findAllMatchIn(generated).size
+      withClue("run ./mill bindings and commit the result: ")(
+        exported shouldBe generators(root).size,
+      )
+    }
+
+    "be exposed as a Python method" in {
+      val root = repoRoot.getOrElse(cancel("LINKML_REPO_ROOT is not set"))
+      val generated = os.read(root / "python" / "linkml_scala" / "_generated.py")
+      val methods = "\\n    def (\\w+)\\(".r.findAllMatchIn(generated).size
+      withClue("run ./mill bindings and commit the result: ")(
+        methods shouldBe generators(root).size,
+      )
+    }
+
+    "be documented in the npm module's README" in {
+      val root = repoRoot.getOrElse(cancel("LINKML_REPO_ROOT is not set"))
+      val readme = os.read(root / "generator" / "npm" / "README.md")
+      // Taken from the facade rather than derived from the generator names, because the JS spelling
+      // is not mechanical: LinkMlGenerator is `linkml`, not `linkMl`. This also covers `lint`.
+      val missing = jsMethods(root).filterNot(readme.contains)
+      withClue("add it to the API table in generator/npm/README.md: ")(missing shouldBe empty)
+    }
+
+    "be documented in the Python bindings guide" in {
+      val root = repoRoot.getOrElse(cancel("LINKML_REPO_ROOT is not set"))
+      val docs = os.read(root / "docs" / "python_bindings.md")
+      // The doc lists the Python method names, so check those rather than the Scala class names.
+      val pythonNames = "\\n    def (\\w+)\\(".r
+        .findAllMatchIn(os.read(root / "python" / "linkml_scala" / "_generated.py"))
+        .map(_.group(1))
+        .toSeq
+      val missing = pythonNames.filterNot(name => docs.contains(s"schema.$name("))
+      withClue("add it to the Generating section of docs/python_bindings.md: ")(
+        missing shouldBe empty,
+      )
+    }
+  }
+}

--- a/generator/test/src-jvm/eu/neverblink/linkml/generator/BindingCoverageSpec.scala
+++ b/generator/test/src-jvm/eu/neverblink/linkml/generator/BindingCoverageSpec.scala
@@ -11,7 +11,7 @@ import org.scalatest.wordspec.AnyWordSpec
 class BindingCoverageSpec extends AnyWordSpec, Matchers {
 
   private val repoRoot: Option[os.Path] =
-    sys.env.get("LINKML_REPO_ROOT").map(os.Path(_)).filter(os.exists)
+    sys.env.get("MILL_WORKSPACE_ROOT").map(os.Path(_)).filter(os.exists)
 
   /** Every generator in the generator module: a `*Generator.scala` declaring an `Options` case
     * class. The `Options` is what makes it a public generator rather than an internal helper.
@@ -61,7 +61,7 @@ class BindingCoverageSpec extends AnyWordSpec, Matchers {
 
   "every generator" should {
     "be registered as a CLI command" in {
-      val root = repoRoot.getOrElse(cancel("LINKML_REPO_ROOT is not set"))
+      val root = repoRoot.getOrElse(cancel("MILL_WORKSPACE_ROOT is not set"))
       val registered = cliCommands(root)
       // The CLI names its commands after the generator, minus the suffix: ShaclGenerator -> Shacl.
       val missing = generators(root).map(_.stripSuffix("Generator")).filterNot(registered)
@@ -69,7 +69,7 @@ class BindingCoverageSpec extends AnyWordSpec, Matchers {
     }
 
     "be offered by the playground" in {
-      val root = repoRoot.getOrElse(cancel("LINKML_REPO_ROOT is not set"))
+      val root = repoRoot.getOrElse(cancel("MILL_WORKSPACE_ROOT is not set"))
       val targets = playgroundTargets(root)
       // The playground drives the JS API, so its target ids are the facade's method names.
       val missing = jsMethods(root).filterNot(targets)
@@ -77,7 +77,7 @@ class BindingCoverageSpec extends AnyWordSpec, Matchers {
     }
 
     "be listed in the shared entry-point table" in {
-      val root = repoRoot.getOrElse(cancel("LINKML_REPO_ROOT is not set"))
+      val root = repoRoot.getOrElse(cancel("MILL_WORKSPACE_ROOT is not set"))
       val table = os.read(root / "mill-build" / "src" / "Entrypoints.scala")
       val missing = generators(root).filterNot(name => table.contains(s"\"$name\""))
       withClue(
@@ -86,7 +86,7 @@ class BindingCoverageSpec extends AnyWordSpec, Matchers {
     }
 
     "be exposed by the JavaScript facade" in {
-      val root = repoRoot.getOrElse(cancel("LINKML_REPO_ROOT is not set"))
+      val root = repoRoot.getOrElse(cancel("MILL_WORKSPACE_ROOT is not set"))
       val facade =
         os.read(
           root / "generator" / "src-js" / "eu" / "neverblink" / "linkml" / "js" / "LinkMlJsApi.scala",
@@ -98,7 +98,7 @@ class BindingCoverageSpec extends AnyWordSpec, Matchers {
     }
 
     "be exposed by the native library's Scala facade" in {
-      val root = repoRoot.getOrElse(cancel("LINKML_REPO_ROOT is not set"))
+      val root = repoRoot.getOrElse(cancel("MILL_WORKSPACE_ROOT is not set"))
       val facade = os.read(
         root / "nativelib" / "src" / "eu" / "neverblink" / "linkml" / "nativelib" /
           "LinkMlNativeApi.scala",
@@ -108,7 +108,7 @@ class BindingCoverageSpec extends AnyWordSpec, Matchers {
     }
 
     "be exposed as a C entry point" in {
-      val root = repoRoot.getOrElse(cancel("LINKML_REPO_ROOT is not set"))
+      val root = repoRoot.getOrElse(cancel("MILL_WORKSPACE_ROOT is not set"))
       val generated = os.read(
         root / "nativelib" / "src" / "eu" / "neverblink" / "linkml" / "nativelib" /
           "LinkMlCGenerators.java",
@@ -121,7 +121,7 @@ class BindingCoverageSpec extends AnyWordSpec, Matchers {
     }
 
     "be exposed as a Python method" in {
-      val root = repoRoot.getOrElse(cancel("LINKML_REPO_ROOT is not set"))
+      val root = repoRoot.getOrElse(cancel("MILL_WORKSPACE_ROOT is not set"))
       val generated = os.read(root / "python" / "linkml_scala" / "_generated.py")
       val methods = "\\n    def (\\w+)\\(".r.findAllMatchIn(generated).size
       withClue("run ./mill bindings and commit the result: ")(
@@ -130,7 +130,7 @@ class BindingCoverageSpec extends AnyWordSpec, Matchers {
     }
 
     "be documented in the npm module's README" in {
-      val root = repoRoot.getOrElse(cancel("LINKML_REPO_ROOT is not set"))
+      val root = repoRoot.getOrElse(cancel("MILL_WORKSPACE_ROOT is not set"))
       val readme = os.read(root / "generator" / "npm" / "README.md")
       // Taken from the facade rather than derived from the generator names, because the JS spelling
       // is not mechanical: LinkMlGenerator is `linkml`, not `linkMl`. This also covers `lint`.
@@ -139,7 +139,7 @@ class BindingCoverageSpec extends AnyWordSpec, Matchers {
     }
 
     "be documented in the Python bindings guide" in {
-      val root = repoRoot.getOrElse(cancel("LINKML_REPO_ROOT is not set"))
+      val root = repoRoot.getOrElse(cancel("MILL_WORKSPACE_ROOT is not set"))
       val docs = os.read(root / "docs" / "python_bindings.md")
       // The doc lists the Python method names, so check those rather than the Scala class names.
       val pythonNames = "\\n    def (\\w+)\\(".r

--- a/generator/test/src-jvm/eu/neverblink/linkml/generator/erdiagram/ErDiagramMermaidSpec.scala
+++ b/generator/test/src-jvm/eu/neverblink/linkml/generator/erdiagram/ErDiagramMermaidSpec.scala
@@ -151,7 +151,7 @@ class ErDiagramMermaidSpec extends AnyWordSpec, Matchers, ModelCatalogueSpec {
       (
         "cardinalityWithoutOptionalMarker",
         ErDiagramGenerator(using ModelCatalogue.cardinality.model)
-          .generate(optionalMarker = false),
+          .generate(ErDiagramGenerator.Options(optionalMarker = false)),
       )
 
   /** Generated diagrams, and what Mermaid made of them. Both are computed once: Node startup costs

--- a/generator/test/src-jvm/eu/neverblink/linkml/generator/rdfs/RdfsGeneratorSpec.scala
+++ b/generator/test/src-jvm/eu/neverblink/linkml/generator/rdfs/RdfsGeneratorSpec.scala
@@ -264,7 +264,8 @@ class RdfsGeneratorSpec extends AnyWordSpec, Matchers {
         SchemaView.loadSchemaViewFromUri("https://w3id.org/linkml/annotations"),
       )
       val turtle =
-        RdfUtils.toTurtle(RdfsGenerator(using sv).generate(_, onlyClassesFromRootSchema = true))
+        RdfUtils.toTurtle(RdfsGenerator(using sv)
+            .generate(_, RdfsGenerator.Options(onlyClassesFromRootSchema = true)))
       turtle should include("linkml:Annotatable a rdfs:Class")
       turtle should include("linkml:Annotation a rdfs:Class")
       turtle should not include "linkml:Any a rdfs:Class"

--- a/generator/test/src-jvm/eu/neverblink/linkml/generator/scala/ScalaGeneratorCompileSpec.scala
+++ b/generator/test/src-jvm/eu/neverblink/linkml/generator/scala/ScalaGeneratorCompileSpec.scala
@@ -41,7 +41,7 @@ class ScalaGeneratorCompileSpec extends AnyWordSpec, Matchers, ModelCatalogueSpe
       s"generate compilable code for model '${entry.name}'" in {
         processSkip(entry.name, "")
         val dir = os.temp.dir(prefix = "linkml-scala-src")
-        val sources = ScalaGenerator(using entry.model).generate("generated").map {
+        val sources = ScalaGenerator(using entry.model).generate(ScalaGenerator.Options("generated")).map {
           (name, content) =>
             val file = dir / name
             os.write(file, content)

--- a/generator/test/src-jvm/eu/neverblink/linkml/generator/shacl/ShaclGeneratorSpec.scala
+++ b/generator/test/src-jvm/eu/neverblink/linkml/generator/shacl/ShaclGeneratorSpec.scala
@@ -102,7 +102,7 @@ class ShaclGeneratorSpec extends AnyWordSpec, Matchers {
            |""".stripMargin
       val schemaView = loadWithImports(input)
       val turtle =
-        RdfUtils.toTurtle(ShaclGenerator(using schemaView).generate(_, enforceOpenShapes = true))
+        RdfUtils.toTurtle(ShaclGenerator(using schemaView).generate(_, ShaclGenerator.Options(open = true)))
       val expected =
         """@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
           |@prefix sh: <http://www.w3.org/ns/shacl#> .
@@ -487,7 +487,8 @@ class ShaclGeneratorSpec extends AnyWordSpec, Matchers {
         SchemaView.loadSchemaViewFromUri("https://w3id.org/linkml/annotations"),
       )
       val turtle =
-        RdfUtils.toTurtle(ShaclGenerator(using sv).generate(_, onlyClassesFromRootSchema = true))
+        RdfUtils.toTurtle(ShaclGenerator(using sv)
+            .generate(_, ShaclGenerator.Options(onlyClassesFromRootSchema = true)))
       turtle should include("linkml:Annotatable a sh:NodeShape")
       turtle should include("linkml:Annotation a sh:NodeShape")
       turtle should not include "linkml:Any a sh:NodeShape"

--- a/generator/test/src/eu/neverblink/linkml/generator/erdiagram/ErDiagramGeneratorSpec.scala
+++ b/generator/test/src/eu/neverblink/linkml/generator/erdiagram/ErDiagramGeneratorSpec.scala
@@ -56,7 +56,7 @@ class ErDiagramGeneratorSpec extends AnyWordSpec, Matchers {
     "omit the optional marker when asked, for renderers older than Mermaid 11.16" in {
       given SchemaView = ModelCatalogue.cardinality.model
 
-      val result = ErDiagramGenerator().serialize(optionalMarker = false)
+      val result = ErDiagramGenerator().serialize(ErDiagramGenerator.Options(optionalMarker = false))
       Seq(
         "string one",
         "string atMostOne",
@@ -216,7 +216,7 @@ class ErDiagramGeneratorSpec extends AnyWordSpec, Matchers {
     "prune in tree_root mode if requested" in {
       given SchemaView = ModelCatalogue.pruning.model
 
-      val result = ErDiagramGenerator().serialize(pruningMode = PruningMode.treeRoot(None))
+      val result = ErDiagramGenerator().serialize(ErDiagramGenerator.Options(PruningMode.treeRoot(None)))
       result should include("SomeClass {")
       result should not include "NotTreeRootClass"
     }
@@ -225,7 +225,8 @@ class ErDiagramGeneratorSpec extends AnyWordSpec, Matchers {
       given SchemaView = ModelCatalogue.pruning.model
 
       val result =
-        ErDiagramGenerator().serialize(pruningMode = PruningMode.treeRoot(Some("NotTreeRootClass")))
+        ErDiagramGenerator()
+          .serialize(ErDiagramGenerator.Options(PruningMode.treeRoot(Some("NotTreeRootClass"))))
       result should include("NotTreeRootClass {")
       result should not include "SomeClass {"
     }

--- a/generator/test/src/eu/neverblink/linkml/generator/graphql/GraphQlGeneratorSpec.scala
+++ b/generator/test/src/eu/neverblink/linkml/generator/graphql/GraphQlGeneratorSpec.scala
@@ -189,7 +189,7 @@ class GraphQlGeneratorSpec extends AnyWordSpec, Matchers {
     "include unused linkml:types elements if requested" in {
       given SchemaView = ModelCatalogue.reference.model
 
-      val result = GraphQlGenerator().serialize(pruningMode = skip)
+      val result = GraphQlGenerator().serialize(GraphQlGenerator.Options(skip))
       Seq(
         "scalar uri",
         "scalar uriorcurie",
@@ -202,7 +202,7 @@ class GraphQlGeneratorSpec extends AnyWordSpec, Matchers {
     "prune in tree_root mode if requested" in {
       given SchemaView = ModelCatalogue.pruning.model
 
-      val result = GraphQlGenerator().serialize(pruningMode = PruningMode.treeRoot(None))
+      val result = GraphQlGenerator().serialize(GraphQlGenerator.Options(PruningMode.treeRoot(None)))
       Seq(
         "type SomeClass",
         "interface SomeOtherClass",
@@ -223,7 +223,7 @@ class GraphQlGeneratorSpec extends AnyWordSpec, Matchers {
       given SchemaView = ModelCatalogue.pruning.model
 
       val result =
-        GraphQlGenerator().serialize(pruningMode = PruningMode.treeRoot(Some("NotTreeRootClass")))
+        GraphQlGenerator().serialize(GraphQlGenerator.Options(PruningMode.treeRoot(Some("NotTreeRootClass"))))
       Seq(
         "type NotTreeRootClass",
       ).foreach { snippet =>

--- a/generator/test/src/eu/neverblink/linkml/generator/jsonschema/JsonSchemaGeneratorSpec.scala
+++ b/generator/test/src/eu/neverblink/linkml/generator/jsonschema/JsonSchemaGeneratorSpec.scala
@@ -705,7 +705,7 @@ class JsonSchemaGeneratorSpec extends AnyWordSpec, Matchers {
           ),
         )
 
-        JsonSchemaGenerator().generate(treeRootInlineTypeOverride = Some("plain"))
+        JsonSchemaGenerator().generate(JsonSchemaGenerator.Options(treeRootInlineType = Some("plain")))
           .$ref shouldBe Some("#/$defs/C1")
       }
 
@@ -716,7 +716,7 @@ class JsonSchemaGeneratorSpec extends AnyWordSpec, Matchers {
           ),
         )
 
-        val schema = JsonSchemaGenerator().generate(treeRootInlineTypeOverride = Some("optional"))
+        val schema = JsonSchemaGenerator().generate(JsonSchemaGenerator.Options(treeRootInlineType = Some("optional")))
 
         schema.oneOf.map(
           _.asInstanceOf[Schema].$ref,
@@ -734,7 +734,7 @@ class JsonSchemaGeneratorSpec extends AnyWordSpec, Matchers {
           ),
         )
 
-        val schema = JsonSchemaGenerator().generate(treeRootInlineTypeOverride = Some("list"))
+        val schema = JsonSchemaGenerator().generate(JsonSchemaGenerator.Options(treeRootInlineType = Some("list")))
 
         schema.`type` shouldBe Some(List(SchemaType.Array))
 
@@ -751,7 +751,7 @@ class JsonSchemaGeneratorSpec extends AnyWordSpec, Matchers {
         )
 
         val schema =
-          JsonSchemaGenerator().generate(treeRootInlineTypeOverride = Some("compact_dict"))
+          JsonSchemaGenerator().generate(JsonSchemaGenerator.Options(treeRootInlineType = Some("compact_dict")))
 
         schema.additionalProperties.get.asInstanceOf[Schema]
           .$ref shouldBe Some("#/$defs/C1__identifier_optional")
@@ -767,7 +767,7 @@ class JsonSchemaGeneratorSpec extends AnyWordSpec, Matchers {
         )
 
         val schema =
-          JsonSchemaGenerator().generate(treeRootInlineTypeOverride = Some("simple_dict"))
+          JsonSchemaGenerator().generate(JsonSchemaGenerator.Options(treeRootInlineType = Some("simple_dict")))
 
         schema.additionalProperties.get.asInstanceOf[Schema]
           .$ref shouldBe Some("#/$defs/C1__simple_dict_value")
@@ -833,8 +833,8 @@ class JsonSchemaGeneratorSpec extends AnyWordSpec, Matchers {
         SchemaIssues.orThrow(SchemaView.loadSchemaViewFromUri("https://w3id.org/linkml/meta"))
       given SchemaView = sv
       val generator = JsonSchemaGenerator()
-      val expected = encoderSchema(generator.generate(false, None)).noSpaces
-      val result = generator.serialize(indentationStep = 0)
+      val expected = encoderSchema(generator.generate(JsonSchemaGenerator.Options())).noSpaces
+      val result = generator.serialize(JsonSchemaGenerator.Options(indentationStep = 0))
       result shouldBe expected
     }
 
@@ -843,8 +843,8 @@ class JsonSchemaGeneratorSpec extends AnyWordSpec, Matchers {
         s"model '${entry.model.root.name}'" in {
           assume(!skipModels.contains(entry.model.root.name))
           val generator = JsonSchemaGenerator(using entry.model)
-          val expected = encoderSchema(generator.generate(false, None)).noSpaces
-          val result = generator.serialize(indentationStep = 0)
+          val expected = encoderSchema(generator.generate(JsonSchemaGenerator.Options())).noSpaces
+          val result = generator.serialize(JsonSchemaGenerator.Options(indentationStep = 0))
           result shouldBe expected
         }
     }

--- a/generator/test/src/eu/neverblink/linkml/generator/linkml/LinkMlGeneratorSpec.scala
+++ b/generator/test/src/eu/neverblink/linkml/generator/linkml/LinkMlGeneratorSpec.scala
@@ -13,7 +13,7 @@ class LinkMlGeneratorSpec extends AnyWordSpec, Matchers {
     "inline imports into the schema" in {
       val sv = ModelCatalogue.pruning.model
       val schema =
-        LinkMlGenerator(using sv).generate(skipClassDerivation = true, pruningMode = skip)
+        LinkMlGenerator(using sv).generate(LinkMlGenerator.Options(pruningMode = skip, skipClassDerivation = true))
       schema.classes.keys should contain theSameElementsAs Seq(
         "NotTreeRootClass",
         "SomeClass",
@@ -27,7 +27,9 @@ class LinkMlGeneratorSpec extends AnyWordSpec, Matchers {
     "prune unused elements from the schema (tree_root)" in {
       val sv = ModelCatalogue.pruning.model
       val schema =
-        LinkMlGenerator(using sv).generate(skipClassDerivation = true, pruningMode = treeRoot(None))
+        LinkMlGenerator(using sv).generate(
+          LinkMlGenerator.Options(pruningMode = treeRoot(None), skipClassDerivation = true),
+        )
       schema.classes.keys should contain theSameElementsAs Seq(
         "SomeClass",
         "SomeOtherClass",
@@ -47,8 +49,10 @@ class LinkMlGeneratorSpec extends AnyWordSpec, Matchers {
     "prune unused elements from the schema (tree_root override)" in {
       val sv = ModelCatalogue.pruning.model
       val schema = LinkMlGenerator(using sv).generate(
-        skipClassDerivation = true,
-        pruningMode = treeRoot(Some("NotTreeRootClass")),
+        LinkMlGenerator.Options(
+          pruningMode = treeRoot(Some("NotTreeRootClass")),
+          skipClassDerivation = true,
+        ),
       )
       schema.classes.keys should contain theSameElementsAs Seq(
         "NotTreeRootClass",
@@ -66,7 +70,7 @@ class LinkMlGeneratorSpec extends AnyWordSpec, Matchers {
     "prune unused elements from the schema (root schema)" in {
       val sv = ModelCatalogue.pruning.model
       val schema =
-        LinkMlGenerator(using sv).generate(skipClassDerivation = true, pruningMode = schemaRoot)
+        LinkMlGenerator(using sv).generate(LinkMlGenerator.Options(pruningMode = schemaRoot, skipClassDerivation = true))
       schema.classes.keys should contain theSameElementsAs Seq(
         "NotTreeRootClass",
         "SomeClass",
@@ -85,7 +89,7 @@ class LinkMlGeneratorSpec extends AnyWordSpec, Matchers {
 
     "derive classes and clear relevant slots (skip pruning)" in {
       val sv = ModelCatalogue.pruning.model
-      val schema = LinkMlGenerator(using sv).generate(pruningMode = skip)
+      val schema = LinkMlGenerator(using sv).generate(LinkMlGenerator.Options(pruningMode = skip))
       schema.classes.keys should contain theSameElementsAs Seq(
         "NotTreeRootClass",
         "SomeClass",
@@ -105,7 +109,7 @@ class LinkMlGeneratorSpec extends AnyWordSpec, Matchers {
 
     "derive classes and prune the schema (tree_root)" in {
       val sv = ModelCatalogue.pruning.model
-      val schema = LinkMlGenerator(using sv).generate(pruningMode = treeRoot(None))
+      val schema = LinkMlGenerator(using sv).generate(LinkMlGenerator.Options(pruningMode = treeRoot(None)))
       schema.classes.keys should contain theSameElementsAs Seq(
         "SomeClass",
       )
@@ -124,7 +128,7 @@ class LinkMlGeneratorSpec extends AnyWordSpec, Matchers {
     "derive classes and prune the schema (tree_root override)" in {
       val sv = ModelCatalogue.pruning.model
       val schema =
-        LinkMlGenerator(using sv).generate(pruningMode = treeRoot(Some("NotTreeRootClass")))
+        LinkMlGenerator(using sv).generate(LinkMlGenerator.Options(pruningMode = treeRoot(Some("NotTreeRootClass"))))
       schema.classes.keys should contain theSameElementsAs Seq(
         "NotTreeRootClass",
       )
@@ -142,7 +146,7 @@ class LinkMlGeneratorSpec extends AnyWordSpec, Matchers {
     "derive classes and prune the schema (schema root)" in {
       val sv = ModelCatalogue.pruning.model
       val schema =
-        LinkMlGenerator(using sv).generate(pruningMode = schemaRoot)
+        LinkMlGenerator(using sv).generate(LinkMlGenerator.Options(pruningMode = schemaRoot))
       schema.classes.keys should contain theSameElementsAs Seq(
         "SomeClass",
         "NotTreeRootClass",
@@ -189,7 +193,7 @@ class LinkMlGeneratorSpec extends AnyWordSpec, Matchers {
     "prune using schema mode if requested tree_root mode but no tree root" in {
       val sv = ModelCatalogue.treeRootless.model
       val schema =
-        LinkMlGenerator(using sv).generate(pruningMode = treeRoot(None))
+        LinkMlGenerator(using sv).generate(LinkMlGenerator.Options(pruningMode = treeRoot(None)))
       schema.classes.keys should contain theSameElementsAs Seq(
         "SomeClass",
         "SomeOtherClass",
@@ -203,7 +207,7 @@ class LinkMlGeneratorSpec extends AnyWordSpec, Matchers {
     "prune using tree_root override if no schema tree root" in {
       val sv = ModelCatalogue.treeRootless.model
       val schema =
-        LinkMlGenerator(using sv).generate(pruningMode = treeRoot(Some("SomeClass")))
+        LinkMlGenerator(using sv).generate(LinkMlGenerator.Options(pruningMode = treeRoot(Some("SomeClass"))))
       schema.classes.keys should contain theSameElementsAs Seq(
         "SomeClass",
       )
@@ -227,22 +231,22 @@ class LinkMlGeneratorSpec extends AnyWordSpec, Matchers {
 
       SchemaView.single(
         LinkMlGenerator(using sv).generate(
-          skipClassDerivation = true,
+          LinkMlGenerator.Options(skipClassDerivation = true),
         ),
       ).lint() shouldBe empty
     }
 
     "serialize yaml format without errors" in {
       val sv = SchemaIssues.orThrow(SchemaView.loadSchemaViewFromUri("linkml:meta"))
-      LinkMlGenerator(using sv).serialize(outputFormat =
-        LinkMlGenerator.OutputFormat.yaml,
+      LinkMlGenerator(using sv).serialize(
+        LinkMlGenerator.Options(outputFormat = LinkMlGenerator.OutputFormat.yaml),
       ).isEmpty shouldBe false
     }
 
     "serialize json format without errors" in {
       val sv = SchemaIssues.orThrow(SchemaView.loadSchemaViewFromUri("linkml:meta"))
-      LinkMlGenerator(using sv).serialize(outputFormat =
-        LinkMlGenerator.OutputFormat.json,
+      LinkMlGenerator(using sv).serialize(
+        LinkMlGenerator.Options(outputFormat = LinkMlGenerator.OutputFormat.json),
       ).isEmpty shouldBe false
     }
 
@@ -258,7 +262,7 @@ class LinkMlGeneratorSpec extends AnyWordSpec, Matchers {
           |    annotations:
           |      kb-article: "## How it works Change the default password as soon as a new device is received. The default credentials are normally documented in an instruction manual that is either packaged with the device, published online through official means, or published online through unofficial means. ## Considerations"
           |""".stripMargin))
-      LinkMlGenerator(using sv).serialize(outputFormat = LinkMlGenerator.OutputFormat.json) shouldBe
+      LinkMlGenerator(using sv).serialize(LinkMlGenerator.Options(outputFormat = LinkMlGenerator.OutputFormat.json)) shouldBe
         """{
         |  "name": "d3fend",
         |  "id": "https://d3fend.mitre.org/ontologies/d3fend.owl",
@@ -300,7 +304,7 @@ class LinkMlGeneratorSpec extends AnyWordSpec, Matchers {
           |    description: "3.14"
           |""".stripMargin))
 
-      LinkMlGenerator(using sv).serialize(outputFormat = LinkMlGenerator.OutputFormat.json) shouldBe
+      LinkMlGenerator(using sv).serialize(LinkMlGenerator.Options(outputFormat = LinkMlGenerator.OutputFormat.json)) shouldBe
         """{
         |  "name": "numeric_strings",
         |  "id": "https://example.org/numeric-strings",
@@ -318,7 +322,7 @@ class LinkMlGeneratorSpec extends AnyWordSpec, Matchers {
 
       // The same nodes feed the YAML output, which must quote them for the same reason.
       val yaml =
-        LinkMlGenerator(using sv).serialize(outputFormat = LinkMlGenerator.OutputFormat.yaml)
+        LinkMlGenerator(using sv).serialize(LinkMlGenerator.Options(outputFormat = LinkMlGenerator.OutputFormat.yaml))
       yaml should include("""title: "123"""")
       yaml should include("""description: "true"""")
       yaml should include("""license: "null"""")
@@ -331,12 +335,12 @@ class LinkMlGeneratorSpec extends AnyWordSpec, Matchers {
           LinkMlGenerator(using entry.model)
             .serialize() should not be empty
           LinkMlGenerator(using entry.model)
-            .serialize(skipClassDerivation = true) should not be empty
+            .serialize(LinkMlGenerator.Options(skipClassDerivation = true)) should not be empty
 
           SchemaView.single(LinkMlGenerator(using entry.model).generate())
             .lint() shouldBe empty
           SchemaView.single(
-            LinkMlGenerator(using entry.model).generate(skipClassDerivation = true),
+            LinkMlGenerator(using entry.model).generate(LinkMlGenerator.Options(skipClassDerivation = true)),
           ).lint() shouldBe empty
         }
     }

--- a/generator/test/src/eu/neverblink/linkml/generator/linkml/LinkMlGeneratorSpec.scala
+++ b/generator/test/src/eu/neverblink/linkml/generator/linkml/LinkMlGeneratorSpec.scala
@@ -216,7 +216,9 @@ class LinkMlGeneratorSpec extends AnyWordSpec, Matchers {
     "include all default_ranges when pruning" in {
       val sv = ModelCatalogue.pruningDefaultRange.model
       val schema =
-        LinkMlGenerator(using sv).generate()
+        LinkMlGenerator(using sv).generate(
+          LinkMlGenerator.Options(pruningMode = treeRoot(None)),
+        )
       schema.types.keys should contain theSameElementsAs Seq(
         "integer",
         "string",
@@ -262,7 +264,12 @@ class LinkMlGeneratorSpec extends AnyWordSpec, Matchers {
           |    annotations:
           |      kb-article: "## How it works Change the default password as soon as a new device is received. The default credentials are normally documented in an instruction manual that is either packaged with the device, published online through official means, or published online through unofficial means. ## Considerations"
           |""".stripMargin))
-      LinkMlGenerator(using sv).serialize(LinkMlGenerator.Options(outputFormat = LinkMlGenerator.OutputFormat.json)) shouldBe
+      LinkMlGenerator(using sv).serialize(
+        LinkMlGenerator.Options(
+          pruningMode = treeRoot(None),
+          outputFormat = LinkMlGenerator.OutputFormat.json,
+        ),
+      ) shouldBe
         """{
         |  "name": "d3fend",
         |  "id": "https://d3fend.mitre.org/ontologies/d3fend.owl",
@@ -304,7 +311,12 @@ class LinkMlGeneratorSpec extends AnyWordSpec, Matchers {
           |    description: "3.14"
           |""".stripMargin))
 
-      LinkMlGenerator(using sv).serialize(LinkMlGenerator.Options(outputFormat = LinkMlGenerator.OutputFormat.json)) shouldBe
+      LinkMlGenerator(using sv).serialize(
+        LinkMlGenerator.Options(
+          pruningMode = treeRoot(None),
+          outputFormat = LinkMlGenerator.OutputFormat.json,
+        ),
+      ) shouldBe
         """{
         |  "name": "numeric_strings",
         |  "id": "https://example.org/numeric-strings",

--- a/generator/test/src/eu/neverblink/linkml/generator/scala/ScalaGeneratorSpec.scala
+++ b/generator/test/src/eu/neverblink/linkml/generator/scala/ScalaGeneratorSpec.scala
@@ -23,7 +23,7 @@ class ScalaGeneratorSpec extends AnyWordSpec, Matchers {
 
     "generate abstract interfaces and implementations for plain classes" in {
       given SchemaView = ModelCatalogue.basic.model
-      val code = ScalaGenerator().generate(testPkg).toMap.apply("SomeClass.scala")
+      val code = ScalaGenerator().generate(ScalaGenerator.Options(testPkg)).toMap.apply("SomeClass.scala")
       Seq(
         s"package $testPkg",
         "case class SomeClassImpl",
@@ -47,7 +47,7 @@ class ScalaGeneratorSpec extends AnyWordSpec, Matchers {
     "not generate implementations for abstract classes" in {
       given SchemaView = ModelCatalogue.`abstract`.model
 
-      val code = ScalaGenerator().generate(testPkg).toMap.apply("SomeClass.scala")
+      val code = ScalaGenerator().generate(ScalaGenerator.Options(testPkg)).toMap.apply("SomeClass.scala")
       Seq(
         "abstract class SomeClass",
         "def someOtherSlot: Int",
@@ -69,7 +69,7 @@ class ScalaGeneratorSpec extends AnyWordSpec, Matchers {
     "generate trait interfaces for mixin classes" in {
       given SchemaView = ModelCatalogue.mixin.model
 
-      val code = ScalaGenerator().generate(testPkg).toMap.apply("SomeOtherClass.scala")
+      val code = ScalaGenerator().generate(ScalaGenerator.Options(testPkg)).toMap.apply("SomeOtherClass.scala")
       Seq(
         "trait SomeOtherClass",
         "def someOtherSlot: Int",
@@ -90,7 +90,7 @@ class ScalaGeneratorSpec extends AnyWordSpec, Matchers {
     "generate abstract interfaces with inheritance" in {
       given SchemaView = ModelCatalogue.inheritance.model
 
-      val code = ScalaGenerator().generate(testPkg).toMap.apply("ChildClass.scala")
+      val code = ScalaGenerator().generate(ScalaGenerator.Options(testPkg)).toMap.apply("ChildClass.scala")
       Seq(
         "abstract class ChildClass extends BaseClass",
       ).foreach { snippet =>
@@ -101,7 +101,7 @@ class ScalaGeneratorSpec extends AnyWordSpec, Matchers {
     "reference other classes" in {
       given SchemaView = ModelCatalogue.reference.model
 
-      val code = ScalaGenerator().generate(testPkg).toMap.apply("SomeClass.scala")
+      val code = ScalaGenerator().generate(ScalaGenerator.Options(testPkg)).toMap.apply("SomeClass.scala")
       Seq(
         "Option[Reference[SomeOtherClass]]",
       ).foreach { snippet =>
@@ -112,7 +112,7 @@ class ScalaGeneratorSpec extends AnyWordSpec, Matchers {
     "reference multivalued other classes as a list of references" in {
       given SchemaView = ModelCatalogue.multivaluedReference.model
 
-      val code = ScalaGenerator().generate(testPkg).toMap.apply("SomeClass.scala")
+      val code = ScalaGenerator().generate(ScalaGenerator.Options(testPkg)).toMap.apply("SomeClass.scala")
       Seq(
         "Seq[Reference[SomeOtherClass]]",
       ).foreach { snippet =>
@@ -123,7 +123,7 @@ class ScalaGeneratorSpec extends AnyWordSpec, Matchers {
     "implicitly inline identifier-less classes" in {
       given SchemaView = ModelCatalogue.inlines.implicitInline.model
 
-      val code = ScalaGenerator().generate(testPkg).toMap.apply("SomeClass.scala")
+      val code = ScalaGenerator().generate(ScalaGenerator.Options(testPkg)).toMap.apply("SomeClass.scala")
       Seq(
         "Option[SomeOtherClassImpl]",
       ).foreach { snippet =>
@@ -134,7 +134,7 @@ class ScalaGeneratorSpec extends AnyWordSpec, Matchers {
     "implicitly inline multivalued other classes (implicitly as compact dict)" in {
       given SchemaView = ModelCatalogue.inlines.implicitInlineAsCompactDict.model
 
-      val code = ScalaGenerator().generate(testPkg).toMap.apply("SomeClass.scala")
+      val code = ScalaGenerator().generate(ScalaGenerator.Options(testPkg)).toMap.apply("SomeClass.scala")
       Seq(
         "@compactDict",
         "Map[String, SomeOtherClassImpl]",
@@ -146,7 +146,7 @@ class ScalaGeneratorSpec extends AnyWordSpec, Matchers {
     "implicitly inline multivalued other classes (implicitly as list)" in {
       given SchemaView = ModelCatalogue.inlines.implicitInlineAsList.model
 
-      val code = ScalaGenerator().generate(testPkg).toMap.apply("SomeClass.scala")
+      val code = ScalaGenerator().generate(ScalaGenerator.Options(testPkg)).toMap.apply("SomeClass.scala")
       Seq(
         "Seq[SomeOtherClassImpl]",
       ).foreach { snippet =>
@@ -157,7 +157,7 @@ class ScalaGeneratorSpec extends AnyWordSpec, Matchers {
     "explicitly inline multivalued other classes (implicitly as compact dict)" in {
       given SchemaView = ModelCatalogue.inlines.explicitInlineImplicitlyAsCompactDict.model
 
-      val code = ScalaGenerator().generate(testPkg).toMap.apply("SomeClass.scala")
+      val code = ScalaGenerator().generate(ScalaGenerator.Options(testPkg)).toMap.apply("SomeClass.scala")
       Seq(
         "@compactDict",
         "Map[String, SomeOtherClassImpl]",
@@ -169,7 +169,7 @@ class ScalaGeneratorSpec extends AnyWordSpec, Matchers {
     "explicitly inline multivalued other classes (implicitly as simple dict)" in {
       given SchemaView = ModelCatalogue.inlines.explicitInlineImplicitlyAsSimpleDict.model
 
-      val code = ScalaGenerator().generate(testPkg).toMap.apply("SomeClass.scala")
+      val code = ScalaGenerator().generate(ScalaGenerator.Options(testPkg)).toMap.apply("SomeClass.scala")
       Seq(
         "@simpleDict",
         "Map[String, SomeOtherClassImpl]",
@@ -181,7 +181,7 @@ class ScalaGeneratorSpec extends AnyWordSpec, Matchers {
     "explicitly inline multivalued other classes (implicitly as list)" in {
       given SchemaView = ModelCatalogue.inlines.explicitInlineImplicitlyAsList.model
 
-      val code = ScalaGenerator().generate(testPkg).toMap.apply("SomeClass.scala")
+      val code = ScalaGenerator().generate(ScalaGenerator.Options(testPkg)).toMap.apply("SomeClass.scala")
       Seq(
         "Seq[SomeOtherClassImpl]",
       ).foreach { snippet =>
@@ -192,7 +192,7 @@ class ScalaGeneratorSpec extends AnyWordSpec, Matchers {
     "explicitly inline multivalued other classes (explicitly as list)" in {
       given SchemaView = ModelCatalogue.inlines.explicitInlineList.model
 
-      val code = ScalaGenerator().generate(testPkg).toMap.apply("SomeClass.scala")
+      val code = ScalaGenerator().generate(ScalaGenerator.Options(testPkg)).toMap.apply("SomeClass.scala")
       Seq(
         "Seq[SomeOtherClassImpl]",
       ).foreach { snippet =>
@@ -205,7 +205,7 @@ class ScalaGeneratorSpec extends AnyWordSpec, Matchers {
       // one has to be typed as the interface, or the generated code does not compile.
       given SchemaView = ModelCatalogue.inlines.inlineAbstract.model
 
-      val code = ScalaGenerator().generate(testPkg).toMap.apply("Container.scala")
+      val code = ScalaGenerator().generate(ScalaGenerator.Options(testPkg)).toMap.apply("Container.scala")
       Seq(
         "toAbstract: Option[AbstractRange] = None",
         "toMixin: Option[MixinRange] = None",
@@ -236,7 +236,7 @@ class ScalaGeneratorSpec extends AnyWordSpec, Matchers {
 
       given SchemaView = decode(input)
 
-      val files = ScalaGenerator().generate(testPkg).toMap
+      val files = ScalaGenerator().generate(ScalaGenerator.Options(testPkg)).toMap
 
       files("SomeClass.scala") should include("@named(\"serialized_name\")")
       files("SomeClass.scala") should include("someSlot: Option[String]")
@@ -245,7 +245,7 @@ class ScalaGeneratorSpec extends AnyWordSpec, Matchers {
     "provide annotations inlining the class compact dict style" in {
       given SchemaView = ModelCatalogue.inlines.explicitInlineImplicitlyAsCompactDict.model
 
-      val files = ScalaGenerator().generate(testPkg).toMap
+      val files = ScalaGenerator().generate(ScalaGenerator.Options(testPkg)).toMap
 
       files("SomeOtherClass.scala") should include regex raw"@id\s*id: String"
     }
@@ -253,7 +253,7 @@ class ScalaGeneratorSpec extends AnyWordSpec, Matchers {
     "provide annotations inlining the class simple dict style" in {
       given SchemaView = ModelCatalogue.inlines.selfSimple2.model
 
-      val files = ScalaGenerator().generate(testPkg).toMap
+      val files = ScalaGenerator().generate(ScalaGenerator.Options(testPkg)).toMap
 
       files("SomeClass.scala") should include regex """@id\s*(@named\(".*"\))?\s*id: String"""
       files(
@@ -264,7 +264,7 @@ class ScalaGeneratorSpec extends AnyWordSpec, Matchers {
     "provide annotations inlining the class simple dict style (2 required fields case)" in {
       given SchemaView = ModelCatalogue.inlines.selfSimple2Required.model
 
-      val files = ScalaGenerator().generate(testPkg).toMap
+      val files = ScalaGenerator().generate(ScalaGenerator.Options(testPkg)).toMap
 
       files("SomeClass.scala") should include regex """@id\s*(@named\(".*"\))?\s*id: String"""
       files(
@@ -275,7 +275,7 @@ class ScalaGeneratorSpec extends AnyWordSpec, Matchers {
     "only provide annotations for inlining the class as a compact dict (2> slots)" in {
       given SchemaView = ModelCatalogue.inlines.selfCompact3.model
 
-      val files = ScalaGenerator().generate(testPkg).toMap
+      val files = ScalaGenerator().generate(ScalaGenerator.Options(testPkg)).toMap
 
       files("SomeClass.scala") should include regex raw"@id\s*id: String"
       files("SomeClass.scala") shouldNot include("@value")
@@ -284,7 +284,7 @@ class ScalaGeneratorSpec extends AnyWordSpec, Matchers {
     "only provide annotations for inlining the class as a compact dict (2> required slots)" in {
       given SchemaView = ModelCatalogue.inlines.selfCompact3Required.model
 
-      val files = ScalaGenerator().generate(testPkg).toMap
+      val files = ScalaGenerator().generate(ScalaGenerator.Options(testPkg)).toMap
 
       files("SomeClass.scala") should include regex raw"@id\s*id: String"
       files("SomeClass.scala") shouldNot include("@value")
@@ -320,7 +320,7 @@ class ScalaGeneratorSpec extends AnyWordSpec, Matchers {
            |""".stripMargin
 
       given SchemaView = decode(input)
-      val files = ScalaGenerator().generate(testPkg).toMap
+      val files = ScalaGenerator().generate(ScalaGenerator.Options(testPkg)).toMap
       val code = files("SomeClass.scala")
       Seq(
         "extends SomeOtherClass, SomeMixin, SomeOtherMixin",
@@ -354,7 +354,7 @@ class ScalaGeneratorSpec extends AnyWordSpec, Matchers {
 
       given SchemaView = decode(input)
 
-      val files = ScalaGenerator().generate(testPkg).toMap
+      val files = ScalaGenerator().generate(ScalaGenerator.Options(testPkg)).toMap
 
       files("SomeClass.scala") should include(
         "SomeClass extends SomeOtherClass",
@@ -388,7 +388,7 @@ class ScalaGeneratorSpec extends AnyWordSpec, Matchers {
 
       given SchemaView = decode(input)
 
-      val files = ScalaGenerator().generate(testPkg).toMap
+      val files = ScalaGenerator().generate(ScalaGenerator.Options(testPkg)).toMap
 
       files("SomeClass.scala") should include("def someSlot: Int")
       files("SomeClass.scala") should include("someSlot: Int,")
@@ -408,7 +408,7 @@ class ScalaGeneratorSpec extends AnyWordSpec, Matchers {
 
       given SchemaView = decode(input)
 
-      val files = ScalaGenerator().generate(testPkg).toMap
+      val files = ScalaGenerator().generate(ScalaGenerator.Options(testPkg)).toMap
       files("SomeClass.scala") should include("someSlot: Boolean = false,")
     }
 
@@ -423,7 +423,7 @@ class ScalaGeneratorSpec extends AnyWordSpec, Matchers {
 
       given SchemaView = decode(input)
 
-      val files = ScalaGenerator().generate(testPkg).toMap
+      val files = ScalaGenerator().generate(ScalaGenerator.Options(testPkg)).toMap
       files("SomeClass.scala") should include("someSlot: Option[String] = None,")
     }
 
@@ -445,7 +445,7 @@ class ScalaGeneratorSpec extends AnyWordSpec, Matchers {
 
       given SchemaView = decode(input)
 
-      val files = ScalaGenerator().generate(testPkg).toMap
+      val files = ScalaGenerator().generate(ScalaGenerator.Options(testPkg)).toMap
       files("SomeClass.scala") should include("someSlot: Map[String, SomeOtherClassImpl] = Map(),")
     }
 
@@ -468,7 +468,7 @@ class ScalaGeneratorSpec extends AnyWordSpec, Matchers {
 
       given SchemaView = decode(input)
 
-      val files = ScalaGenerator().generate(testPkg).toMap
+      val files = ScalaGenerator().generate(ScalaGenerator.Options(testPkg)).toMap
       files("SomeClass.scala") should include("someSlot: Seq[SomeOtherClassImpl] = Seq(),")
     }
 
@@ -487,7 +487,7 @@ class ScalaGeneratorSpec extends AnyWordSpec, Matchers {
 
       given SchemaView = decode(input)
 
-      val files = ScalaGenerator().generate(testPkg).toMap
+      val files = ScalaGenerator().generate(ScalaGenerator.Options(testPkg)).toMap
 
       files("SomeClass.scala") should include("def someSlot: MyAny")
       files("SomeClass.scala") should include("someSlot: MyAny,")
@@ -535,7 +535,7 @@ class ScalaGeneratorSpec extends AnyWordSpec, Matchers {
 
       given SchemaView = decode(input)
 
-      val files = ScalaGenerator().generate(testPkg).toMap
+      val files = ScalaGenerator().generate(ScalaGenerator.Options(testPkg)).toMap
 
       val code = files("MySlotDef.scala")
       Seq(
@@ -565,7 +565,7 @@ class ScalaGeneratorSpec extends AnyWordSpec, Matchers {
 
       given SchemaView = decode(input)
 
-      val files = ScalaGenerator().generate(testPkg).toMap
+      val files = ScalaGenerator().generate(ScalaGenerator.Options(testPkg)).toMap
 
       files("SomeClass.scala") should include(testPkg)
     }
@@ -601,7 +601,7 @@ class ScalaGeneratorSpec extends AnyWordSpec, Matchers {
 
       given SchemaView = decode(input)
 
-      val files = ScalaGenerator().generate(testPkg).toMap
+      val files = ScalaGenerator().generate(ScalaGenerator.Options(testPkg)).toMap
 
       val code = files("SomeClass.scala")
       Seq(
@@ -645,7 +645,7 @@ class ScalaGeneratorSpec extends AnyWordSpec, Matchers {
 
       given SchemaView = decode(input)
 
-      val code = ScalaGenerator().generate(testPkg).toMap.apply("SomeClass.scala")
+      val code = ScalaGenerator().generate(ScalaGenerator.Options(testPkg)).toMap.apply("SomeClass.scala")
       Seq(
         ": String",
         ": Seq[Int]",
@@ -671,7 +671,7 @@ class ScalaGeneratorSpec extends AnyWordSpec, Matchers {
 
       given SchemaView = decode(input)
 
-      val code = ScalaGenerator().generate(testPkg).toMap.apply("SomeEnum.scala")
+      val code = ScalaGenerator().generate(ScalaGenerator.Options(testPkg)).toMap.apply("SomeEnum.scala")
       code shouldBe
         """package eu.neverblink.linkml.generator.scala.test
           |
@@ -723,7 +723,7 @@ class ScalaGeneratorSpec extends AnyWordSpec, Matchers {
 
       given SchemaView = decode(input)
 
-      val code = ScalaGenerator().generate(testPkg).toMap.apply("SomeEnum.scala")
+      val code = ScalaGenerator().generate(ScalaGenerator.Options(testPkg)).toMap.apply("SomeEnum.scala")
       Seq(
         "sealed trait SomeEnum",
       ).foreach { snippet =>
@@ -746,7 +746,7 @@ class ScalaGeneratorSpec extends AnyWordSpec, Matchers {
 
       given SchemaView = decode(input)
 
-      val code = ScalaGenerator().generate(testPkg).toMap.apply("SomeEnum.scala")
+      val code = ScalaGenerator().generate(ScalaGenerator.Options(testPkg)).toMap.apply("SomeEnum.scala")
       Seq(
         "trait SomeEnum",
       ).foreach { snippet =>
@@ -755,8 +755,7 @@ class ScalaGeneratorSpec extends AnyWordSpec, Matchers {
     }
 
     "generate an infer() method from equals_expression" in {
-      val code = ScalaGenerator(using ModelCatalogue.equalsExpression.model)
-        .generate(testPkg).toMap.apply("SomeClass.scala")
+      val code = ScalaGenerator(using ModelCatalogue.equalsExpression.model).generate(ScalaGenerator.Options(testPkg)).toMap.apply("SomeClass.scala")
       Seq(
         // Declared on the interface, narrowed to the implementation type in the impl
         "def infer(): SomeClass\n",
@@ -792,8 +791,7 @@ class ScalaGeneratorSpec extends AnyWordSpec, Matchers {
     }
 
     "generate an infer() method reaching into inlined classes" in {
-      val code = ScalaGenerator(using ModelCatalogue.equalsExpression.model)
-        .generate(testPkg).toMap.apply("SomeClass.scala")
+      val code = ScalaGenerator(using ModelCatalogue.equalsExpression.model).generate(ScalaGenerator.Options(testPkg)).toMap.apply("SomeClass.scala")
       Seq(
         // Every optional link along the path is unwrapped, the outermost one last
         """fromOptionalNested = inferOptional("from_optional_nested", fromOptionalNested, """ +
@@ -809,8 +807,7 @@ class ScalaGeneratorSpec extends AnyWordSpec, Matchers {
     }
 
     "generate an infer() method that stringifies non-string ranges" in {
-      val code = ScalaGenerator(using ModelCatalogue.equalsExpression.model)
-        .generate(testPkg).toMap.apply("SomeClass.scala")
+      val code = ScalaGenerator(using ModelCatalogue.equalsExpression.model).generate(ScalaGenerator.Options(testPkg)).toMap.apply("SomeClass.scala")
       Seq(
         """fromNumbers = inferOptional("from_numbers", fromNumbers, """ +
           """stringify(inferenceInput("count", count)) + " items, ratio " + """ +
@@ -852,7 +849,7 @@ class ScalaGeneratorSpec extends AnyWordSpec, Matchers {
            |        equals_expression: "{inner}"
            |""".stripMargin
       val error = intercept[RuntimeException] {
-        ScalaGenerator(using decode(input)).generate(testPkg).toMap
+        ScalaGenerator(using decode(input)).generate(ScalaGenerator.Options(testPkg)).toMap
       }
       error.getMessage should include("SomeClass.message")
       error.getMessage should include("inner")
@@ -860,8 +857,7 @@ class ScalaGeneratorSpec extends AnyWordSpec, Matchers {
     }
 
     "substitute a static enum, which stringifies to its LinkML text" in {
-      val code = ScalaGenerator(using ModelCatalogue.equalsExpression.model)
-        .generate(testPkg).toMap
+      val code = ScalaGenerator(using ModelCatalogue.equalsExpression.model).generate(ScalaGenerator.Options(testPkg)).toMap
       // The instance is derived from the sealed hierarchy, reading the `@named` text
       code("StatusEnum.scala") should include("sealed abstract class StatusEnum derives Stringify")
       code("StatusEnum.scala") should include("""@named("in progress") case object InProgress""")
@@ -880,7 +876,7 @@ class ScalaGeneratorSpec extends AnyWordSpec, Matchers {
            |    permissible_values:
            |      a:
            |""".stripMargin
-      val code = ScalaGenerator(using decode(input)).generate(testPkg).toMap
+      val code = ScalaGenerator(using decode(input)).generate(ScalaGenerator.Options(testPkg)).toMap
         .apply("SomeEnum.scala")
       code should include("abstract class SomeEnum")
       code should not include "derives Stringify"
@@ -900,22 +896,21 @@ class ScalaGeneratorSpec extends AnyWordSpec, Matchers {
            |        range: string
            |        equals_expression: "{choice}"
            |""".stripMargin
-      val code = ScalaGenerator(using decode(input)).generate(testPkg).toMap
+      val code = ScalaGenerator(using decode(input)).generate(ScalaGenerator.Options(testPkg)).toMap
         .apply("SomeClass.scala")
       code should include("choice: Option[String]")
       code should include("""inferenceInput("choice", choice)""")
     }
 
     "generate an infer() method that does nothing when there are no expressions" in {
-      val code = ScalaGenerator(using ModelCatalogue.basic.model)
-        .generate(testPkg).toMap.apply("SomeClass.scala")
+      val code = ScalaGenerator(using ModelCatalogue.basic.model).generate(ScalaGenerator.Options(testPkg)).toMap.apply("SomeClass.scala")
       code should include("def infer(): SomeClassImpl")
       code should include("def infer(): SomeClass\n")
       code should not include "inferOptional"
     }
 
     "generate ifabsent default values for enum-ranged slots" in {
-      val files = ScalaGenerator(using ModelCatalogue.ifabsent.enums.model).generate(testPkg).toMap
+      val files = ScalaGenerator(using ModelCatalogue.ifabsent.enums.model).generate(ScalaGenerator.Options(testPkg)).toMap
       val code = files("SomeClass.scala")
       Seq(
         "someSlot: Option[SomeEnum] = Some(SomeEnum.SomeOption)",
@@ -939,7 +934,7 @@ class ScalaGeneratorSpec extends AnyWordSpec, Matchers {
     }
 
     "mark ifabsent default values with @serializeDefault" in {
-      val files = ScalaGenerator(using ModelCatalogue.ifabsent.enums.model).generate(testPkg).toMap
+      val files = ScalaGenerator(using ModelCatalogue.ifabsent.enums.model).generate(ScalaGenerator.Options(testPkg)).toMap
       // Drop the indentation, so that the snippets below can be written without it.
       // Done without a regex, as Scala.js has no MULTILINE support below ES2018.
       val code = files("SomeClass.scala").linesIterator.map(_.stripLeading()).mkString("\n")
@@ -956,8 +951,7 @@ class ScalaGeneratorSpec extends AnyWordSpec, Matchers {
     }
 
     "generate an emit_prefixes object" in {
-      val files = ScalaGenerator(using ModelCatalogue.emitPrefixes.model)
-        .generate(testPkg).toMap
+      val files = ScalaGenerator(using ModelCatalogue.emitPrefixes.model).generate(ScalaGenerator.Options(testPkg)).toMap
       files.keys should contain theSameElementsAs Seq(
         "SomeClass.scala",
         "Prefixes.scala",
@@ -975,14 +969,14 @@ class ScalaGeneratorSpec extends AnyWordSpec, Matchers {
     "generate Linkml Date and/or Time for dates" in {
       given SchemaView = ModelCatalogue.typed.model
 
-      val code = ScalaGenerator().generate(testPkg).toMap.apply("Typed.scala")
+      val code = ScalaGenerator().generate(ScalaGenerator.Options(testPkg)).toMap.apply("Typed.scala")
       code should include("dateSlot: LinkmlDate")
     }
 
     "generate type aliases" in {
       given SchemaView = ModelCatalogue.typed.model
 
-      val files = ScalaGenerator().generate(testPkg).toMap
+      val files = ScalaGenerator().generate(ScalaGenerator.Options(testPkg)).toMap
       files("Typed.scala") should include("customSlot: Custom")
       files("Custom.scala") should include("type Custom = String")
     }
@@ -990,7 +984,7 @@ class ScalaGeneratorSpec extends AnyWordSpec, Matchers {
     "not generate aliases for primitive types" in {
       given SchemaView = ModelCatalogue.basic.model
 
-      val files = ScalaGenerator().generate(testPkg).toMap
+      val files = ScalaGenerator().generate(ScalaGenerator.Options(testPkg)).toMap
       files.keys should contain theSameElementsAs Seq(
         "SomeClass.scala",
       )
@@ -999,7 +993,7 @@ class ScalaGeneratorSpec extends AnyWordSpec, Matchers {
     "generate an external type reference if unknown base is used" in {
       given SchemaView = ModelCatalogue.externalType.model
 
-      val files = ScalaGenerator().generate(testPkg).toMap
+      val files = ScalaGenerator().generate(ScalaGenerator.Options(testPkg)).toMap
       files.keys should contain theSameElementsAs Seq(
         "SomeClass.scala",
         "ExtType.scala",
@@ -1016,13 +1010,13 @@ class ScalaGeneratorSpec extends AnyWordSpec, Matchers {
         SchemaIssues.orThrow(SchemaView.loadSchemaViewFromUri("https://w3id.org/linkml/meta"))
       given SchemaView = sv
 
-      ScalaGenerator().generate("eu.neverblink.linkml.metamodel")
+      ScalaGenerator().generate(ScalaGenerator.Options("eu.neverblink.linkml.metamodel"))
     }
 
     "generate all catalogue models without errors" when {
       for entry <- ModelCatalogue.all do
         s"model '${entry.model.root.name}'" in {
-          val files = ScalaGenerator(using entry.model).generate("eu.neverblink.linkml.scala.test")
+          val files = ScalaGenerator(using entry.model).generate(ScalaGenerator.Options("eu.neverblink.linkml.scala.test"))
           files should not be empty
           for (_, content) <- files do content should not be ""
         }

--- a/generator/test/src/eu/neverblink/linkml/generator/tableschema/TableSchemaGeneratorSpec.scala
+++ b/generator/test/src/eu/neverblink/linkml/generator/tableschema/TableSchemaGeneratorSpec.scala
@@ -32,7 +32,7 @@ class TableSchemaGeneratorSpec extends AnyWordSpec, Matchers {
 
   "TableSchemaGenerator" should {
     "generate basic fields" in {
-      val td = TableSchemaGenerator(using ModelCatalogue.basic.model).generate(None)
+      val td = TableSchemaGenerator(using ModelCatalogue.basic.model).generate(TableSchemaGenerator.Options(None))
       td.fields should not be empty
       td.fields.map(_.name) should contain theSameElementsAs Seq(
         "some_slot",
@@ -49,14 +49,14 @@ class TableSchemaGeneratorSpec extends AnyWordSpec, Matchers {
     }
 
     "generate references" in {
-      val td = TableSchemaGenerator(using ModelCatalogue.reference.model).generate(None)
+      val td = TableSchemaGenerator(using ModelCatalogue.reference.model).generate(TableSchemaGenerator.Options(None))
       val someSlot = td.fields.head
       someSlot.`type` shouldBe "string"
       someSlot.rdfType shouldBe Some(ModelCatalogue.reference.id + "SomeOtherClass")
     }
 
     "generate types" in {
-      val td = TableSchemaGenerator(using ModelCatalogue.typed.model).generate(None)
+      val td = TableSchemaGenerator(using ModelCatalogue.typed.model).generate(TableSchemaGenerator.Options(None))
       val fieldMap = td.fields.map(fd => fd.name -> fd).toMap
 
       fieldMap("stringSlot").`type` shouldBe "string"
@@ -79,7 +79,7 @@ class TableSchemaGeneratorSpec extends AnyWordSpec, Matchers {
     }
 
     "generate uri format" in {
-      val td = TableSchemaGenerator(using ModelCatalogue.uri.model).generate(None)
+      val td = TableSchemaGenerator(using ModelCatalogue.uri.model).generate(TableSchemaGenerator.Options(None))
       val fieldMap = td.fields.map(fd => fd.name -> fd).toMap
       fieldMap("some_slot").`type` shouldBe "string"
       fieldMap("some_slot").format shouldBe "uri"
@@ -92,7 +92,7 @@ class TableSchemaGeneratorSpec extends AnyWordSpec, Matchers {
 
     "generate inlines" in {
       val td =
-        TableSchemaGenerator(using ModelCatalogue.inlines.explicitInline.model).generate(None)
+        TableSchemaGenerator(using ModelCatalogue.inlines.explicitInline.model).generate(TableSchemaGenerator.Options(None))
       val someSlot = td.fields.head
       someSlot.`type` shouldBe "object"
       someSlot.rdfType shouldBe Some(ModelCatalogue.inlines.explicitInline.id + "SomeOtherClass")
@@ -100,7 +100,7 @@ class TableSchemaGeneratorSpec extends AnyWordSpec, Matchers {
 
     "generate array inlines" in {
       val td =
-        TableSchemaGenerator(using ModelCatalogue.inlines.explicitInlineList.model).generate(None)
+        TableSchemaGenerator(using ModelCatalogue.inlines.explicitInlineList.model).generate(TableSchemaGenerator.Options(None))
       val someSlot = td.fields.head
       someSlot.`type` shouldBe "array"
       someSlot.rdfType shouldBe Some(
@@ -109,19 +109,19 @@ class TableSchemaGeneratorSpec extends AnyWordSpec, Matchers {
     }
 
     "generate any" in {
-      val td = TableSchemaGenerator(using ModelCatalogue.anything.model).generate(None)
+      val td = TableSchemaGenerator(using ModelCatalogue.anything.model).generate(TableSchemaGenerator.Options(None))
       val someSlot = td.fields.head
       someSlot.`type` shouldBe "any"
     }
 
     "generate any for unknown types" in {
-      val td = TableSchemaGenerator(using ModelCatalogue.externalType.model).generate(None)
+      val td = TableSchemaGenerator(using ModelCatalogue.externalType.model).generate(TableSchemaGenerator.Options(None))
       val someSlot = td.fields.head
       someSlot.`type` shouldBe "any"
     }
 
     "generate enum values" in {
-      val td = TableSchemaGenerator(using ModelCatalogue.`enum`.model).generate(None)
+      val td = TableSchemaGenerator(using ModelCatalogue.`enum`.model).generate(TableSchemaGenerator.Options(None))
       val someSlot = td.fields.head
       someSlot.`type` shouldBe "string"
       someSlot.constraints.get.`enum`.get should contain theSameElementsAs Seq(
@@ -132,7 +132,7 @@ class TableSchemaGeneratorSpec extends AnyWordSpec, Matchers {
     }
 
     "generate type constraints" in {
-      val td = TableSchemaGenerator(using ModelCatalogue.constraints.model).generate(None)
+      val td = TableSchemaGenerator(using ModelCatalogue.constraints.model).generate(TableSchemaGenerator.Options(None))
 
       val fieldMap = td.fields.map(fd => fd.name -> fd).toMap
       val intConstraints = fieldMap("intSlot").constraints.get
@@ -148,7 +148,7 @@ class TableSchemaGeneratorSpec extends AnyWordSpec, Matchers {
 
     "allow tree root overriding" in {
       val td =
-        TableSchemaGenerator(using ModelCatalogue.treeRootless.model).generate(Some("SomeClass"))
+        TableSchemaGenerator(using ModelCatalogue.treeRootless.model).generate(TableSchemaGenerator.Options(Some("SomeClass")))
       td.fields should not be empty
       td.fields.map(_.name) should contain theSameElementsAs Seq(
         "some_slot",
@@ -164,7 +164,7 @@ class TableSchemaGeneratorSpec extends AnyWordSpec, Matchers {
       )
 
       val td2 = TableSchemaGenerator(using ModelCatalogue.treeRootless.model).generate(
-        Some("SomeOtherClass"),
+        TableSchemaGenerator.Options(Some("SomeOtherClass")),
       )
       td2.fields.length shouldBe 1
       td2.fields.head.name shouldBe "some_slot"
@@ -174,7 +174,7 @@ class TableSchemaGeneratorSpec extends AnyWordSpec, Matchers {
       val emptyMaterialized = writeToString(TableDescriptor())
       for model <- ModelCatalogue.all do
         s"model '${model.name}'" in {
-          val res = TableSchemaGenerator(using model.model).serialize(None)
+          val res = TableSchemaGenerator(using model.model).serialize(TableSchemaGenerator.Options(None))
           res should not be empty
           res should not be emptyMaterialized
         }

--- a/mill-build/src/CApiGen.scala
+++ b/mill-build/src/CApiGen.scala
@@ -1,0 +1,60 @@
+package millbuild
+
+/** Generates the generator entry points of the C ABI from [[Entrypoints]].
+  */
+object CApiGen {
+
+  /** @param read
+    *   reads a repository-relative path, so the caller decides where the sources come from
+    */
+  def apply(read: String => String): String = {
+    val methods = Entrypoints.all.map(entry => render(entry, read(entry.source)))
+
+    s"""// AUTO-GENERATED from mill-build/src/Entrypoints.scala and the generators' Options case
+       |// classes. Do not edit by hand - regenerate with ./mill bindings.
+       |package eu.neverblink.linkml.nativelib;
+       |
+       |import org.graalvm.nativeimage.IsolateThread;
+       |import org.graalvm.nativeimage.c.function.CEntryPoint;
+       |import org.graalvm.nativeimage.c.type.CCharPointer;
+       |import org.graalvm.nativeimage.c.type.CCharPointerPointer;
+       |import org.graalvm.nativeimage.c.type.CConst;
+       |
+       |/**
+       | * The generator entry points of the C ABI, one per generator.
+       | *
+       | * <p>All of them have the same shape: a schema handle, an options JSON that may be NULL for
+       | * defaults, and an error out-param. They return the generated document, or NULL with {@code
+       | * *error} set. Release returned strings with {@code linkml_free}.
+       | *
+       | * <p>See {@link LinkMlCApi} for loading, linting and the lifecycle.
+       | */
+       |public final class LinkMlCGenerators {
+       |
+       |    private LinkMlCGenerators() {}
+       |
+       |${methods.mkString("\n")}}
+       |""".stripMargin
+  }
+
+  private def render(entry: Entrypoints.Entrypoint, source: String): String = {
+    val options = OptionsReader.fields(source, entry.generator, entry.source)
+    val listed =
+      if options.isEmpty then "Takes no options."
+      else "Options: " + options.map(field => s"{@code ${field.name}}").mkString(", ") + "."
+
+    s"""    /** ${entry.cComment} $listed */
+       |    @CEntryPoint(name = "${entry.symbol}")
+       |    static CCharPointer ${entry.python.split('_').toList match {
+        case head :: tail => head + tail.map(_.capitalize).mkString
+        case Nil => entry.python
+      }}(
+       |            IsolateThread thread,
+       |            long handle,
+       |            @CConst CCharPointer options,
+       |            CCharPointerPointer error) {
+       |        return LinkMlCApi.document(handle, options, error, LinkMlNativeApi::${entry.scalaMethod});
+       |    }
+       |""".stripMargin
+  }
+}

--- a/mill-build/src/Entrypoints.scala
+++ b/mill-build/src/Entrypoints.scala
@@ -1,0 +1,120 @@
+package millbuild
+
+/** The generators exposed by the native library exposes.
+  *
+  * This is used by the C and Python code generators.
+  */
+object Entrypoints {
+
+  /** @param python
+    *   Python method name on `linkml_scala.Schema`
+    * @param symbol
+    *   the exported C function
+    * @param scalaMethod
+    *   the `LinkMlNativeApi` method the C entry point calls
+    * @param generator
+    *   the generator object holding the `Options` case class
+    * @param returns
+    *   Python return annotation. Anything but `str` is parsed as JSON.
+    * @param summary
+    *   first line of the Python docstring
+    * @param cComment
+    *   one-line description for the C entry point
+    */
+  final case class Entrypoint(
+      python: String,
+      symbol: String,
+      scalaMethod: String,
+      generator: String,
+      returns: String,
+      summary: String,
+      cComment: String,
+  ) {
+
+    /** Where the generator lives, derived from its name: the package is the lower-cased name minus
+      * the `Generator` suffix, which is the layout the whole generator module follows.
+      */
+    def source: String = {
+      val pkg = generator.stripSuffix("Generator").toLowerCase
+      s"generator/src/eu/neverblink/linkml/generator/$pkg/$generator.scala"
+    }
+
+    /** Whether the result is JSON to be parsed rather than a document to hand back as-is. */
+    def structured: Boolean = returns != "str"
+  }
+
+  val all: Seq[Entrypoint] = Seq(
+    Entrypoint(
+      "json_schema",
+      "linkml_json_schema",
+      "jsonSchema",
+      "JsonSchemaGenerator",
+      "str",
+      "Generate a JSON Schema.",
+      "Generate JSON Schema.",
+    ),
+    Entrypoint(
+      "shacl",
+      "linkml_shacl",
+      "shacl",
+      "ShaclGenerator",
+      "str",
+      "Generate SHACL shapes, serialized as N-Triples.",
+      "Generate SHACL shapes as N-Triples.",
+    ),
+    Entrypoint(
+      "rdfs",
+      "linkml_rdfs",
+      "rdfs",
+      "RdfsGenerator",
+      "str",
+      "Generate RDFS, serialized as N-Triples.",
+      "Generate RDFS as N-Triples.",
+    ),
+    Entrypoint(
+      "linkml",
+      "linkml_linkml",
+      "linkml",
+      "LinkMlGenerator",
+      "str",
+      "Materialize a derived LinkML schema: imports resolved, slots pushed into attributes.",
+      "Materialize a derived LinkML schema.",
+    ),
+    Entrypoint(
+      "table_schema",
+      "linkml_table_schema",
+      "tableSchema",
+      "TableSchemaGenerator",
+      "str",
+      "Generate a Frictionless Table Schema, serialized as JSON.",
+      "Generate a Frictionless Table Schema as JSON.",
+    ),
+    Entrypoint(
+      "graphql",
+      "linkml_graphql",
+      "graphQl",
+      "GraphQlGenerator",
+      "str",
+      "Generate a GraphQL schema: types, interfaces, scalars and enums, but no queries.",
+      "Generate a GraphQL schema.",
+    ),
+    Entrypoint(
+      "er_diagram",
+      "linkml_er_diagram",
+      "erDiagram",
+      "ErDiagramGenerator",
+      "str",
+      "Generate a Mermaid entity relationship diagram.",
+      "Generate a Mermaid entity relationship diagram.",
+    ),
+    Entrypoint(
+      "scala",
+      "linkml_scala",
+      "scalaFiles",
+      "ScalaGenerator",
+      "dict[str, str]",
+      "Generate Scala classes, as a filename to source mapping.",
+      "Generate Scala sources, as a JSON object mapping filename to source.",
+    ),
+  )
+}

--- a/mill-build/src/OptionsReader.scala
+++ b/mill-build/src/OptionsReader.scala
@@ -1,0 +1,99 @@
+package millbuild
+
+import _root_.scala.meta.*
+
+/** Reads a generator's `Options` case class out of its source: the fields, and the `@param` lines
+  * documenting them.
+  *
+  * Shared by [[PyBindingsGen]] and [[CApiGen]]. A syntactic parse only, no compiler, the same as
+  * [[TsDefsGen]].
+  */
+object OptionsReader {
+
+  /** One field of an `Options` case class.
+    *
+    * @param name
+    *   field name, with any backticks stripped
+    * @param tpe
+    *   the declared type, as written
+    * @param default
+    *   the default value, as written
+    * @param doc
+    *   the matching `@param` text, empty if undocumented
+    */
+  final case class Field(name: String, tpe: String, default: String, doc: String)
+
+  /** @param source
+    *   the generator's source text
+    * @param generator
+    *   the object holding the `Options` case class
+    * @param path
+    *   only used to say where, if there is nothing to read
+    */
+  def fields(source: String, generator: String, path: String): Seq[Field] = {
+    val options = findOptions(source, generator)
+      .getOrElse(sys.error(s"no Options case class found in $generator ($path)"))
+    val docs = paramDocs(source, options)
+    options.ctor.paramClauses.flatMap(_.values).map { param =>
+      val name = param.name.value.stripPrefix("`").stripSuffix("`")
+      Field(
+        name = name,
+        tpe = param.decltpe.map(_.syntax).getOrElse("Any"),
+        default = param.default.map(_.syntax).getOrElse(""),
+        doc = docs.getOrElse(name, ""),
+      )
+    }
+  }
+
+  private def findOptions(source: String, generator: String): Option[Defn.Class] = {
+    val parsed = dialects.Scala3(source).parse[Source].get
+    def inObject(t: Tree): Option[Defn.Class] = t match {
+      case o: Defn.Object if o.name.value == generator =>
+        collectClasses(o).find(_.name.value == "Options")
+      case _ => t.children.iterator.flatMap(inObject).nextOption()
+    }
+    inObject(parsed)
+  }
+
+  private def collectClasses(t: Tree): List[Defn.Class] = {
+    val self = t match { case c: Defn.Class => List(c); case _ => Nil }
+    self ++ t.children.flatMap(collectClasses)
+  }
+
+  /** The `@param` entries of the scaladoc directly above the `Options` class. */
+  private def paramDocs(source: String, options: Defn.Class): Map[String, String] = {
+    val raw = "/\\*\\*[\\s\\S]*?\\*/".r
+      .findAllMatchIn(source)
+      .filter(_.end <= options.pos.start)
+      .toList
+      .lastOption
+      .map(_.matched)
+      .getOrElse("")
+
+    val lines = raw
+      .stripPrefix("/**")
+      .stripSuffix("*/")
+      .linesIterator
+      .map(l => l.trim.stripPrefix("*").trim)
+      .toList
+
+    val docs = Map.newBuilder[String, String]
+    var current = ""
+    val text = new StringBuilder
+    def flush(): Unit =
+      if current.nonEmpty then {
+        docs += current -> text.toString.trim
+        text.clear()
+        current = ""
+      }
+    lines.foreach { line =>
+      if line.startsWith("@param") then {
+        flush()
+        current = line.stripPrefix("@param").trim.stripPrefix("`").stripSuffix("`")
+      } else if line.startsWith("@") then flush()
+      else if current.nonEmpty && line.nonEmpty then text.append(line).append(" ")
+    }
+    flush()
+    docs.result()
+  }
+}

--- a/mill-build/src/PyBindingsGen.scala
+++ b/mill-build/src/PyBindingsGen.scala
@@ -1,0 +1,349 @@
+package millbuild
+
+import _root_.scala.meta.*
+
+/** Generates the Python bindings' generator methods from each generator's `Options` case class, so
+  * the option names, types, defaults and docs can never drift from the Scala they came from.
+  *
+  * The same idea as [[TsDefsGen]].
+  */
+object PyBindingsGen {
+
+  /** One Python method: the exported symbol it calls, and the generator whose `Options` describes
+    * its keyword arguments.
+    *
+    * @param python
+    *   Python method name
+    * @param symbol
+    *   the exported C function
+    * @param generator
+    *   the generator object holding the `Options` case class
+    * @param returns
+    *   Python return annotation
+    * @param summary
+    *   first line of the docstring
+    */
+  private case class Binding(
+      python: String,
+      symbol: String,
+      generator: String,
+      returns: String,
+      summary: String,
+  ) {
+
+    def source: String = {
+      val pkg = generator.stripSuffix("Generator").toLowerCase
+      s"generator/src/eu/neverblink/linkml/generator/$pkg/$generator.scala"
+    }
+
+    /** Whether the result is JSON to be parsed rather than a document. */
+    def structured: Boolean = returns != "str"
+  }
+
+  private val bindings = Seq(
+    Binding(
+      "json_schema",
+      "linkml_json_schema",
+      "JsonSchemaGenerator",
+      "str",
+      "Generate a JSON Schema.",
+    ),
+    Binding(
+      "shacl",
+      "linkml_shacl",
+      "ShaclGenerator",
+      "str",
+      "Generate SHACL shapes, serialized as N-Triples.",
+    ),
+    Binding(
+      "rdfs",
+      "linkml_rdfs",
+      "RdfsGenerator",
+      "str",
+      "Generate RDFS, serialized as N-Triples.",
+    ),
+    Binding(
+      "linkml",
+      "linkml_linkml",
+      "LinkMlGenerator",
+      "str",
+      "Materialize a derived LinkML schema: imports resolved, slots pushed into attributes.",
+    ),
+    Binding(
+      "table_schema",
+      "linkml_table_schema",
+      "TableSchemaGenerator",
+      "str",
+      "Generate a Frictionless Table Schema, serialized as JSON.",
+    ),
+    Binding(
+      "graphql",
+      "linkml_graphql",
+      "GraphQlGenerator",
+      "str",
+      "Generate a GraphQL schema: types, interfaces, scalars and enums, but no queries.",
+    ),
+    Binding(
+      "er_diagram",
+      "linkml_er_diagram",
+      "ErDiagramGenerator",
+      "str",
+      "Generate a Mermaid entity relationship diagram.",
+    ),
+    Binding(
+      "scala",
+      "linkml_scala",
+      "ScalaGenerator",
+      "dict[str, str]",
+      "Generate Scala classes, as a filename to source mapping.",
+    ),
+  )
+
+  /** @param read
+    *   reads a repository-relative path, so the caller decides where the sources come from
+    */
+  def apply(read: String => String): String = {
+    val methods = bindings.map(binding => render(binding, read(binding.source)))
+    val symbols = bindings.map(b => s"""    "${b.symbol}",""").mkString("\n")
+
+    s"""# AUTO-GENERATED from the generators' Options case classes.
+       |# Do not edit by hand - regenerate with ./mill pyBindings.
+       |\"\"\"The generator methods of :class:`linkml_scala.Schema`.
+       |
+       |Each one mirrors an ``Options`` case class in the Scala sources, so the keyword arguments,
+       |their defaults and their documentation are whatever the generator itself declares.
+       |\"\"\"
+       |
+       |from __future__ import annotations
+       |
+       |from typing import Any
+       |
+       |
+       |def _pruning(mode: str, tree_root: str | None) -> Any:
+       |    \"\"\"Encode the pruning mode the way the generators read it back.
+       |
+       |    `PruningMode` carries the tree-root override inside its `treeRoot` case rather than
+       |    beside it, so naming a root is an object instead of a second field.
+       |    \"\"\"
+       |    if tree_root is None:
+       |        return mode
+       |    if mode not in ("treeRoot", "tree_root", "tree-root"):
+       |        raise ValueError(f"tree_root only applies to pruning_mode='treeRoot', not {mode!r}")
+       |    return {"treeRoot": tree_root}
+       |
+       |
+       |# Every exported function taking (handle, options) and returning a document or NULL.
+       |DOCUMENT_FUNCTIONS = (
+       |$symbols
+       |)
+       |
+       |
+       |class Generators:
+       |    \"\"\"Mixin holding one method per generator. Mixed into :class:`linkml_scala.Schema`.\"\"\"
+       |
+       |${methods.mkString("\n")}""".stripMargin
+  }
+
+  private def render(binding: Binding, source: String): String = {
+    val options = findOptions(source, binding.generator)
+      .getOrElse(sys.error(s"no Options case class found in ${binding.source}"))
+    val docs = paramDocs(source, options)
+    val params = options.ctor.paramClauses.flatMap(_.values)
+      .flatMap(param => pythonParams(param, docs))
+
+    val signature =
+      if params.isEmpty then s"    def ${binding.python}(self) -> ${binding.returns}:"
+      else {
+        val rendered = params.map(p => s"        ${p.name}: ${p.tpe} = ${p.default},")
+        s"""    def ${binding.python}(
+           |        self,
+           |        *,
+           |${rendered.mkString("\n")}
+           |    ) -> ${binding.returns}:""".stripMargin
+      }
+
+    val doc = {
+      val lines = params.filter(_.doc.nonEmpty).map(p => wrap(s":param ${p.name}: ${p.doc}"))
+      if lines.isEmpty then s"""        \"\"\"${binding.summary}\"\"\""""
+      else s"""        \"\"\"${binding.summary}
+           |
+           |${lines.mkString("\n")}
+           |        \"\"\"""".stripMargin
+    }
+
+    val call = params.flatMap(_.argument)
+    val method = if binding.structured then "_json" else "_document"
+    val body =
+      if call.isEmpty then s"""        return self.$method("${binding.symbol}")"""
+      else s"""        return self.$method(
+           |            "${binding.symbol}",
+           |${call.map(a => s"            $a,").mkString("\n")}
+           |        )""".stripMargin
+
+    s"$signature\n$doc\n$body\n"
+  }
+
+  /** A Python keyword argument derived from one `Options` field.
+    *
+    * @param argument
+    *   how to pass it on, or None when it is folded into another field's argument
+    */
+  private case class PyParam(
+      name: String,
+      tpe: String,
+      default: String,
+      doc: String,
+      argument: Option[String],
+  )
+
+  /** Translate one `Options` field into the Python keyword arguments that stand for it.
+    *
+    * Usually one. `PruningMode` becomes two, because it carries its tree root override inside
+    * itself while Python users expect to name the class separately.
+    */
+  private def pythonParams(param: Term.Param, docs: Map[String, String]): Seq[PyParam] = {
+    val scalaName = param.name.value.stripPrefix("`").stripSuffix("`")
+    val name = snakeCase(scalaName)
+    val tpe = param.decltpe.map(_.syntax).getOrElse("Any")
+    val default = param.default.map(_.syntax).getOrElse("None")
+    val doc = docs.getOrElse(scalaName, "")
+
+    tpe match {
+      case "PruningMode" =>
+        Seq(
+          PyParam(
+            name,
+            "str",
+            pruningDefault(default),
+            doc,
+            Some(s"$scalaName=_pruning($name, tree_root)"),
+          ),
+          PyParam(
+            "tree_root",
+            "str | None",
+            "None",
+            "prune from this class instead of the schema's own `tree_root`. Only valid with " +
+              "`pruning_mode=\"treeRoot\"`.",
+            None,
+          ),
+        )
+      case _ =>
+        Seq(
+          PyParam(
+            name,
+            pythonType(tpe),
+            pythonDefault(tpe, default),
+            doc,
+            Some(s"$scalaName=$name"),
+          ),
+        )
+    }
+  }
+
+  private def pythonType(scalaType: String): String = scalaType match {
+    case "Boolean" => "bool"
+    case "Int" | "Long" => "int"
+    case "String" => "str"
+    case "Option[String]" => "str | None"
+    // LinkMlGenerator.OutputFormat and friends: enums the boundary spells as their name.
+    case _ => "str"
+  }
+
+  private def pythonDefault(scalaType: String, default: String): String =
+    (scalaType, default) match {
+      case (_, "true") => "True"
+      case (_, "false") => "False"
+      case (_, "None") => "None"
+      case ("Option[String]", value) => value.stripPrefix("Some(").stripSuffix(")")
+      case ("Int" | "Long" | "String", value) => value
+      // An enum case referenced bare or qualified, e.g. `yaml` or `OutputFormat.yaml`.
+      case (_, value) => "\"" + value.split('.').last + "\""
+    }
+
+  /** `PruningMode.treeRoot(None)` and `schemaRoot` are how the enum is written in Scala; the
+    * boundary spells the same three modes as plain names.
+    */
+  private def pruningDefault(default: String): String =
+    default.split('.').last.takeWhile(_ != '(') match {
+      case "schemaRoot" => "\"schema\""
+      case "treeRoot" => "\"treeRoot\""
+      case other => "\"" + other + "\""
+    }
+
+  private def snakeCase(camel: String): String =
+    camel.flatMap(c => if c.isUpper then s"_${c.toLower}" else c.toString)
+
+  private def findOptions(source: String, generator: String): Option[Defn.Class] = {
+    val parsed = dialects.Scala3(source).parse[Source].get
+    def inObject(t: Tree): Option[Defn.Class] = t match {
+      case o: Defn.Object if o.name.value == generator =>
+        collect[Defn.Class](o).find(_.name.value == "Options")
+      case _ => t.children.iterator.flatMap(inObject).nextOption()
+    }
+    inObject(parsed)
+  }
+
+  private def collect[T <: Tree](t: Tree)(using tag: reflect.ClassTag[T]): List[T] = {
+    val self = t match { case matched: T => List(matched); case _ => Nil }
+    self ++ t.children.flatMap(collect[T])
+  }
+
+  /** The `@param` entries of the scaladoc directly above the `Options` class. */
+  private def paramDocs(source: String, options: Defn.Class): Map[String, String] = {
+    val raw = "/\\*\\*[\\s\\S]*?\\*/".r
+      .findAllMatchIn(source)
+      .filter(_.end <= options.pos.start)
+      .toList
+      .lastOption
+      .map(_.matched)
+      .getOrElse("")
+
+    val lines = raw
+      .stripPrefix("/**")
+      .stripSuffix("*/")
+      .linesIterator
+      .map(l => l.trim.stripPrefix("*").trim)
+      .toList
+
+    val docs = Map.newBuilder[String, String]
+    var current = ""
+    val text = new StringBuilder
+    def flush(): Unit =
+      if current.nonEmpty then {
+        // Scaladoc wraps `code` in backticks, which reads the same in Python docstrings.
+        docs += current -> text.toString.trim
+        text.clear()
+        current = ""
+      }
+    lines.foreach { line =>
+      if line.startsWith("@param") then {
+        flush()
+        current = line.stripPrefix("@param").trim
+      } else if line.startsWith("@") then flush()
+      else if current.nonEmpty && line.nonEmpty then text.append(line).append(" ")
+    }
+    flush()
+    docs.result()
+  }
+
+  /** Wrap a `:param:` line to stay inside the project's line length, indenting continuations the
+    * way the hand-written docstrings do.
+    */
+  private def wrap(line: String): String = {
+    val limit = 96
+    val words = line.split(' ')
+    val out = List.newBuilder[String]
+    val current = new StringBuilder("        ")
+    words.foreach { word =>
+      if current.length + 1 + word.length > limit && current.toString.trim.nonEmpty then {
+        out += current.toString.stripTrailing()
+        current.clear()
+        current.append("            ")
+      }
+      if current.toString.trim.nonEmpty then current.append(' ')
+      current.append(word)
+    }
+    out += current.toString.stripTrailing()
+    out.result().mkString("\n")
+  }
+}

--- a/mill-build/src/PyBindingsGen.scala
+++ b/mill-build/src/PyBindingsGen.scala
@@ -1,113 +1,22 @@
 package millbuild
 
-import _root_.scala.meta.*
-
-/** Generates the Python bindings' generator methods from each generator's `Options` case class, so
-  * the option names, types, defaults and docs can never drift from the Scala they came from.
+/** Generates the Python bindings' generator methods from [[Entrypoints]] and each generator's
+  * `Options` case class, so the option names, types, defaults and docs can never drift from the
+  * Scala they came from.
   *
-  * The same idea as [[TsDefsGen]].
+  * The same idea as [[TsDefsGen]]. Reading the sources is [[OptionsReader]]'s job.
   */
 object PyBindingsGen {
-
-  /** One Python method: the exported symbol it calls, and the generator whose `Options` describes
-    * its keyword arguments.
-    *
-    * @param python
-    *   Python method name
-    * @param symbol
-    *   the exported C function
-    * @param generator
-    *   the generator object holding the `Options` case class
-    * @param returns
-    *   Python return annotation
-    * @param summary
-    *   first line of the docstring
-    */
-  private case class Binding(
-      python: String,
-      symbol: String,
-      generator: String,
-      returns: String,
-      summary: String,
-  ) {
-
-    def source: String = {
-      val pkg = generator.stripSuffix("Generator").toLowerCase
-      s"generator/src/eu/neverblink/linkml/generator/$pkg/$generator.scala"
-    }
-
-    /** Whether the result is JSON to be parsed rather than a document. */
-    def structured: Boolean = returns != "str"
-  }
-
-  private val bindings = Seq(
-    Binding(
-      "json_schema",
-      "linkml_json_schema",
-      "JsonSchemaGenerator",
-      "str",
-      "Generate a JSON Schema.",
-    ),
-    Binding(
-      "shacl",
-      "linkml_shacl",
-      "ShaclGenerator",
-      "str",
-      "Generate SHACL shapes, serialized as N-Triples.",
-    ),
-    Binding(
-      "rdfs",
-      "linkml_rdfs",
-      "RdfsGenerator",
-      "str",
-      "Generate RDFS, serialized as N-Triples.",
-    ),
-    Binding(
-      "linkml",
-      "linkml_linkml",
-      "LinkMlGenerator",
-      "str",
-      "Materialize a derived LinkML schema: imports resolved, slots pushed into attributes.",
-    ),
-    Binding(
-      "table_schema",
-      "linkml_table_schema",
-      "TableSchemaGenerator",
-      "str",
-      "Generate a Frictionless Table Schema, serialized as JSON.",
-    ),
-    Binding(
-      "graphql",
-      "linkml_graphql",
-      "GraphQlGenerator",
-      "str",
-      "Generate a GraphQL schema: types, interfaces, scalars and enums, but no queries.",
-    ),
-    Binding(
-      "er_diagram",
-      "linkml_er_diagram",
-      "ErDiagramGenerator",
-      "str",
-      "Generate a Mermaid entity relationship diagram.",
-    ),
-    Binding(
-      "scala",
-      "linkml_scala",
-      "ScalaGenerator",
-      "dict[str, str]",
-      "Generate Scala classes, as a filename to source mapping.",
-    ),
-  )
 
   /** @param read
     *   reads a repository-relative path, so the caller decides where the sources come from
     */
   def apply(read: String => String): String = {
-    val methods = bindings.map(binding => render(binding, read(binding.source)))
-    val symbols = bindings.map(b => s"""    "${b.symbol}",""").mkString("\n")
+    val methods = Entrypoints.all.map(entry => render(entry, read(entry.source)))
+    val symbols = Entrypoints.all.map(e => s"""    "${e.symbol}",""").mkString("\n")
 
-    s"""# AUTO-GENERATED from the generators' Options case classes.
-       |# Do not edit by hand - regenerate with ./mill pyBindings.
+    s"""# AUTO-GENERATED from mill-build/src/Entrypoints.scala and the generators' Options case
+       |# classes. Do not edit by hand - regenerate with ./mill bindings.
        |\"\"\"The generator methods of :class:`linkml_scala.Schema`.
        |
        |Each one mirrors an ``Options`` case class in the Scala sources, so the keyword arguments,
@@ -144,39 +53,37 @@ object PyBindingsGen {
        |${methods.mkString("\n")}""".stripMargin
   }
 
-  private def render(binding: Binding, source: String): String = {
-    val options = findOptions(source, binding.generator)
-      .getOrElse(sys.error(s"no Options case class found in ${binding.source}"))
-    val docs = paramDocs(source, options)
-    val params = options.ctor.paramClauses.flatMap(_.values)
-      .flatMap(param => pythonParams(param, docs))
+  private def render(entry: Entrypoints.Entrypoint, source: String): String = {
+    val params = OptionsReader.fields(source, entry.generator, entry.source).flatMap(pythonParams)
 
     val signature =
-      if params.isEmpty then s"    def ${binding.python}(self) -> ${binding.returns}:"
+      if params.isEmpty then s"    def ${entry.python}(self) -> ${entry.returns}:"
       else {
         val rendered = params.map(p => s"        ${p.name}: ${p.tpe} = ${p.default},")
-        s"""    def ${binding.python}(
+        s"""    def ${entry.python}(
            |        self,
            |        *,
            |${rendered.mkString("\n")}
-           |    ) -> ${binding.returns}:""".stripMargin
+           |    ) -> ${entry.returns}:""".stripMargin
       }
 
     val doc = {
       val lines = params.filter(_.doc.nonEmpty).map(p => wrap(s":param ${p.name}: ${p.doc}"))
-      if lines.isEmpty then s"""        \"\"\"${binding.summary}\"\"\""""
-      else s"""        \"\"\"${binding.summary}
+      if lines.isEmpty then s"""        \"\"\"${entry.summary}\"\"\""""
+      else
+        s"""        \"\"\"${entry.summary}
            |
            |${lines.mkString("\n")}
            |        \"\"\"""".stripMargin
     }
 
     val call = params.flatMap(_.argument)
-    val method = if binding.structured then "_json" else "_document"
+    val method = if entry.structured then "_json" else "_document"
     val body =
-      if call.isEmpty then s"""        return self.$method("${binding.symbol}")"""
-      else s"""        return self.$method(
-           |            "${binding.symbol}",
+      if call.isEmpty then s"""        return self.$method("${entry.symbol}")"""
+      else
+        s"""        return self.$method(
+           |            "${entry.symbol}",
            |${call.map(a => s"            $a,").mkString("\n")}
            |        )""".stripMargin
 
@@ -201,22 +108,17 @@ object PyBindingsGen {
     * Usually one. `PruningMode` becomes two, because it carries its tree root override inside
     * itself while Python users expect to name the class separately.
     */
-  private def pythonParams(param: Term.Param, docs: Map[String, String]): Seq[PyParam] = {
-    val scalaName = param.name.value.stripPrefix("`").stripSuffix("`")
-    val name = snakeCase(scalaName)
-    val tpe = param.decltpe.map(_.syntax).getOrElse("Any")
-    val default = param.default.map(_.syntax).getOrElse("None")
-    val doc = docs.getOrElse(scalaName, "")
-
-    tpe match {
+  private def pythonParams(field: OptionsReader.Field): Seq[PyParam] = {
+    val name = snakeCase(field.name)
+    field.tpe match {
       case "PruningMode" =>
         Seq(
           PyParam(
             name,
             "str",
-            pruningDefault(default),
-            doc,
-            Some(s"$scalaName=_pruning($name, tree_root)"),
+            pruningDefault(field.default),
+            field.doc,
+            Some(s"${field.name}=_pruning($name, tree_root)"),
           ),
           PyParam(
             "tree_root",
@@ -227,14 +129,14 @@ object PyBindingsGen {
             None,
           ),
         )
-      case _ =>
+      case tpe =>
         Seq(
           PyParam(
             name,
             pythonType(tpe),
-            pythonDefault(tpe, default),
-            doc,
-            Some(s"$scalaName=$name"),
+            pythonDefault(tpe, field.default),
+            field.doc,
+            Some(s"${field.name}=$name"),
           ),
         )
     }
@@ -253,7 +155,7 @@ object PyBindingsGen {
     (scalaType, default) match {
       case (_, "true") => "True"
       case (_, "false") => "False"
-      case (_, "None") => "None"
+      case (_, "None") | (_, "") => "None"
       case ("Option[String]", value) => value.stripPrefix("Some(").stripSuffix(")")
       case ("Int" | "Long" | "String", value) => value
       // An enum case referenced bare or qualified, e.g. `yaml` or `OutputFormat.yaml`.
@@ -266,65 +168,11 @@ object PyBindingsGen {
   private def pruningDefault(default: String): String =
     default.split('.').last.takeWhile(_ != '(') match {
       case "schemaRoot" => "\"schema\""
-      case "treeRoot" => "\"treeRoot\""
       case other => "\"" + other + "\""
     }
 
   private def snakeCase(camel: String): String =
     camel.flatMap(c => if c.isUpper then s"_${c.toLower}" else c.toString)
-
-  private def findOptions(source: String, generator: String): Option[Defn.Class] = {
-    val parsed = dialects.Scala3(source).parse[Source].get
-    def inObject(t: Tree): Option[Defn.Class] = t match {
-      case o: Defn.Object if o.name.value == generator =>
-        collect[Defn.Class](o).find(_.name.value == "Options")
-      case _ => t.children.iterator.flatMap(inObject).nextOption()
-    }
-    inObject(parsed)
-  }
-
-  private def collect[T <: Tree](t: Tree)(using tag: reflect.ClassTag[T]): List[T] = {
-    val self = t match { case matched: T => List(matched); case _ => Nil }
-    self ++ t.children.flatMap(collect[T])
-  }
-
-  /** The `@param` entries of the scaladoc directly above the `Options` class. */
-  private def paramDocs(source: String, options: Defn.Class): Map[String, String] = {
-    val raw = "/\\*\\*[\\s\\S]*?\\*/".r
-      .findAllMatchIn(source)
-      .filter(_.end <= options.pos.start)
-      .toList
-      .lastOption
-      .map(_.matched)
-      .getOrElse("")
-
-    val lines = raw
-      .stripPrefix("/**")
-      .stripSuffix("*/")
-      .linesIterator
-      .map(l => l.trim.stripPrefix("*").trim)
-      .toList
-
-    val docs = Map.newBuilder[String, String]
-    var current = ""
-    val text = new StringBuilder
-    def flush(): Unit =
-      if current.nonEmpty then {
-        // Scaladoc wraps `code` in backticks, which reads the same in Python docstrings.
-        docs += current -> text.toString.trim
-        text.clear()
-        current = ""
-      }
-    lines.foreach { line =>
-      if line.startsWith("@param") then {
-        flush()
-        current = line.stripPrefix("@param").trim
-      } else if line.startsWith("@") then flush()
-      else if current.nonEmpty && line.nonEmpty then text.append(line).append(" ")
-    }
-    flush()
-    docs.result()
-  }
 
   /** Wrap a `:param:` line to stay inside the project's line length, indenting continuations the
     * way the hand-written docstrings do.

--- a/nativelib/package.sh
+++ b/nativelib/package.sh
@@ -98,16 +98,21 @@ cat >"${prefix}/README.md" <<EOF
 
 LinkML schema validation and code generation as a native shared library, with a C ABI. Experimental.
 
-The library exports two functions, plus the GraalVM isolate lifecycle functions:
+See include/liblinkml_scala.h for the full API: one function per generator, plus loading, linting
+and the lifecycle. Two conventions cover all of it.
 
-    char* linkml_call(graal_isolatethread_t*, char*);   // JSON request in, JSON response out
-    void  linkml_free(graal_isolatethread_t*, char*);   // release a response
+Options are one JSON string, and may be NULL for defaults, so the common case needs no JSON:
 
-Create an isolate with \`graal_create_isolate\`, attach any further threads with
-\`graal_attach_thread\`, then send JSON requests. The request is \`const\`; the response is not,
-because you own it and must release it with \`linkml_free\`.
+    char *err = NULL;
+    char *shacl = linkml_shacl(thread, handle, NULL, &err);
 
-The protocol, the full API and a worked example in Python are documented at:
+Failure is NULL plus a message written to the error out-param. Everything the library hands back --
+documents, reports and error messages alike -- is yours, and must be released with \`linkml_free\`.
+
+Create an isolate with \`graal_create_isolate\` and attach any further threads with
+\`graal_attach_thread\` before calling in.
+
+The options each generator accepts, and a worked example in Python, are documented at:
 
   https://github.com/NeverBlink-OSS/linkml-scala/blob/main/docs/python_bindings.md
 

--- a/nativelib/package.sh
+++ b/nativelib/package.sh
@@ -37,7 +37,7 @@ repo_root="$(cd "$(dirname "$0")/.." && pwd)"
 prefix_name="liblinkml-scala-${version}-${platform}"
 staging="$(mktemp -d)"
 prefix="${staging}/${prefix_name}"
-trap 'rm -rf "$staging"' EXIT
+echo "staging in ${staging}" >&2
 
 # Windows keeps DLLs in bin/ and the import library in lib/; everywhere else the shared object
 # goes in lib/.
@@ -125,12 +125,13 @@ out_dir="$(cd "$out_dir" && pwd)"
 case "$platform" in
 windows-*)
   archive="${out_dir}/linkml-scala-lib-${platform}.zip"
+  # zip adds to an existing archive rather than replacing it, so a rerun would otherwise keep
+  # entries from the previous one.
   rm -f "$archive"
   (cd "$staging" && zip -q -r -9 "$archive" "$prefix_name")
   ;;
 *)
   archive="${out_dir}/linkml-scala-lib-${platform}.tar.gz"
-  rm -f "$archive"
   tar -czf "$archive" -C "$staging" "$prefix_name"
   ;;
 esac

--- a/nativelib/package.sh
+++ b/nativelib/package.sh
@@ -1,0 +1,135 @@
+#!/usr/bin/env bash
+#
+# Package a native-image shared library build into the layout C, C++ and Rust consumers expect:
+#
+#   liblinkml-scala-<version>-<platform>/
+#     include/*.h          the headers native-image generated
+#     lib/liblinkml_scala.*  (bin/ for the Windows DLL, as is conventional there)
+#     linkml-scala.pc      pkg-config, so `pkg-config --cflags --libs linkml-scala` works
+#     LICENSE
+#     README.md
+#
+# That is what `make install` and `cmake --install` produce, so -I<prefix>/include
+# -L<prefix>/lib -llinkml_scala just work.
+#
+# Usage: nativelib/package.sh <version> <platform> <build-dir> <out-dir>
+#
+#   version     e.g. 0.13.2 (no leading v)
+#   platform    e.g. linux-x86_64, windows-x86_64
+#   build-dir   out/nativelib/sharedLibrary.dest, or a downloaded CI artifact
+#   out-dir     where to write the archive
+#
+# Writes <out-dir>/linkml-scala-lib-<platform>.tar.gz, or .zip for Windows platforms.
+
+set -euo pipefail
+
+if [ "$#" -ne 4 ]; then
+  sed -n '2,26p' "$0" >&2
+  exit 2
+fi
+
+version="$1"
+platform="$2"
+build_dir="$3"
+out_dir="$4"
+
+repo_root="$(cd "$(dirname "$0")/.." && pwd)"
+prefix_name="liblinkml-scala-${version}-${platform}"
+staging="$(mktemp -d)"
+prefix="${staging}/${prefix_name}"
+trap 'rm -rf "$staging"' EXIT
+
+# Windows keeps DLLs in bin/ and the import library in lib/; everywhere else the shared object
+# goes in lib/.
+case "$platform" in
+windows-*) runtime_dir="bin" ;;
+*) runtime_dir="lib" ;;
+esac
+
+mkdir -p "${prefix}/include" "${prefix}/lib" "${prefix}/${runtime_dir}"
+
+# Sort whatever native-image produced by extension rather than by name: the exact set differs per
+# platform (Windows adds an import library, and we would rather not hardcode its name).
+found_library=""
+for file in "${build_dir}"/*; do
+  [ -f "$file" ] || continue
+  case "$file" in
+  *.h) cp "$file" "${prefix}/include/" ;;
+  *.so | *.dylib | *.dll)
+    cp "$file" "${prefix}/${runtime_dir}/"
+    found_library="$file"
+    ;;
+  *.lib | *.a) cp "$file" "${prefix}/lib/" ;;
+  *) echo "note: ignoring unexpected build output $(basename "$file")" >&2 ;;
+  esac
+done
+
+if [ -z "$found_library" ]; then
+  echo "error: no shared library (.so/.dylib/.dll) found in ${build_dir}" >&2
+  exit 1
+fi
+
+# A shared library is not executed directly, but 755 is what every distro ships and what
+# `cmake --install` sets.
+chmod 755 "${prefix}/${runtime_dir}"/*
+
+# Drop the empty one of lib/ and bin/ on Windows-only builds.
+rmdir "${prefix}/lib" 2>/dev/null || true
+rmdir "${prefix}/${runtime_dir}" 2>/dev/null || true
+
+cp "${repo_root}/LICENSE" "${prefix}/LICENSE"
+
+# ${pcfiledir} keeps this relocatable, so it works wherever the archive is unpacked.
+cat >"${prefix}/linkml-scala.pc" <<EOF
+prefix=\${pcfiledir}
+includedir=\${prefix}/include
+libdir=\${prefix}/lib
+
+Name: linkml-scala
+Description: LinkML schema validation and multi-format code generation
+URL: https://github.com/NeverBlink-OSS/linkml-scala
+Version: ${version}
+Cflags: -I\${includedir}
+Libs: -L\${libdir} -llinkml_scala
+EOF
+
+cat >"${prefix}/README.md" <<EOF
+# LinkML-Scala shared library ${version} (${platform})
+
+LinkML schema validation and code generation as a native shared library, with a C ABI. Experimental.
+
+The library exports two functions, plus the GraalVM isolate lifecycle functions:
+
+    char* linkml_call(graal_isolatethread_t*, char*);   // JSON request in, JSON response out
+    void  linkml_free(graal_isolatethread_t*, char*);   // release a response
+
+Create an isolate with \`graal_create_isolate\`, attach any further threads with
+\`graal_attach_thread\`, then send JSON requests. Release every response with \`linkml_free\`.
+
+Note that the generated header declares the request parameter as \`char *\`, not \`const char *\`.
+Passing a string literal warns in C and does not compile in C++, so cast or use a mutable buffer.
+
+The protocol, the full API and a worked example in Python are documented at:
+
+  https://github.com/NeverBlink-OSS/linkml-scala/blob/main/docs/python_bindings.md
+
+Licensed under the Apache License 2.0. See LICENSE.
+EOF
+
+mkdir -p "$out_dir"
+out_dir="$(cd "$out_dir" && pwd)"
+
+case "$platform" in
+windows-*)
+  archive="${out_dir}/linkml-scala-lib-${platform}.zip"
+  rm -f "$archive"
+  (cd "$staging" && zip -q -r -9 "$archive" "$prefix_name")
+  ;;
+*)
+  archive="${out_dir}/linkml-scala-lib-${platform}.tar.gz"
+  rm -f "$archive"
+  tar -czf "$archive" -C "$staging" "$prefix_name"
+  ;;
+esac
+
+echo "$archive"

--- a/nativelib/package.sh
+++ b/nativelib/package.sh
@@ -104,10 +104,8 @@ The library exports two functions, plus the GraalVM isolate lifecycle functions:
     void  linkml_free(graal_isolatethread_t*, char*);   // release a response
 
 Create an isolate with \`graal_create_isolate\`, attach any further threads with
-\`graal_attach_thread\`, then send JSON requests. Release every response with \`linkml_free\`.
-
-Note that the generated header declares the request parameter as \`char *\`, not \`const char *\`.
-Passing a string literal warns in C and does not compile in C++, so cast or use a mutable buffer.
+\`graal_attach_thread\`, then send JSON requests. The request is \`const\`; the response is not,
+because you own it and must release it with \`linkml_free\`.
 
 The protocol, the full API and a worked example in Python are documented at:
 

--- a/nativelib/smoke.c
+++ b/nativelib/smoke.c
@@ -2,60 +2,75 @@
  * Smoke test for the packaged shared library, and a worked example of driving it from C.
  *
  * Checks the parts that only break once the library leaves the build directory: that the headers
- * and the shared object in the release archive agree, that an isolate comes up, and that a schema
- * can be loaded and generated from. Prints nothing on success beyond a summary; exits non-zero on
- * any failure.
+ * and the shared object in the release archive agree, that an isolate comes up, that a schema can
+ * be loaded and generated from, and that failures arrive as errors rather than crashes.
  *
- * Build against an unpacked release archive:
+ * Exits non-zero if any check fails. Build against an unpacked release archive:
  *
  *   gcc nativelib/smoke.c -o smoke $(PKG_CONFIG_PATH=<prefix> pkg-config --cflags --libs linkml-scala)
  *   LD_LIBRARY_PATH=<prefix>/lib ./smoke
+ *
+ * or just run nativelib/smoke.sh <prefix>, which handles the per-platform details.
  */
 
 #include <liblinkml_scala.h>
 #include <stdio.h>
-#include <stdlib.h>
 #include <string.h>
 
-static const char *LOAD_REQUEST =
-    "{\"op\":\"load\",\"schema\":\""
-    "id: https://example.org/smoke\\n"
-    "name: smoke\\n"
-    "imports:\\n"
-    "  - linkml:types\\n"
-    "default_range: string\\n"
-    "classes:\\n"
-    "  Person:\\n"
-    "    tree_root: true\\n"
-    "    attributes:\\n"
-    "      name:\\n"
-    "        range: string\\n"
-    "\"}";
+static const char *SCHEMA =
+    "id: https://example.org/smoke\n"
+    "name: smoke\n"
+    "imports:\n"
+    "  - linkml:types\n"
+    "default_range: string\n"
+    "classes:\n"
+    "  Person:\n"
+    "    tree_root: true\n"
+    "    attributes:\n"
+    "      name:\n"
+    "        range: string\n";
 
 static int failures = 0;
 
-/* Report whether `haystack` contains `needle`, counting a miss as a failure. */
-static void expect(const char *what, const char *haystack, const char *needle) {
-    if (haystack != NULL && strstr(haystack, needle) != NULL) {
-        printf("ok    %s\n", what);
-    } else {
-        printf("FAIL  %s: expected to find '%s' in:\n%.400s\n", what, needle,
-               haystack == NULL ? "(null)" : haystack);
-        failures++;
-    }
+static void ok(const char *what) { printf("ok    %s\n", what); }
+
+static void fail(const char *what, const char *detail) {
+    printf("FAIL  %s: %s\n", what, detail == NULL ? "(no detail)" : detail);
+    failures++;
 }
 
-/* Pull the schema handle out of a load response. Returns 0 if there is none. */
-static long long handle_of(const char *response) {
-    const char *found = response == NULL ? NULL : strstr(response, "\"handle\"");
-    long long handle = 0;
-    if (found == NULL || sscanf(found, "\"handle\" : %lld", &handle) != 1) {
-        /* The writer's spacing is not part of the protocol, so fall back to a looser scan. */
-        if (found == NULL || sscanf(found + 8, " %*[:] %lld", &handle) != 1) {
-            return 0;
-        }
+/* Check that a document came back and contains `needle`. Frees it either way. */
+static void expect(graal_isolatethread_t *thread, const char *what, char *document,
+                   char **error, const char *needle) {
+    if (document == NULL) {
+        fail(what, *error);
+    } else if (strstr(document, needle) == NULL) {
+        printf("FAIL  %s: expected '%s' in:\n%.300s\n", what, needle, document);
+        failures++;
+    } else {
+        ok(what);
     }
-    return handle;
+    linkml_free(thread, document);
+    linkml_free(thread, *error);
+    *error = NULL;
+}
+
+/* Check that a call was refused, and said why. */
+static void expect_refused(graal_isolatethread_t *thread, const char *what, char *document,
+                           char **error, const char *needle) {
+    if (document != NULL) {
+        fail(what, "the call was expected to fail, but returned a document");
+    } else if (*error == NULL) {
+        fail(what, "returned NULL without setting an error");
+    } else if (strstr(*error, needle) == NULL) {
+        printf("FAIL  %s: expected '%s' in error: %s\n", what, needle, *error);
+        failures++;
+    } else {
+        ok(what);
+    }
+    linkml_free(thread, document);
+    linkml_free(thread, *error);
+    *error = NULL;
 }
 
 int main(void) {
@@ -66,52 +81,72 @@ int main(void) {
         fprintf(stderr, "FAIL  graal_create_isolate\n");
         return 1;
     }
-    printf("ok    isolate created\n");
+    ok("isolate created");
 
-    char *version = linkml_call(thread, "{\"op\":\"version\"}");
-    expect("version", version, "\"abiVersion\"");
-    linkml_free(thread, version);
-
-    char *loaded = linkml_call(thread, LOAD_REQUEST);
-    expect("load succeeded", loaded, "\"ok\"");
-    expect("load found no issues", loaded, "\"issues\"");
-    long long handle = handle_of(loaded);
-    linkml_free(thread, loaded);
-
-    if (handle <= 0) {
-        printf("FAIL  load returned no usable handle\n");
-        failures++;
+    if (linkml_abi_version(thread) != 1) {
+        fail("abi version", "expected 1");
     } else {
-        char request[128];
-        snprintf(request, sizeof(request),
-                 "{\"op\":\"generate\",\"handle\":%lld,\"generator\":\"json-schema\"}", handle);
-        char *generated = linkml_call(thread, request);
-        /* The metamodel is compiled into the library, so `range: string` resolving at all proves
-         * that `linkml:types` survived into the native build. */
-        expect("json-schema generated", generated, "json-schema.org");
-        expect("the schema's own class is in it", generated, "Person");
-        linkml_free(thread, generated);
-
-        snprintf(request, sizeof(request), "{\"op\":\"close\",\"handle\":%lld}", handle);
-        char *closed = linkml_call(thread, request);
-        expect("close", closed, "\"ok\"");
-        linkml_free(thread, closed);
+        ok("abi version");
     }
 
-    /* A bad request has to come back as an error rather than taking the process with it. */
-    char *rejected = linkml_call(thread, "{\"op\":\"nonsense\"}");
-    expect("an unknown op is rejected", rejected, "unknown op");
-    linkml_free(thread, rejected);
+    /* Load. No import map, so the array arguments are NULL and the count is 0. */
+    char *report = NULL, *error = NULL;
+    long long handle =
+        linkml_load_string(thread, NULL, SCHEMA, NULL, NULL, 0, NULL, &report, &error);
+    if (handle <= 0) {
+        fail("load", error != NULL ? error : report);
+    } else if (report == NULL) {
+        fail("load", "no report was written");
+    } else {
+        ok("load");
+    }
+    linkml_free(thread, report);
+    linkml_free(thread, error);
 
-    char *malformed = linkml_call(thread, "not json at all");
-    expect("malformed JSON is rejected", malformed, "\"error\"");
-    linkml_free(thread, malformed);
+    if (handle > 0) {
+        char *out;
+
+        /* NULL options means defaults, so the common case needs no JSON at all. The metamodel is
+         * compiled into the library, so `range: string` resolving proves linkml:types survived. */
+        out = linkml_json_schema(thread, handle, NULL, &error);
+        expect(thread, "json-schema with default options", out, &error, "json-schema.org");
+
+        out = linkml_shacl(thread, handle, NULL, &error);
+        expect(thread, "shacl", out, &error, "shacl#NodeShape");
+
+        /* And here is the options channel being used. */
+        out = linkml_shacl(thread, handle, "{\"open\":true}", &error);
+        expect(thread, "shacl with options", out, &error, "shacl#NodeShape");
+
+        out = linkml_er_diagram(thread, handle, NULL, &error);
+        expect(thread, "er-diagram", out, &error, "erDiagram");
+
+        out = linkml_lint(thread, handle, NULL, &error);
+        expect(thread, "lint returns a report", out, &error, "issues");
+
+        out = linkml_scala(thread, handle, NULL, &error);
+        expect(thread, "scala returns a file map", out, &error, "Person.scala");
+
+        /* An option that does not exist is refused, not quietly ignored. */
+        out = linkml_json_schema(thread, handle, "{\"nonsense\":true}", &error);
+        expect_refused(thread, "an unknown option is refused", out, &error, "nonsense");
+
+        linkml_close(thread, handle);
+        ok("close");
+
+        /* Using a closed handle must be an error, not a crash. */
+        out = linkml_json_schema(thread, handle, NULL, &error);
+        expect_refused(thread, "a closed handle is refused", out, &error, "closed");
+    }
+
+    /* A handle that was never issued. */
+    char *never = linkml_shacl(thread, 999999, NULL, &error);
+    expect_refused(thread, "an unknown handle is refused", never, &error, "999999");
 
     if (graal_tear_down_isolate(thread) != 0) {
-        printf("FAIL  graal_tear_down_isolate\n");
-        failures++;
+        fail("isolate torn down", "graal_tear_down_isolate returned non-zero");
     } else {
-        printf("ok    isolate torn down\n");
+        ok("isolate torn down");
     }
 
     if (failures > 0) {

--- a/nativelib/smoke.c
+++ b/nativelib/smoke.c
@@ -1,0 +1,125 @@
+/*
+ * Smoke test for the packaged shared library, and a worked example of driving it from C.
+ *
+ * Checks the parts that only break once the library leaves the build directory: that the headers
+ * and the shared object in the release archive agree, that an isolate comes up, and that a schema
+ * can be loaded and generated from. Prints nothing on success beyond a summary; exits non-zero on
+ * any failure.
+ *
+ * Build against an unpacked release archive:
+ *
+ *   gcc nativelib/smoke.c -o smoke $(PKG_CONFIG_PATH=<prefix> pkg-config --cflags --libs linkml-scala)
+ *   LD_LIBRARY_PATH=<prefix>/lib ./smoke
+ */
+
+#include <liblinkml_scala.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+/* An array rather than a `const char *`: native-image declares the parameter as plain `char *`, so
+ * passing a const pointer warns in C and fails outright in C++. */
+static char LOAD_REQUEST[] =
+    "{\"op\":\"load\",\"schema\":\""
+    "id: https://example.org/smoke\\n"
+    "name: smoke\\n"
+    "imports:\\n"
+    "  - linkml:types\\n"
+    "default_range: string\\n"
+    "classes:\\n"
+    "  Person:\\n"
+    "    tree_root: true\\n"
+    "    attributes:\\n"
+    "      name:\\n"
+    "        range: string\\n"
+    "\"}";
+
+static int failures = 0;
+
+/* Report whether `haystack` contains `needle`, counting a miss as a failure. */
+static void expect(const char *what, const char *haystack, const char *needle) {
+    if (haystack != NULL && strstr(haystack, needle) != NULL) {
+        printf("ok    %s\n", what);
+    } else {
+        printf("FAIL  %s: expected to find '%s' in:\n%.400s\n", what, needle,
+               haystack == NULL ? "(null)" : haystack);
+        failures++;
+    }
+}
+
+/* Pull the schema handle out of a load response. Returns 0 if there is none. */
+static long long handle_of(const char *response) {
+    const char *found = response == NULL ? NULL : strstr(response, "\"handle\"");
+    long long handle = 0;
+    if (found == NULL || sscanf(found, "\"handle\" : %lld", &handle) != 1) {
+        /* The writer's spacing is not part of the protocol, so fall back to a looser scan. */
+        if (found == NULL || sscanf(found + 8, " %*[:] %lld", &handle) != 1) {
+            return 0;
+        }
+    }
+    return handle;
+}
+
+int main(void) {
+    graal_isolate_t *isolate = NULL;
+    graal_isolatethread_t *thread = NULL;
+
+    if (graal_create_isolate(NULL, &isolate, &thread) != 0) {
+        fprintf(stderr, "FAIL  graal_create_isolate\n");
+        return 1;
+    }
+    printf("ok    isolate created\n");
+
+    char *version = linkml_call(thread, "{\"op\":\"version\"}");
+    expect("version", version, "\"abiVersion\"");
+    linkml_free(thread, version);
+
+    char *loaded = linkml_call(thread, LOAD_REQUEST);
+    expect("load succeeded", loaded, "\"ok\"");
+    expect("load found no issues", loaded, "\"issues\"");
+    long long handle = handle_of(loaded);
+    linkml_free(thread, loaded);
+
+    if (handle <= 0) {
+        printf("FAIL  load returned no usable handle\n");
+        failures++;
+    } else {
+        char request[128];
+        snprintf(request, sizeof(request),
+                 "{\"op\":\"generate\",\"handle\":%lld,\"generator\":\"json-schema\"}", handle);
+        char *generated = linkml_call(thread, request);
+        /* The metamodel is compiled into the library, so `range: string` resolving at all proves
+         * that `linkml:types` survived into the native build. */
+        expect("json-schema generated", generated, "json-schema.org");
+        expect("the schema's own class is in it", generated, "Person");
+        linkml_free(thread, generated);
+
+        snprintf(request, sizeof(request), "{\"op\":\"close\",\"handle\":%lld}", handle);
+        char *closed = linkml_call(thread, request);
+        expect("close", closed, "\"ok\"");
+        linkml_free(thread, closed);
+    }
+
+    /* A bad request has to come back as an error rather than taking the process with it. */
+    char *rejected = linkml_call(thread, "{\"op\":\"nonsense\"}");
+    expect("an unknown op is rejected", rejected, "unknown op");
+    linkml_free(thread, rejected);
+
+    char *malformed = linkml_call(thread, "not json at all");
+    expect("malformed JSON is rejected", malformed, "\"error\"");
+    linkml_free(thread, malformed);
+
+    if (graal_tear_down_isolate(thread) != 0) {
+        printf("FAIL  graal_tear_down_isolate\n");
+        failures++;
+    } else {
+        printf("ok    isolate torn down\n");
+    }
+
+    if (failures > 0) {
+        printf("\n%d check(s) failed\n", failures);
+        return 1;
+    }
+    printf("\nall checks passed\n");
+    return 0;
+}

--- a/nativelib/smoke.c
+++ b/nativelib/smoke.c
@@ -17,9 +17,7 @@
 #include <stdlib.h>
 #include <string.h>
 
-/* An array rather than a `const char *`: native-image declares the parameter as plain `char *`, so
- * passing a const pointer warns in C and fails outright in C++. */
-static char LOAD_REQUEST[] =
+static const char *LOAD_REQUEST =
     "{\"op\":\"load\",\"schema\":\""
     "id: https://example.org/smoke\\n"
     "name: smoke\\n"

--- a/nativelib/smoke.sh
+++ b/nativelib/smoke.sh
@@ -1,0 +1,66 @@
+#!/usr/bin/env bash
+#
+# Compile and run nativelib/smoke.c against an unpacked release archive, to check that the archive
+# is usable from C on this platform.
+#
+# Kept out of the workflow files because the compiler and the way a program finds a shared library
+# at run time differ per platform, and that is easier to read (and to run by hand) here.
+#
+# Usage: nativelib/smoke.sh <prefix>
+#
+#   prefix   an unpacked archive, i.e. the directory holding include/ and lib/
+
+set -euo pipefail
+
+if [ "$#" -ne 1 ]; then
+  sed -n '2,12p' "$0" >&2
+  exit 2
+fi
+
+prefix="$(cd "$1" && pwd)"
+here="$(cd "$(dirname "$0")" && pwd)"
+work="$(mktemp -d)"
+trap 'rm -rf "$work"' EXIT
+
+if [ ! -d "${prefix}/include" ]; then
+  echo "error: ${prefix} has no include/ directory" >&2
+  exit 1
+fi
+
+# Collect candidates with nullglob rather than `ls`: `ls a.so b.dylib` exits non-zero for the
+# pattern that does not match even when the other does, which under `set -e` kills the script
+# before it compiles anything.
+shopt -s nullglob
+runtime_libs=("${prefix}"/lib/*.so "${prefix}"/lib/*.dylib "${prefix}"/bin/*.dll)
+import_libs=("${prefix}"/lib/*.lib)
+shopt -u nullglob
+
+if [ ${#runtime_libs[@]} -eq 0 ]; then
+  echo "error: no .so, .dylib or .dll found under ${prefix}" >&2
+  exit 1
+fi
+echo "found $(basename "${runtime_libs[0]}")"
+
+case "$(uname -s)" in
+MINGW* | MSYS* | CYGWIN* | Windows_NT)
+  if [ ${#import_libs[@]} -eq 0 ]; then
+    echo "error: no import library (.lib) under ${prefix}/lib" >&2
+    exit 1
+  fi
+  # _CRT_SECURE_NO_WARNINGS: MSVC deprecates sscanf, which smoke.c uses to read the handle back.
+  # The // prefixes stop MSYS bash rewriting /flags into Windows paths.
+  cl //nologo //D_CRT_SECURE_NO_WARNINGS "//I${prefix}/include" "${here}/smoke.c" \
+    "//Fe:${work}/smoke.exe" //link "${import_libs[0]}"
+  # The loader finds a DLL through PATH.
+  PATH="${prefix}/bin:${PATH}" "${work}/smoke.exe"
+  ;;
+*)
+  # An rpath rather than LD_LIBRARY_PATH/DYLD_LIBRARY_PATH: it is baked into the binary, so the
+  # program runs from anywhere, and it survives macOS stripping DYLD_* from protected processes.
+  cc "${here}/smoke.c" -o "${work}/smoke" \
+    -I"${prefix}/include" -L"${prefix}/lib" -llinkml_scala \
+    -Wl,-rpath,"${prefix}/lib"
+  # Deliberately no library path in the environment: if this runs, the rpath is right.
+  (cd / && "${work}/smoke")
+  ;;
+esac

--- a/nativelib/smoke.sh
+++ b/nativelib/smoke.sh
@@ -20,7 +20,7 @@ fi
 prefix="$(cd "$1" && pwd)"
 here="$(cd "$(dirname "$0")" && pwd)"
 work="$(mktemp -d)"
-trap 'rm -rf "$work"' EXIT
+echo "building in ${work}" >&2
 
 if [ ! -d "${prefix}/include" ]; then
   echo "error: ${prefix} has no include/ directory" >&2

--- a/nativelib/src/eu/neverblink/linkml/nativelib/LinkMlCApi.java
+++ b/nativelib/src/eu/neverblink/linkml/nativelib/LinkMlCApi.java
@@ -117,76 +117,9 @@ public final class LinkMlCApi {
         }
     }
 
-    // Generators. Each returns its document, or NULL with *error set.
+    // The generator entry points are in LinkMlCGenerators, generated from
+    // mill-build/src/Entrypoints.scala. They all share the `document` helper below.
 
-    /** Generate JSON Schema. Options: {@code open}, {@code treeRoot}, {@code treeRootInlineType}. */
-    @CEntryPoint(name = "linkml_json_schema")
-    static CCharPointer jsonSchema(
-            IsolateThread thread, long handle, @CConst CCharPointer options, CCharPointerPointer error) {
-        return document(handle, options, error, LinkMlNativeApi::jsonSchema);
-    }
-
-    /** Generate SHACL shapes as N-Triples. Options: {@code open}, {@code onlyClassesFromRootSchema}. */
-    @CEntryPoint(name = "linkml_shacl")
-    static CCharPointer shacl(
-            IsolateThread thread, long handle, @CConst CCharPointer options, CCharPointerPointer error) {
-        return document(handle, options, error, LinkMlNativeApi::shacl);
-    }
-
-    /** Generate RDFS as N-Triples. Options: {@code onlyClassesFromRootSchema}. */
-    @CEntryPoint(name = "linkml_rdfs")
-    static CCharPointer rdfs(
-            IsolateThread thread, long handle, @CConst CCharPointer options, CCharPointerPointer error) {
-        return document(handle, options, error, LinkMlNativeApi::rdfs);
-    }
-
-    /**
-     * Materialize a derived LinkML schema. Options: {@code skipDerivation}, {@code pruningMode},
-     * {@code treeRoot}, {@code format}.
-     */
-    @CEntryPoint(name = "linkml_linkml")
-    static CCharPointer linkml(
-            IsolateThread thread, long handle, @CConst CCharPointer options, CCharPointerPointer error) {
-        return document(handle, options, error, LinkMlNativeApi::linkml);
-    }
-
-    /** Generate a Frictionless Table Schema as JSON. Options: {@code treeRoot}. */
-    @CEntryPoint(name = "linkml_table_schema")
-    static CCharPointer tableSchema(
-            IsolateThread thread, long handle, @CConst CCharPointer options, CCharPointerPointer error) {
-        return document(handle, options, error, LinkMlNativeApi::tableSchema);
-    }
-
-    /** Generate a GraphQL schema. Options: {@code pruningMode}, {@code treeRoot}. */
-    @CEntryPoint(name = "linkml_graphql")
-    static CCharPointer graphQl(
-            IsolateThread thread, long handle, @CConst CCharPointer options, CCharPointerPointer error) {
-        return document(handle, options, error, LinkMlNativeApi::graphQl);
-    }
-
-    /**
-     * Generate a Mermaid ER diagram. Options: {@code pruningMode}, {@code treeRoot}, {@code
-     * optionalMarker}.
-     */
-    @CEntryPoint(name = "linkml_er_diagram")
-    static CCharPointer erDiagram(
-            IsolateThread thread, long handle, @CConst CCharPointer options, CCharPointerPointer error) {
-        return document(handle, options, error, LinkMlNativeApi::erDiagram);
-    }
-
-    /**
-     * Generate Scala sources, as a JSON object mapping filename to source. JSON because this is the
-     * one generator producing several files. Options: {@code package}, {@code generateEmitPrefixes}.
-     */
-    @CEntryPoint(name = "linkml_scala")
-    static CCharPointer scalaFiles(
-            IsolateThread thread, long handle, @CConst CCharPointer options, CCharPointerPointer error) {
-        return document(handle, options, error, LinkMlNativeApi::scalaFiles);
-    }
-
-    /**
-     * Lint a loaded schema, returning a validation report as JSON. Options: {@code inferMessages}.
-     */
     @CEntryPoint(name = "linkml_lint")
     static CCharPointer lint(
             IsolateThread thread, long handle, @CConst CCharPointer options, CCharPointerPointer error) {
@@ -209,14 +142,14 @@ public final class LinkMlCApi {
 
     /** One of the generator entry points on {@link LinkMlNativeApi}. */
     @FunctionalInterface
-    private interface Generator {
+    interface Generator {
         String generate(long handle, String optionsJson);
     }
 
     /**
      * Run a generator, applying the NULL-plus-message convention.
      */
-    private static CCharPointer document(
+    static CCharPointer document(
             long handle, @CConst CCharPointer options, CCharPointerPointer error, Generator work) {
         clear(error);
         try {
@@ -279,6 +212,8 @@ public final class LinkMlCApi {
     /**
      * Copy a string into unmanaged memory as NUL-terminated UTF-8, so it stays valid after the call
      * returns and can be freed from C.
+     * <p>
+     * TODO LNK-186: (perf) reduce memory copies and string re-encoding
      */
     private static CCharPointer copy(String value) {
         byte[] bytes = value.getBytes(StandardCharsets.UTF_8);

--- a/nativelib/src/eu/neverblink/linkml/nativelib/LinkMlCApi.java
+++ b/nativelib/src/eu/neverblink/linkml/nativelib/LinkMlCApi.java
@@ -6,6 +6,7 @@ import org.graalvm.nativeimage.IsolateThread;
 import org.graalvm.nativeimage.UnmanagedMemory;
 import org.graalvm.nativeimage.c.function.CEntryPoint;
 import org.graalvm.nativeimage.c.type.CCharPointer;
+import org.graalvm.nativeimage.c.type.CConst;
 import org.graalvm.nativeimage.c.type.CTypeConversion;
 
 /**
@@ -36,7 +37,7 @@ public final class LinkMlCApi {
      *     linkml_free}
      */
     @CEntryPoint(name = "linkml_call")
-    static CCharPointer call(IsolateThread thread, CCharPointer request) {
+    static CCharPointer call(IsolateThread thread, @CConst CCharPointer request) {
         String response;
         try {
             response = LinkMlNativeApi.call(CTypeConversion.toJavaString(request));
@@ -72,6 +73,8 @@ public final class LinkMlCApi {
     /**
      * Copy a string into unmanaged memory as NUL-terminated UTF-8, so that it stays valid after this
      * call returns and can be freed from C.
+     *
+     * TODO: direct serialize to the buffer with jsoniter?
      */
     private static CCharPointer toCString(String value) {
         byte[] bytes = value.getBytes(StandardCharsets.UTF_8);

--- a/nativelib/src/eu/neverblink/linkml/nativelib/LinkMlCApi.java
+++ b/nativelib/src/eu/neverblink/linkml/nativelib/LinkMlCApi.java
@@ -6,77 +6,281 @@ import org.graalvm.nativeimage.IsolateThread;
 import org.graalvm.nativeimage.UnmanagedMemory;
 import org.graalvm.nativeimage.c.function.CEntryPoint;
 import org.graalvm.nativeimage.c.type.CCharPointer;
+import org.graalvm.nativeimage.c.type.CCharPointerPointer;
 import org.graalvm.nativeimage.c.type.CConst;
 import org.graalvm.nativeimage.c.type.CTypeConversion;
+import org.graalvm.word.WordFactory;
 
 /**
- * The C ABI of the shared library: two functions, both of which GraalVM turns into exported
- * symbols.
+ * The C ABI of the shared library.
  *
- * <p>{@code linkml_call} takes a JSON request and returns a JSON response, both NUL-terminated
- * UTF-8. See {@link LinkMlNativeApi} for the protocol. {@code linkml_free} releases a response.
+ * <p>Conventions:
  *
- * <p>This is Java rather than Scala because {@code @CEntryPoint} methods have to be static, and
- * writing them here is more direct than relying on the static forwarders the Scala compiler
- * generates for an {@code object}.
+ * <ul>
+ *   <li><b>Options are one JSON string</b>, and may be NULL for defaults. The recognized fields
+ *   are documented in docs/python_bindings.md.
+ *   <li><b>Failure is NULL plus a message.</b> A function that returns a string returns NULL and
+ *       writes the reason to {@code *error}. Loading returns handle 0 instead. Both {@code *error}
+ *       and {@code *report} are set to NULL first, so a caller can reuse them across calls.
+ * </ul>
  *
- * <p>Every entry point also has to catch {@link Throwable}: an exception escaping into C aborts the
- * whole process, which for a library loaded into someone else's Python interpreter is unacceptable.
+ * <p>Every string the functions return -- documents, reports and error messages -- are owned by the
+ * caller and must be released with {@code linkml_free}.
  */
 public final class LinkMlCApi {
 
     private LinkMlCApi() {}
 
-    /**
-     * Run one request.
-     *
-     * @param thread the calling thread's isolate thread, from {@code graal_create_isolate} or
-     *     {@code graal_attach_thread}
-     * @param request a NUL-terminated UTF-8 JSON request
-     * @return a NUL-terminated UTF-8 JSON response, which the caller must release with {@code
-     *     linkml_free}
-     */
-    @CEntryPoint(name = "linkml_call")
-    static CCharPointer call(IsolateThread thread, @CConst CCharPointer request) {
-        String response;
-        try {
-            response = LinkMlNativeApi.call(CTypeConversion.toJavaString(request));
-        } catch (Throwable outer) {
-            // LinkMlNativeApi.call() handles everything non-fatal itself, so getting here means
-            // something like a StackOverflowError -- which may well break the reply too.
-            try {
-                response = LinkMlNativeApi.fatalResponse(outer);
-            } catch (Throwable ignored) {
-                response = "{\"ok\":false,\"error\":\"unrecoverable error in the LinkML native library\"}";
-            }
-        }
-        return toCString(response);
+    /** The version of this ABI, so a caller can check it matches what it was built against. */
+    @CEntryPoint(name = "linkml_abi_version")
+    static int abiVersion(IsolateThread thread) {
+        return LinkMlNativeApi.abiVersion();
     }
 
     /**
-     * Release a response returned by {@code linkml_call}. Does nothing when given NULL.
+     * Load a schema from the file system, resolving its imports from disk.
      *
-     * @param thread the calling thread's isolate thread
-     * @param response a pointer previously returned by {@code linkml_call}
+     * @param path the schema file to read
+     * @param options JSON, or NULL. Recognizes {@code inferMessages}.
+     * @param report receives the validation report as JSON, whether loading succeeded
+     * @param error receives the reason the call could not be made
+     * @return a schema handle, or 0 if the schema could not be loaded
      */
-    @CEntryPoint(name = "linkml_free")
-    static void free(IsolateThread thread, CCharPointer response) {
+    @CEntryPoint(name = "linkml_load_file")
+    static long loadFile(
+            IsolateThread thread,
+            @CConst CCharPointer path,
+            @CConst CCharPointer options,
+            CCharPointerPointer report,
+            CCharPointerPointer error) {
+        clear(report);
+        clear(error);
         try {
-            if (response.isNonNull()) {
-                UnmanagedMemory.free(response);
+            // Converted inside the try: a bad pointer should be an error, not a crash.
+            return complete(report, LinkMlNativeApi.loadFile(string(path), string(options)));
+        } catch (Throwable failure) {
+            report(error, failure);
+            return 0L;
+        }
+    }
+
+    /**
+     * Load a schema from memory, resolving its imports against a caller-supplied map.
+     *
+     * <p>The map is two parallel string arrays.
+     *
+     * @param path the root schema's own key in the import map, or NULL to load {@code schema}
+     *     directly. Use this to correctly resolve circular imports.
+     * @param schema the root schema as YAML. Ignored when {@code path} is given.
+     * @param importNames import map keys, {@code importCount} of them
+     * @param importBodies the matching schema texts
+     * @param options JSON, or NULL. Recognizes {@code inferMessages}.
+     * @param report receives the validation report as JSON, whether loading succeeded
+     * @param error receives the reason the call could not be made
+     * @return a schema handle, or 0 if the schema could not be loaded
+     */
+    @CEntryPoint(name = "linkml_load_string")
+    static long loadString(
+            IsolateThread thread,
+            @CConst CCharPointer path,
+            @CConst CCharPointer schema,
+            CCharPointerPointer importNames,
+            CCharPointerPointer importBodies,
+            int importCount,
+            @CConst CCharPointer options,
+            CCharPointerPointer report,
+            CCharPointerPointer error) {
+        clear(report);
+        clear(error);
+        try {
+            return complete(
+                    report,
+                    LinkMlNativeApi.loadString(
+                            string(path),
+                            string(schema),
+                            strings(importNames, importCount),
+                            strings(importBodies, importCount),
+                            string(options)));
+        } catch (Throwable failure) {
+            report(error, failure);
+            return 0L;
+        }
+    }
+
+    /** Release a schema handle. Closing one that is already gone does nothing. */
+    @CEntryPoint(name = "linkml_close")
+    static void close(IsolateThread thread, long handle) {
+        try {
+            LinkMlNativeApi.close(handle);
+        } catch (Throwable ignored) {
+            // Releasing must not throw into C.
+        }
+    }
+
+    // Generators. Each returns its document, or NULL with *error set.
+
+    /** Generate JSON Schema. Options: {@code open}, {@code treeRoot}, {@code treeRootInlineType}. */
+    @CEntryPoint(name = "linkml_json_schema")
+    static CCharPointer jsonSchema(
+            IsolateThread thread, long handle, @CConst CCharPointer options, CCharPointerPointer error) {
+        return document(handle, options, error, LinkMlNativeApi::jsonSchema);
+    }
+
+    /** Generate SHACL shapes as N-Triples. Options: {@code open}, {@code onlyClassesFromRootSchema}. */
+    @CEntryPoint(name = "linkml_shacl")
+    static CCharPointer shacl(
+            IsolateThread thread, long handle, @CConst CCharPointer options, CCharPointerPointer error) {
+        return document(handle, options, error, LinkMlNativeApi::shacl);
+    }
+
+    /** Generate RDFS as N-Triples. Options: {@code onlyClassesFromRootSchema}. */
+    @CEntryPoint(name = "linkml_rdfs")
+    static CCharPointer rdfs(
+            IsolateThread thread, long handle, @CConst CCharPointer options, CCharPointerPointer error) {
+        return document(handle, options, error, LinkMlNativeApi::rdfs);
+    }
+
+    /**
+     * Materialize a derived LinkML schema. Options: {@code skipDerivation}, {@code pruningMode},
+     * {@code treeRoot}, {@code format}.
+     */
+    @CEntryPoint(name = "linkml_linkml")
+    static CCharPointer linkml(
+            IsolateThread thread, long handle, @CConst CCharPointer options, CCharPointerPointer error) {
+        return document(handle, options, error, LinkMlNativeApi::linkml);
+    }
+
+    /** Generate a Frictionless Table Schema as JSON. Options: {@code treeRoot}. */
+    @CEntryPoint(name = "linkml_table_schema")
+    static CCharPointer tableSchema(
+            IsolateThread thread, long handle, @CConst CCharPointer options, CCharPointerPointer error) {
+        return document(handle, options, error, LinkMlNativeApi::tableSchema);
+    }
+
+    /** Generate a GraphQL schema. Options: {@code pruningMode}, {@code treeRoot}. */
+    @CEntryPoint(name = "linkml_graphql")
+    static CCharPointer graphQl(
+            IsolateThread thread, long handle, @CConst CCharPointer options, CCharPointerPointer error) {
+        return document(handle, options, error, LinkMlNativeApi::graphQl);
+    }
+
+    /**
+     * Generate a Mermaid ER diagram. Options: {@code pruningMode}, {@code treeRoot}, {@code
+     * optionalMarker}.
+     */
+    @CEntryPoint(name = "linkml_er_diagram")
+    static CCharPointer erDiagram(
+            IsolateThread thread, long handle, @CConst CCharPointer options, CCharPointerPointer error) {
+        return document(handle, options, error, LinkMlNativeApi::erDiagram);
+    }
+
+    /**
+     * Generate Scala sources, as a JSON object mapping filename to source. JSON because this is the
+     * one generator producing several files. Options: {@code package}, {@code generateEmitPrefixes}.
+     */
+    @CEntryPoint(name = "linkml_scala")
+    static CCharPointer scalaFiles(
+            IsolateThread thread, long handle, @CConst CCharPointer options, CCharPointerPointer error) {
+        return document(handle, options, error, LinkMlNativeApi::scalaFiles);
+    }
+
+    /**
+     * Lint a loaded schema, returning a validation report as JSON. Options: {@code inferMessages}.
+     */
+    @CEntryPoint(name = "linkml_lint")
+    static CCharPointer lint(
+            IsolateThread thread, long handle, @CConst CCharPointer options, CCharPointerPointer error) {
+        return document(handle, options, error, LinkMlNativeApi::lint);
+    }
+
+    /** Release anything this library returned. Does nothing when given NULL. */
+    @CEntryPoint(name = "linkml_free")
+    static void free(IsolateThread thread, CCharPointer buffer) {
+        try {
+            if (buffer.isNonNull()) {
+                UnmanagedMemory.free(buffer);
             }
         } catch (Throwable ignored) {
             // Freeing must not throw into C. A leak beats a crash.
         }
     }
 
+    // Plumbing
+
+    /** One of the generator entry points on {@link LinkMlNativeApi}. */
+    @FunctionalInterface
+    private interface Generator {
+        String generate(long handle, String optionsJson);
+    }
+
     /**
-     * Copy a string into unmanaged memory as NUL-terminated UTF-8, so that it stays valid after this
-     * call returns and can be freed from C.
-     *
-     * TODO: direct serialize to the buffer with jsoniter?
+     * Run a generator, applying the NULL-plus-message convention.
      */
-    private static CCharPointer toCString(String value) {
+    private static CCharPointer document(
+            long handle, @CConst CCharPointer options, CCharPointerPointer error, Generator work) {
+        clear(error);
+        try {
+            return copy(work.generate(handle, string(options)));
+        } catch (Throwable failure) {
+            report(error, failure);
+            return WordFactory.nullPointer();
+        }
+    }
+
+    /** Write the report from `load` to its out-param and return the handle it produced. */
+    private static long complete(CCharPointerPointer report, LinkMlNativeApi.Loaded loaded) {
+        write(report, loaded.report());
+        return loaded.handle();
+    }
+
+    /** Describe a failure into an out-param, falling back to a constant if even that fails. */
+    private static void report(CCharPointerPointer error, Throwable failure) {
+        String message;
+        try {
+            message = LinkMlNativeApi.describe(failure);
+        } catch (Throwable ignored) {
+            // Getting here means something like a StackOverflowError, which may break the reply too.
+            message = "unrecoverable error in the LinkML native library";
+        }
+        write(error, message);
+    }
+
+    private static void clear(CCharPointerPointer out) {
+        if (out.isNonNull()) {
+            out.write(WordFactory.nullPointer());
+        }
+    }
+
+    private static void write(CCharPointerPointer out, String value) {
+        if (out.isNonNull()) {
+            out.write(copy(value));
+        }
+    }
+
+    /** NULL comes back as null, so an omitted optional argument stays optional in Scala. */
+    private static String string(CCharPointer ptr) {
+        return ptr.isNull() ? null : CTypeConversion.toJavaString(ptr);
+    }
+
+    private static String[] strings(CCharPointerPointer array, int count) {
+        if (count <= 0) {
+            return new String[0];
+        }
+        if (array.isNull()) {
+            throw new IllegalArgumentException("import map has " + count + " entries but no array");
+        }
+        String[] values = new String[count];
+        for (int i = 0; i < count; i++) {
+            values[i] = string(array.read(i));
+        }
+        return values;
+    }
+
+    /**
+     * Copy a string into unmanaged memory as NUL-terminated UTF-8, so it stays valid after the call
+     * returns and can be freed from C.
+     */
+    private static CCharPointer copy(String value) {
         byte[] bytes = value.getBytes(StandardCharsets.UTF_8);
         CCharPointer buffer = UnmanagedMemory.malloc(bytes.length + 1);
         ByteBuffer out = CTypeConversion.asByteBuffer(buffer, bytes.length + 1);

--- a/nativelib/src/eu/neverblink/linkml/nativelib/LinkMlCGenerators.java
+++ b/nativelib/src/eu/neverblink/linkml/nativelib/LinkMlCGenerators.java
@@ -11,9 +11,9 @@ import org.graalvm.nativeimage.c.type.CConst;
 /**
  * The generator entry points of the C ABI, one per generator.
  *
- * <p>All of them share the same shape: a schema handle, an options JSON that may be NULL for
+ * <p>All of them have the same shape: a schema handle, an options JSON that may be NULL for
  * defaults, and an error out-param. They return the generated document, or NULL with {@code
- * *error} set. Release whatever comes back with {@code linkml_free}.
+ * *error} set. Release returned strings with {@code linkml_free}.
  *
  * <p>See {@link LinkMlCApi} for loading, linting and the lifecycle.
  */

--- a/nativelib/src/eu/neverblink/linkml/nativelib/LinkMlCGenerators.java
+++ b/nativelib/src/eu/neverblink/linkml/nativelib/LinkMlCGenerators.java
@@ -1,0 +1,103 @@
+// AUTO-GENERATED from mill-build/src/Entrypoints.scala and the generators' Options case
+// classes. Do not edit by hand - regenerate with ./mill bindings.
+package eu.neverblink.linkml.nativelib;
+
+import org.graalvm.nativeimage.IsolateThread;
+import org.graalvm.nativeimage.c.function.CEntryPoint;
+import org.graalvm.nativeimage.c.type.CCharPointer;
+import org.graalvm.nativeimage.c.type.CCharPointerPointer;
+import org.graalvm.nativeimage.c.type.CConst;
+
+/**
+ * The generator entry points of the C ABI, one per generator.
+ *
+ * <p>All of them share the same shape: a schema handle, an options JSON that may be NULL for
+ * defaults, and an error out-param. They return the generated document, or NULL with {@code
+ * *error} set. Release whatever comes back with {@code linkml_free}.
+ *
+ * <p>See {@link LinkMlCApi} for loading, linting and the lifecycle.
+ */
+public final class LinkMlCGenerators {
+
+    private LinkMlCGenerators() {}
+
+    /** Generate JSON Schema. Options: {@code open}, {@code treeRoot}, {@code treeRootInlineType}, {@code indentationStep}. */
+    @CEntryPoint(name = "linkml_json_schema")
+    static CCharPointer jsonSchema(
+            IsolateThread thread,
+            long handle,
+            @CConst CCharPointer options,
+            CCharPointerPointer error) {
+        return LinkMlCApi.document(handle, options, error, LinkMlNativeApi::jsonSchema);
+    }
+
+    /** Generate SHACL shapes as N-Triples. Options: {@code open}, {@code onlyClassesFromRootSchema}. */
+    @CEntryPoint(name = "linkml_shacl")
+    static CCharPointer shacl(
+            IsolateThread thread,
+            long handle,
+            @CConst CCharPointer options,
+            CCharPointerPointer error) {
+        return LinkMlCApi.document(handle, options, error, LinkMlNativeApi::shacl);
+    }
+
+    /** Generate RDFS as N-Triples. Options: {@code onlyClassesFromRootSchema}. */
+    @CEntryPoint(name = "linkml_rdfs")
+    static CCharPointer rdfs(
+            IsolateThread thread,
+            long handle,
+            @CConst CCharPointer options,
+            CCharPointerPointer error) {
+        return LinkMlCApi.document(handle, options, error, LinkMlNativeApi::rdfs);
+    }
+
+    /** Materialize a derived LinkML schema. Options: {@code pruningMode}, {@code skipClassDerivation}, {@code outputFormat}. */
+    @CEntryPoint(name = "linkml_linkml")
+    static CCharPointer linkml(
+            IsolateThread thread,
+            long handle,
+            @CConst CCharPointer options,
+            CCharPointerPointer error) {
+        return LinkMlCApi.document(handle, options, error, LinkMlNativeApi::linkml);
+    }
+
+    /** Generate a Frictionless Table Schema as JSON. Options: {@code treeRoot}. */
+    @CEntryPoint(name = "linkml_table_schema")
+    static CCharPointer tableSchema(
+            IsolateThread thread,
+            long handle,
+            @CConst CCharPointer options,
+            CCharPointerPointer error) {
+        return LinkMlCApi.document(handle, options, error, LinkMlNativeApi::tableSchema);
+    }
+
+    /** Generate a GraphQL schema. Options: {@code pruningMode}. */
+    @CEntryPoint(name = "linkml_graphql")
+    static CCharPointer graphql(
+            IsolateThread thread,
+            long handle,
+            @CConst CCharPointer options,
+            CCharPointerPointer error) {
+        return LinkMlCApi.document(handle, options, error, LinkMlNativeApi::graphQl);
+    }
+
+    /** Generate a Mermaid entity relationship diagram. Options: {@code pruningMode}, {@code optionalMarker}. */
+    @CEntryPoint(name = "linkml_er_diagram")
+    static CCharPointer erDiagram(
+            IsolateThread thread,
+            long handle,
+            @CConst CCharPointer options,
+            CCharPointerPointer error) {
+        return LinkMlCApi.document(handle, options, error, LinkMlNativeApi::erDiagram);
+    }
+
+    /** Generate Scala sources, as a JSON object mapping filename to source. Options: {@code package}, {@code generateEmitPrefixes}. */
+    @CEntryPoint(name = "linkml_scala")
+    static CCharPointer scala(
+            IsolateThread thread,
+            long handle,
+            @CConst CCharPointer options,
+            CCharPointerPointer error) {
+        return LinkMlCApi.document(handle, options, error, LinkMlNativeApi::scalaFiles);
+    }
+}

--- a/nativelib/src/eu/neverblink/linkml/nativelib/LinkMlNativeApi.scala
+++ b/nativelib/src/eu/neverblink/linkml/nativelib/LinkMlNativeApi.scala
@@ -1,7 +1,5 @@
 package eu.neverblink.linkml.nativelib
 
-import com.github.plokhotnyuk.jsoniter_scala.core.{JsonValueCodec, readFromString}
-import com.github.plokhotnyuk.jsoniter_scala.macros.{CodecMakerConfig, JsonCodecMaker}
 import eu.neverblink.linkml.generator.erdiagram.ErDiagramGenerator
 import eu.neverblink.linkml.generator.graphql.GraphQlGenerator
 import eu.neverblink.linkml.generator.jsonschema.JsonSchemaGenerator
@@ -11,172 +9,175 @@ import eu.neverblink.linkml.generator.rdfs.RdfsGenerator
 import eu.neverblink.linkml.generator.scala.ScalaGenerator
 import eu.neverblink.linkml.generator.shacl.ShaclGenerator
 import eu.neverblink.linkml.generator.tableschema.TableSchemaGenerator
-import eu.neverblink.linkml.generator.util.{JsonUtil, PruningMode, StringSink}
-import eu.neverblink.linkml.schemaview.{Case, SchemaValidator, SchemaView, StringImporter}
+import eu.neverblink.linkml.generator.util.{JsonUtil, StringSink}
+import eu.neverblink.linkml.schemaview.{SchemaValidator, SchemaView, StringImporter}
 import eu.neverblink.linkml.validation.{Codec, SchemaIssue, SchemaValidationReportImpl}
 import org.virtuslab.yaml.{Node, StringNode}
 
 import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.atomic.AtomicLong
-import scala.util.control.NonFatal
 
-/** The whole LinkML API behind a single JSON-in, JSON-out function.
+/** Methods that [[LinkMlCApi]] calls: one method per exported C function.
   *
-  * [[LinkMlCApi]] exposes [[call]] to C (and therefore to Python) as `linkml_call`. Keeping the C
-  * surface down to one function means the ABI does not change when a generator gains an option:
-  * only the JSON inside it does.
+  * Failures are thrown. [[LinkMlCApi]] turns them into the C error convention.
   *
-  * A request is a JSON object with an `op` field, deserialized into a [[Request]]. A response is a
-  * JSON object with an `ok` field, plus `error` when `ok` is false. The recognized ops:
-  *
-  *   - `{"op": "version"}` -> `{"abiVersion": 1}`
-  *   - `{"op": "load", "schema"|"path": "...", "imports": {...}, "inferMessages": true}` ->
-  *     `{"handle": 7, "report": {...}}`, with `handle` left out if the schema had fatal problems
-  *   - `{"op": "generate", "handle": 7, "generator": "shacl", "options": {...}}` ->
-  *     `{"output": "..."}`, or `{"files": {"Foo.scala": "..."}}` for the Scala generator
-  *   - `{"op": "lint", "handle": 7, "inferMessages": true}` -> `{"report": {...}}`
-  *   - `{"op": "close", "handle": 7}` -> `{}`
-  *
-  * Loaded schemas live in a table here rather than being handed to the caller as pointers, so a
-  * stale or made-up handle is a plain error response instead of a crash.
+  * Loaded schemas live in a table here and are handed out as integer handles.
   */
 object LinkMlNativeApi {
 
-  /** Bumped whenever a change to the request or response shape breaks existing callers. */
+  /** Bumped whenever a change to the exported functions or to the options JSON breaks existing
+    * callers.
+    */
   final val abiVersion: Int = 1
 
   private val schemas = new ConcurrentHashMap[java.lang.Long, SchemaView]()
 
   private val handleSeq = new AtomicLong(0L)
 
-  /** Handle one request. Never throws: everything that goes wrong comes back as an error response.
+  /** A loaded schema: the handle to use for it, and the validation report from loading it. */
+  final class Loaded private[nativelib] (val handle: Long, val report: String)
+
+  // Loading
+
+  /** Load a schema from the file system, resolving its imports the same way the CLI does.
+    *
+    * @return
+    *   a handle and the report, or handle 0 and a report saying why the schema could not be loaded
     */
-  def call(request: String): String =
-    try {
-      val req =
-        try readFromString(request)(using Request.codec)
-        catch {
-          case ex if NonFatal(ex) => throw BadRequest(s"malformed request: ${ex.getMessage}")
-        }
-      req.op match {
-        case "version" => ok(field("abiVersion", numberNode(abiVersion)))
-        case "load" => load(req)
-        case "generate" => generate(req)
-        case "lint" => lint(req)
-        case "close" => close(req)
-        case other => throw BadRequest(s"unknown op '$other'")
-      }
-    } catch {
-      case ex: BadRequest => error(ex.getMessage)
-      case ex if NonFatal(ex) => error(describe(ex))
-    }
+  def loadFile(path: String, optionsJson: String): Loaded =
+    loaded(SchemaView.loadSchemaViewFromUri(path), Some(path), Options.load(optionsJson))
 
-  /** Last-resort response for something [[call]] could not catch itself, such as a
-    * [[StackOverflowError]]. Called from [[LinkMlCApi]], which has its own fallback in case even
-    * this fails.
+  /** Load a schema from YAML text, resolving its imports against a caller-supplied map.
+    *
+    * @param path
+    *   the root schema's own path within the import map, or null to load [[schema]] directly.
+    *   Giving a path makes loading immune to an import that references the root back, because the
+    *   root is then tracked from the start.
+    * @param schema
+    *   the root schema as YAML. Ignored when [[path]] is given, since the root is read from the
+    *   map.
+    * @param importNames
+    *   import map keys, positionally matched with [[importBodies]]
     */
-  def fatalResponse(t: Throwable): String = error(describe(t))
-
-  private def load(req: Request): String = {
-    val (loaded, runId) = (req.schema, req.path) match {
-      case (Some(yaml), _) =>
-        (
-          SchemaView.loadSchemaViewFromString(yaml, ImportMap(req.imports.getOrElse(Map.empty))),
-          None,
-        )
-      case (None, Some(path)) =>
-        // No import map at all means "read imports off the file system", which is what the CLI
-        // does. An empty one is still a map, and fails on the first import.
-        val loaded = req.imports.fold(SchemaView.loadSchemaViewFromUri(path))(map =>
-          SchemaView.loadSchemaViewFromUri(path, ImportMap(map)),
-        )
-        (loaded, Some(path))
-      case (None, None) =>
-        throw BadRequest("load needs either a 'schema' (YAML text) or a 'path' field")
+  def loadString(
+      path: String,
+      schema: String,
+      importNames: Array[String],
+      importBodies: Array[String],
+      optionsJson: String,
+  ): Loaded = {
+    if importNames.length != importBodies.length then
+      throw BadRequest(
+        s"the import map has ${importNames.length} names but ${importBodies.length} bodies",
+      )
+    val importer = ImportMap(importNames.zip(importBodies).toMap)
+    val options = Options.load(optionsJson)
+    if path ne null then
+      loaded(SchemaView.loadSchemaViewFromUri(path, importer), Some(path), options)
+    else {
+      if schema eq null then throw BadRequest("loading needs either a path or the schema text")
+      loaded(SchemaView.loadSchemaViewFromString(schema, importer), None, options)
     }
+  }
 
-    loaded match {
+  /** Drop a schema handle. Closing one that is already gone is not an error, so a caller can close
+    * from a finalizer without tracking whether it already did.
+    */
+  def close(handle: Long): Unit = {
+    schemas.remove(handle)
+    ()
+  }
+
+  // Generators returning a single document
+
+  def jsonSchema(handle: Long, optionsJson: String): String = {
+    given SchemaView = view(handle)
+    JsonSchemaGenerator().serialize(Options.jsonSchema(optionsJson))
+  }
+
+  def shacl(handle: Long, optionsJson: String): String = {
+    given SchemaView = view(handle)
+    nTriples(ShaclGenerator().generate(_, Options.shacl(optionsJson)))
+  }
+
+  def rdfs(handle: Long, optionsJson: String): String = {
+    given SchemaView = view(handle)
+    nTriples(RdfsGenerator().generate(_, Options.rdfs(optionsJson)))
+  }
+
+  def linkml(handle: Long, optionsJson: String): String = {
+    given SchemaView = view(handle)
+    LinkMlGenerator().serialize(Options.linkml(optionsJson))
+  }
+
+  def tableSchema(handle: Long, optionsJson: String): String = {
+    given SchemaView = view(handle)
+    TableSchemaGenerator().serialize(Options.tableSchema(optionsJson))
+  }
+
+  def graphQl(handle: Long, optionsJson: String): String = {
+    given SchemaView = view(handle)
+    GraphQlGenerator().serialize(Options.graphQl(optionsJson))
+  }
+
+  def erDiagram(handle: Long, optionsJson: String): String = {
+    given SchemaView = view(handle)
+    ErDiagramGenerator().serialize(Options.erDiagram(optionsJson))
+  }
+
+  // Results that are structured, and so come back as JSON
+
+  /** Generate Scala sources, as a JSON object mapping filename to source. */
+  def scalaFiles(handle: Long, optionsJson: String): String = {
+    given SchemaView = view(handle)
+    val generated = ScalaGenerator().generate(Options.scala(optionsJson))
+    JsonUtil.yamlToJson(
+      Node.MappingNode(generated.map((name, text) => entry(name, StringNode(text))).toMap),
+    )
+  }
+
+  /** Lint a loaded schema, as a `SchemaValidationReport` in JSON. */
+  def lint(handle: Long, optionsJson: String): String = {
+    val sv = view(handle)
+    report(SchemaValidator(using sv).lintProblems, None, Options.load(optionsJson).inferMessages)
+  }
+
+  /** Turn an exception into the message that goes into the C error out-param.
+    *
+    * Lives here rather than in [[LinkMlCApi]] so it can recognize [[BadRequest]] by type. Caller
+    * mistakes come through as just their message, since those are already written for a human to
+    * read; anything else gets its type attached, because it means a bug in here.
+    */
+  def describe(t: Throwable): String = t match {
+    case BadRequest(reason) => reason
+    case _ =>
+      val msg = t.getMessage
+      if msg eq null then t.getClass.getSimpleName
+      // The generators report the caller's mistakes as a plain RuntimeException.
+      else if t.getClass eq classOf[RuntimeException] then msg
+      else s"${t.getClass.getSimpleName}: $msg"
+  }
+
+  // Internals
+
+  private def loaded(
+      result: Either[Seq[SchemaIssue], SchemaView],
+      runId: Option[String],
+      options: LoadOptions,
+  ): Loaded =
+    result match {
       case Right(sv) =>
         val handle = handleSeq.incrementAndGet()
         schemas.put(handle, sv)
         // Lint straight away, so the report covers errors and warnings too, not just the fatals that
         // would have blocked loading.
         val issues = SchemaValidator(using sv).lintProblems
-        ok(
-          field("handle", numberNode(handle)),
-          field("report", reportNode(issues, runId, req.inferMessages)),
-        )
+        new Loaded(handle, report(issues, runId, options.inferMessages))
       case Left(fatals) =>
-        ok(field("report", reportNode(fatals, runId, req.inferMessages)))
+        new Loaded(0L, report(fatals, runId, options.inferMessages))
     }
-  }
 
-  private def generate(req: Request): String = {
-    given SchemaView = view(req)
-    val opts = req.options
-    req.generator.getOrElse(throw BadRequest("generate needs a 'generator' field")) match {
-      case "json-schema" =>
-        output(
-          JsonSchemaGenerator().serialize(
-            opts.open,
-            opts.treeRoot,
-            treeRootInlineTypeOverride = opts.treeRootInlineType,
-          ),
-        )
-
-      case "shacl" =>
-        output(nTriples(ShaclGenerator().generate(_, opts.open, opts.onlyClassesFromRootSchema)))
-
-      case "rdfs" =>
-        output(nTriples(RdfsGenerator().generate(_, opts.onlyClassesFromRootSchema)))
-
-      case "linkml" =>
-        output(
-          LinkMlGenerator().serialize(
-            skipClassDerivation = opts.skipDerivation,
-            pruningMode = opts.resolvedPruningMode,
-            outputFormat = opts.format.toLowerCase match {
-              case "yaml" | "yml" => LinkMlGenerator.OutputFormat.yaml
-              case "json" => LinkMlGenerator.OutputFormat.json
-              case other => throw BadRequest(s"unknown output format '$other', expected yaml|json")
-            },
-          ),
-        )
-
-      case "table-schema" => output(TableSchemaGenerator().serialize(opts.treeRoot))
-
-      case "graphql" => output(GraphQlGenerator().serialize(opts.resolvedPruningMode))
-
-      case "er-diagram" =>
-        output(ErDiagramGenerator().serialize(opts.resolvedPruningMode, opts.optionalMarker))
-
-      case "scala" =>
-        files(ScalaGenerator().generate(opts.`package`, opts.generateEmitPrefixes))
-
-      case other => throw BadRequest(s"unknown generator '$other'")
-    }
-  }
-
-  private def lint(req: Request): String = {
-    val sv = view(req)
-    ok(
-      field(
-        "report",
-        reportNode(SchemaValidator(using sv).lintProblems, runId = None, req.inferMessages),
-      ),
-    )
-  }
-
-  /** Drop a schema handle. Closing a handle that is already gone is not an error, so a caller can
-    * close from a finalizer without tracking whether it already did.
-    */
-  private def close(req: Request): String = {
-    schemas.remove(req.requiredHandle)
-    ok()
-  }
-
-  private def view(req: Request): SchemaView = {
-    val handle = req.requiredHandle
+  private def view(handle: Long): SchemaView = {
     val sv = schemas.get(handle)
     if (sv eq null) throw BadRequest(s"schema handle $handle is unknown or already closed")
     sv
@@ -191,124 +192,26 @@ object LinkMlNativeApi {
     sink.result
   }
 
-  private def reportNode(
+  private def report(
       issues: Seq[SchemaIssue],
       runId: Option[String],
       inferMessages: Boolean,
-  ): Node =
-    Codec.codec.encode(
-      SchemaValidationReportImpl(
-        issues = if inferMessages then issues.map(_.infer()) else issues,
-        validationRunId = runId,
+  ): String =
+    JsonUtil.yamlToJson(
+      Codec.codec.encode(
+        SchemaValidationReportImpl(
+          issues = if inferMessages then issues.map(_.infer()) else issues,
+          validationRunId = runId,
+        ),
       ),
     )
 
-  // Response building. The validation report is already a YAML node, so responses are built as
-  // nodes too and serialized with the same JSON writer the JS bindings use.
+  private def entry(name: String, value: Node): (Node, Node) = StringNode(name) -> value
 
-  private def ok(fields: (Node, Node)*): String =
-    JsonUtil.yamlToJson(Node.MappingNode((field("ok", trueNode) +: fields)*))
-
-  private def error(message: String): String =
-    JsonUtil.yamlToJson(
-      Node.MappingNode(field("ok", falseNode), field("error", StringNode(message))),
-    )
-
-  private def output(text: String): String = ok(field("output", StringNode(text)))
-
-  private def files(generated: Iterable[(String, String)]): String =
-    ok(field("files", Node.MappingNode(generated.map((n, t) => field(n, StringNode(t))).toMap)))
-
-  private def field(name: String, value: Node): (Node, Node) = StringNode(name) -> value
-
-  private def numberNode(value: Long): Node = Node.ScalarNode(value.toString)
-
-  private val trueNode: Node = Node.ScalarNode("true")
-
-  private val falseNode: Node = Node.ScalarNode("false")
-
-  /** Turn an exception into an error message.
-    *
-    * The generators report things the caller did wrong by throwing a plain `RuntimeException`, and
-    * those messages are already written for a human, so they go through as they are. Anything else
-    * is a bug in here, and gets its type attached to say so.
-    */
-  private def describe(t: Throwable): String = {
-    val msg = t.getMessage
-    if (msg eq null) t.getClass.getSimpleName
-    else if (t.getClass eq classOf[RuntimeException]) msg
-    else s"${t.getClass.getSimpleName}: $msg"
-  }
-
-  /** A schema importer backed by a caller-supplied filename -> YAML map. */
+  /** A schema importer backed by the caller-supplied filename to YAML map. */
   private final case class ImportMap(map: Map[String, String]) extends StringImporter {
     override def read(path: String): String =
       map.getOrElse(path, throw BadRequest(s"could not read from the import map: $path"))
   }
-}
 
-/** A request that is missing a field, or names something that does not exist. Reported back to the
-  * caller as an error response.
-  */
-private final case class BadRequest(reason: String) extends RuntimeException(reason)
-
-/** One request, as sent over the C boundary.
-  *
-  * Fields that only some ops use are optional or defaulted, so callers send just what they mean. A
-  * field the codec does not know about is an error rather than something silently dropped, which
-  * turns a typo on the Python side into a message instead of a mysteriously ignored option.
-  */
-private final case class Request(
-    op: String,
-    schema: Option[String] = None,
-    path: Option[String] = None,
-    imports: Option[Map[String, String]] = None,
-    inferMessages: Boolean = true,
-    handle: Long = 0L,
-    generator: Option[String] = None,
-    options: GeneratorOptions = GeneratorOptions(),
-) {
-
-  /** The schema handle this request works on. Handles start at 1, so 0 means it was left out. */
-  def requiredHandle: Long =
-    if handle <= 0L then throw BadRequest(s"'${op}' needs a 'handle' field") else handle
-}
-
-private object Request {
-  given codec: JsonValueCodec[Request] =
-    JsonCodecMaker.make(CodecMakerConfig.withSkipUnexpectedFields(false))
-}
-
-/** Every generator option there is, in one flat object. Each generator reads the ones it knows and
-  * ignores the rest; the Python bindings only ever send the relevant ones.
-  */
-private final case class GeneratorOptions(
-    open: Boolean = false,
-    treeRoot: Option[String] = None,
-    treeRootInlineType: Option[String] = None,
-    onlyClassesFromRootSchema: Boolean = false,
-    skipDerivation: Boolean = false,
-    pruningMode: String = "skip",
-    format: String = "yaml",
-    optionalMarker: Boolean = true,
-    `package`: String = "eu.neverblink.linkml.metamodel",
-    generateEmitPrefixes: Boolean = true,
-) {
-
-  /** The pruning mode, with the tree root override folded in. Accepts camel, kebab and snake case
-    * alike, as the CLI's `--pruning-mode` does.
-    */
-  def resolvedPruningMode: PruningMode = {
-    val normalized = Case.camelCase(pruningMode)
-    if !GeneratorOptions.pruningModes.contains(normalized) then
-      throw BadRequest(
-        s"unknown pruning mode '$pruningMode', expected one of: " +
-          GeneratorOptions.pruningModes.mkString(", "),
-      )
-    PruningMode(normalized, treeRoot)
-  }
-}
-
-private object GeneratorOptions {
-  private val pruningModes = Seq("treeRoot", "schema", "skip")
 }

--- a/nativelib/src/eu/neverblink/linkml/nativelib/Options.scala
+++ b/nativelib/src/eu/neverblink/linkml/nativelib/Options.scala
@@ -1,0 +1,147 @@
+package eu.neverblink.linkml.nativelib
+
+import com.github.plokhotnyuk.jsoniter_scala.core.*
+import com.github.plokhotnyuk.jsoniter_scala.macros.{CodecMakerConfig, JsonCodecMaker}
+import eu.neverblink.linkml.generator.erdiagram.ErDiagramGenerator
+import eu.neverblink.linkml.generator.graphql.GraphQlGenerator
+import eu.neverblink.linkml.generator.jsonschema.JsonSchemaGenerator
+import eu.neverblink.linkml.generator.linkml.LinkMlGenerator
+import eu.neverblink.linkml.generator.rdfs.RdfsGenerator
+import eu.neverblink.linkml.generator.scala.ScalaGenerator
+import eu.neverblink.linkml.generator.shacl.ShaclGenerator
+import eu.neverblink.linkml.generator.tableschema.TableSchemaGenerator
+import eu.neverblink.linkml.generator.util.PruningMode
+
+import scala.util.control.NonFatal
+
+/** Something the caller got wrong: an unknown handle, an option that does not exist, a value out of
+  * range.
+  */
+private final case class BadRequest(reason: String) extends RuntimeException(reason)
+
+/** Reads the options JSON of the C API into the generators' own option types.
+  *
+  * A null or empty string means "all defaults".
+  */
+private object Options {
+
+  private given pruningModeCodec: JsonValueCodec[PruningMode] = new JsonValueCodec[PruningMode] {
+    override def decodeValue(in: JsonReader, default: PruningMode): PruningMode =
+      if in.isNextToken('{') then {
+        val mode =
+          if in.isCharBufEqualsTo(in.readKeyAsCharBuf(), "treeRoot") then
+            PruningMode.treeRoot(Some(in.readString(null)))
+          else in.decodeError("the only pruning mode taking a value is 'treeRoot'")
+        if !in.isNextToken('}') then in.decodeError("expected a single-field object")
+        mode
+      } else {
+        in.rollbackToken()
+        named(in.readString(null), in)
+      }
+
+    override def encodeValue(x: PruningMode, out: JsonWriter): Unit = x match {
+      case PruningMode.treeRoot(Some(root)) =>
+        out.writeObjectStart()
+        out.writeKey("treeRoot")
+        out.writeVal(root)
+        out.writeObjectEnd()
+      case PruningMode.treeRoot(None) => out.writeVal("treeRoot")
+      case PruningMode.schemaRoot => out.writeVal("schema")
+      case PruningMode.skip => out.writeVal("skip")
+    }
+
+    override def nullValue: PruningMode = null
+
+    private def named(value: String, in: JsonReader): PruningMode = value match {
+      case "treeRoot" | "tree_root" | "tree-root" => PruningMode.treeRoot(None)
+      case "schema" => PruningMode.schemaRoot
+      case "skip" => PruningMode.skip
+      case other =>
+        in.decodeError(s"unknown pruning mode '$other', expected treeRoot, schema or skip")
+    }
+  }
+
+  private given outputFormatCodec: JsonValueCodec[LinkMlGenerator.OutputFormat] =
+    new JsonValueCodec[LinkMlGenerator.OutputFormat] {
+      override def decodeValue(
+          in: JsonReader,
+          default: LinkMlGenerator.OutputFormat,
+      ): LinkMlGenerator.OutputFormat = in.readString(null) match {
+        case "yaml" | "yml" => LinkMlGenerator.OutputFormat.yaml
+        case "json" => LinkMlGenerator.OutputFormat.json
+        case other => in.decodeError(s"unknown output format '$other', expected yaml or json")
+      }
+
+      override def encodeValue(x: LinkMlGenerator.OutputFormat, out: JsonWriter): Unit =
+        out.writeVal(x.toString)
+
+      override def nullValue: LinkMlGenerator.OutputFormat = null
+    }
+
+  // Unknown fields are rejected rather than skipped.
+  private given jsonSchemaOptions: JsonValueCodec[JsonSchemaGenerator.Options] =
+    JsonCodecMaker.make(CodecMakerConfig.withSkipUnexpectedFields(false))
+
+  private given shaclOptions: JsonValueCodec[ShaclGenerator.Options] =
+    JsonCodecMaker.make(CodecMakerConfig.withSkipUnexpectedFields(false))
+
+  private given rdfsOptions: JsonValueCodec[RdfsGenerator.Options] =
+    JsonCodecMaker.make(CodecMakerConfig.withSkipUnexpectedFields(false))
+
+  private given linkmlOptions: JsonValueCodec[LinkMlGenerator.Options] =
+    JsonCodecMaker.make(CodecMakerConfig.withSkipUnexpectedFields(false))
+
+  private given tableSchemaOptions: JsonValueCodec[TableSchemaGenerator.Options] =
+    JsonCodecMaker.make(CodecMakerConfig.withSkipUnexpectedFields(false))
+
+  private given graphQlOptions: JsonValueCodec[GraphQlGenerator.Options] =
+    JsonCodecMaker.make(CodecMakerConfig.withSkipUnexpectedFields(false))
+
+  private given erDiagramOptions: JsonValueCodec[ErDiagramGenerator.Options] =
+    JsonCodecMaker.make(CodecMakerConfig.withSkipUnexpectedFields(false))
+
+  private given scalaOptions: JsonValueCodec[ScalaGenerator.Options] =
+    JsonCodecMaker.make(CodecMakerConfig.withSkipUnexpectedFields(false))
+
+  private given loadOptions: JsonValueCodec[LoadOptions] =
+    JsonCodecMaker.make(CodecMakerConfig.withSkipUnexpectedFields(false))
+
+  private val readable = ReaderConfig.withAppendHexDumpToParseException(false)
+
+  /** Parse an options JSON, or return [[defaults]] when there is nothing to parse. */
+  def apply[T](json: String, defaults: T)(using JsonValueCodec[T]): T =
+    if (json eq null) || json.isEmpty then defaults
+    else
+      try readFromString(json, readable)
+      catch {
+        case ex if NonFatal(ex) => throw BadRequest(s"malformed options: ${ex.getMessage}")
+      }
+
+  def jsonSchema(json: String): JsonSchemaGenerator.Options =
+    apply(json, JsonSchemaGenerator.Options())
+
+  def shacl(json: String): ShaclGenerator.Options = apply(json, ShaclGenerator.Options())
+
+  def rdfs(json: String): RdfsGenerator.Options = apply(json, RdfsGenerator.Options())
+
+  def linkml(json: String): LinkMlGenerator.Options = apply(json, LinkMlGenerator.Options())
+
+  def tableSchema(json: String): TableSchemaGenerator.Options =
+    apply(json, TableSchemaGenerator.Options())
+
+  def graphQl(json: String): GraphQlGenerator.Options = apply(json, GraphQlGenerator.Options())
+
+  def erDiagram(json: String): ErDiagramGenerator.Options =
+    apply(json, ErDiagramGenerator.Options())
+
+  def scala(json: String): ScalaGenerator.Options = apply(json, ScalaGenerator.Options())
+
+  def load(json: String): LoadOptions = apply(json, LoadOptions())
+}
+
+/** @param inferMessages
+  *   Whether to fill in each issue's human-readable `message` and `details`.
+  */
+private final case class LoadOptions(
+    inferMessages: Boolean = true,
+)

--- a/python/linkml_scala/__init__.py
+++ b/python/linkml_scala/__init__.py
@@ -20,6 +20,7 @@ from __future__ import annotations
 from pathlib import Path
 from typing import Any, Mapping
 
+from ._generated import Generators
 from ._runtime import (
     LinkMlError,
     NativeLibraryNotFound,
@@ -73,7 +74,7 @@ class SchemaLoadError(LinkMlError):
         self.report = report
 
 
-class Schema:
+class Schema(Generators):
     """A loaded, import-resolved LinkML schema.
 
     Parsing a schema is the expensive part, so this holds on to the parsed form inside the library
@@ -117,130 +118,7 @@ class Schema:
         :param infer_messages: fill in each issue's human-readable ``message`` and ``details``. Turn
             it off for only the structured fields, which is a little faster.
         """
-        return self._call("lint", inferMessages=infer_messages)["report"]
-
-    # Generators
-
-    def json_schema(
-        self,
-        *,
-        open: bool = False,
-        tree_root: str | None = None,
-        tree_root_inline_type: str | None = None,
-    ) -> str:
-        """Generate a JSON Schema.
-
-        :param open: allow ``additionalProperties`` on generated classes.
-        :param tree_root: use this class as the root instead of the schema's ``tree_root``.
-        :param tree_root_inline_type: override the root class' ``tree_root_as`` extension. One of
-            ``plain``, ``optional``, ``list``, ``compact_dict``, ``simple_dict``.
-        """
-        return self._generate(
-            "json-schema",
-            open=open,
-            treeRoot=tree_root,
-            treeRootInlineType=tree_root_inline_type,
-        )
-
-    def shacl(self, *, open: bool = False, only_classes_from_root_schema: bool = False) -> str:
-        """Generate SHACL shapes, serialized as N-Triples.
-
-        :param open: emit open shapes, which allow properties the schema does not mention.
-        :param only_classes_from_root_schema: leave out classes that came in through ``imports``.
-            Useful when generating shapes per schema file.
-        """
-        return self._generate(
-            "shacl",
-            open=open,
-            onlyClassesFromRootSchema=only_classes_from_root_schema,
-        )
-
-    def rdfs(self, *, only_classes_from_root_schema: bool = False) -> str:
-        """Generate RDFS, serialized as N-Triples.
-
-        :param only_classes_from_root_schema: leave out classes that came in through ``imports``.
-        """
-        return self._generate("rdfs", onlyClassesFromRootSchema=only_classes_from_root_schema)
-
-    def linkml(
-        self,
-        *,
-        skip_derivation: bool = False,
-        pruning_mode: str = "skip",
-        tree_root: str | None = None,
-        format: str = "yaml",
-    ) -> str:
-        """Materialize a derived LinkML schema: imports resolved, slots pushed into attributes.
-
-        :param skip_derivation: copy classes as they are instead of deriving them.
-        :param pruning_mode: which unused elements to drop. ``treeRoot`` removes everything
-            unreachable from the tree root class, ``schema`` everything unreachable from any class in
-            the root schema, ``skip`` nothing.
-        :param tree_root: tree root class to prune from, instead of the schema's own.
-        :param format: ``yaml`` or ``json``.
-        """
-        return self._generate(
-            "linkml",
-            skipDerivation=skip_derivation,
-            pruningMode=pruning_mode,
-            treeRoot=tree_root,
-            format=format,
-        )
-
-    def table_schema(self, *, tree_root: str | None = None) -> str:
-        """Generate a Frictionless Table Schema, serialized as JSON.
-
-        :param tree_root: table root class, instead of the schema's ``tree_root``.
-        """
-        return self._generate("table-schema", treeRoot=tree_root)
-
-    def graphql(self, *, pruning_mode: str = "skip", tree_root: str | None = None) -> str:
-        """Generate a GraphQL schema: types, interfaces, scalars and enums, but no queries.
-
-        :param pruning_mode: see :meth:`linkml`.
-        :param tree_root: see :meth:`linkml`.
-        """
-        return self._generate("graphql", pruningMode=pruning_mode, treeRoot=tree_root)
-
-    def er_diagram(
-        self,
-        *,
-        pruning_mode: str = "skip",
-        tree_root: str | None = None,
-        optional_marker: bool = True,
-    ) -> str:
-        """Generate a Mermaid entity relationship diagram.
-
-        :param pruning_mode: see :meth:`linkml`.
-        :param tree_root: see :meth:`linkml`.
-        :param optional_marker: mark optional attributes with a trailing ``?``. Mermaid understands
-            this from 11.16 on; older renderers reject the whole diagram, so pass ``False`` if the
-            diagram is headed somewhere that pins an older version.
-        """
-        return self._generate(
-            "er-diagram",
-            pruningMode=pruning_mode,
-            treeRoot=tree_root,
-            optionalMarker=optional_marker,
-        )
-
-    def scala(
-        self,
-        package: str = "eu.neverblink.linkml.metamodel",
-        *,
-        generate_emit_prefixes: bool = True,
-    ) -> dict[str, str]:
-        """Generate Scala classes, as a filename to source mapping.
-
-        :param package: package to put the generated classes in.
-        :param generate_emit_prefixes: also generate a ``Prefixes`` object holding the schema's
-            ``emit_prefixes``.
-        """
-        return self._call(
-            "generate",
-            generator="scala",
-            options={"package": package, "generateEmitPrefixes": generate_emit_prefixes},
-        )["files"]
+        return self._json("linkml_lint", inferMessages=infer_messages)
 
     # Lifecycle
 
@@ -248,7 +126,7 @@ class Schema:
         """Release the schema. Calling it more than once is fine."""
         handle, self._handle = self._handle, None
         if handle is not None:
-            self._runtime.call({"op": "close", "handle": handle})
+            self._runtime.close(handle)
 
     def __enter__(self) -> Schema:
         return self
@@ -267,18 +145,18 @@ class Schema:
         state = "closed" if self._handle is None else f"handle={self._handle}"
         return f"<linkml_scala.Schema {state}, {len(self._report.get('issues', []))} issue(s)>"
 
-    def _generate(self, generator: str, **options: Any) -> str:
-        return self._call(
-            "generate",
-            generator=generator,
-            # Leave unset options out entirely, so the library applies its own defaults.
-            options={key: value for key, value in options.items() if value is not None},
-        )["output"]
+    def _document(self, function: str, **options: Any) -> str:
+        """Call a generator that returns a document, by its exported name."""
+        return self._runtime.document(function, self._live(), options)
 
-    def _call(self, op: str, **fields: Any) -> dict[str, Any]:
+    def _json(self, function: str, **options: Any) -> Any:
+        """Call a generator whose result is JSON, and return it parsed."""
+        return self._runtime.json_document(function, self._live(), options)
+
+    def _live(self) -> int:
         if self._handle is None:
             raise LinkMlError("this schema is closed")
-        return self._runtime.call({"op": op, "handle": self._handle, **fields})
+        return self._handle
 
 
 def load_file(path: str | Path, *, infer_messages: bool = True) -> Schema:
@@ -291,7 +169,8 @@ def load_file(path: str | Path, *, infer_messages: bool = True) -> Schema:
     :param infer_messages: fill in each issue's human-readable ``message`` and ``details``.
     :raises SchemaLoadError: if fatal problems stopped the schema from loading.
     """
-    return _load({"path": str(path)}, infer_messages)
+    current = runtime()
+    return _schema(current, *current.load_file(str(path), {"inferMessages": infer_messages}))
 
 
 def load_string(
@@ -311,7 +190,11 @@ def load_string(
     :param infer_messages: fill in each issue's human-readable ``message`` and ``details``.
     :raises SchemaLoadError: if fatal problems stopped the schema from loading.
     """
-    return _load({"schema": schema, "imports": dict(imports or {})}, infer_messages)
+    current = runtime()
+    return _schema(
+        current,
+        *current.load_string(None, schema, imports, {"inferMessages": infer_messages}),
+    )
 
 
 def load_path(
@@ -335,13 +218,19 @@ def load_path(
     :param infer_messages: fill in each issue's human-readable ``message`` and ``details``.
     :raises SchemaLoadError: if fatal problems stopped the schema from loading.
     """
-    return _load({"path": path, "imports": dict(imports)}, infer_messages)
-
-
-def _load(request: dict[str, Any], infer_messages: bool) -> Schema:
     current = runtime()
-    response = current.call({"op": "load", "inferMessages": infer_messages, **request})
-    report = response["report"]
-    if "handle" not in response:
+    return _schema(
+        current,
+        *current.load_string(path, None, imports, {"inferMessages": infer_messages}),
+    )
+
+
+def _schema(current: Runtime, handle: int, report: Report) -> Schema:
+    """Wrap a load result, turning a refused load into an exception.
+
+    The library returns handle 0 when fatal problems stopped the schema loading, and a report either
+    way, so the report is what explains the failure.
+    """
+    if handle == 0:
         raise SchemaLoadError(report)
-    return Schema(current, response["handle"], report)
+    return Schema(current, handle, report)

--- a/python/linkml_scala/_generated.py
+++ b/python/linkml_scala/_generated.py
@@ -1,0 +1,206 @@
+# AUTO-GENERATED from the generators' Options case classes.
+# Do not edit by hand - regenerate with ./mill pyBindings.
+"""The generator methods of :class:`linkml_scala.Schema`.
+
+Each one mirrors an ``Options`` case class in the Scala sources, so the keyword arguments,
+their defaults and their documentation are whatever the generator itself declares.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+
+def _pruning(mode: str, tree_root: str | None) -> Any:
+    """Encode the pruning mode the way the generators read it back.
+
+    `PruningMode` carries the tree-root override inside its `treeRoot` case rather than
+    beside it, so naming a root is an object instead of a second field.
+    """
+    if tree_root is None:
+        return mode
+    if mode not in ("treeRoot", "tree_root", "tree-root"):
+        raise ValueError(f"tree_root only applies to pruning_mode='treeRoot', not {mode!r}")
+    return {"treeRoot": tree_root}
+
+
+# Every exported function taking (handle, options) and returning a document or NULL.
+DOCUMENT_FUNCTIONS = (
+    "linkml_json_schema",
+    "linkml_shacl",
+    "linkml_rdfs",
+    "linkml_linkml",
+    "linkml_table_schema",
+    "linkml_graphql",
+    "linkml_er_diagram",
+    "linkml_scala",
+)
+
+
+class Generators:
+    """Mixin holding one method per generator. Mixed into :class:`linkml_scala.Schema`."""
+
+    def json_schema(
+        self,
+        *,
+        open: bool = False,
+        tree_root: str | None = None,
+        tree_root_inline_type: str | None = None,
+        indentation_step: int = 2,
+    ) -> str:
+        """Generate a JSON Schema.
+
+        :param open: Whether the generated JSON Schema should allow `additionalProperties` for
+            classes.
+        :param tree_root: If defined, override the schema `tree_root` class with the one
+            provided.
+        :param tree_root_inline_type: If defined, override the `tree_root_as` extension of the
+            tree root class with the one provided. One of `plain`, `optional`, `list`,
+            `compact_dict`, `simple_dict`.
+        :param indentation_step: Number of spaces in pretty print indentation of the serialized
+            JSON Schema.
+        """
+        return self._document(
+            "linkml_json_schema",
+            open=open,
+            treeRoot=tree_root,
+            treeRootInlineType=tree_root_inline_type,
+            indentationStep=indentation_step,
+        )
+
+    def shacl(
+        self,
+        *,
+        open: bool = False,
+        only_classes_from_root_schema: bool = False,
+    ) -> str:
+        """Generate SHACL shapes, serialized as N-Triples.
+
+        :param open: Whether the generated shapes should be open, allowing properties the schema
+            does not mention (turned off by default).
+        :param only_classes_from_root_schema: Whether to include only classes from the root
+            schema (turned off by default). This is useful if you intend to generate SHACL
+            shapes for each schema file separately, and you don't need the imported classes to
+            be included in the generated SHACL shapes.
+        """
+        return self._document(
+            "linkml_shacl",
+            open=open,
+            onlyClassesFromRootSchema=only_classes_from_root_schema,
+        )
+
+    def rdfs(
+        self,
+        *,
+        only_classes_from_root_schema: bool = False,
+    ) -> str:
+        """Generate RDFS, serialized as N-Triples.
+
+        :param only_classes_from_root_schema: Whether to include only classes and enums from the
+            root schema (turned off by default). This is useful if you intend to generate RDFS
+            for each schema file separately, and you don't need the imported classes to be
+            included.
+        """
+        return self._document(
+            "linkml_rdfs",
+            onlyClassesFromRootSchema=only_classes_from_root_schema,
+        )
+
+    def linkml(
+        self,
+        *,
+        pruning_mode: str = "treeRoot",
+        tree_root: str | None = None,
+        skip_class_derivation: bool = False,
+        output_format: str = "yaml",
+    ) -> str:
+        """Materialize a derived LinkML schema: imports resolved, slots pushed into attributes.
+
+        :param pruning_mode: Method to use for schema definition pruning.
+        :param tree_root: prune from this class instead of the schema's own `tree_root`. Only
+            valid with `pruning_mode="treeRoot"`.
+        :param skip_class_derivation: If true, will not derive classes and instead copy them
+            as-is.
+        :param output_format: Output serialization format to use.
+        """
+        return self._document(
+            "linkml_linkml",
+            pruningMode=_pruning(pruning_mode, tree_root),
+            skipClassDerivation=skip_class_derivation,
+            outputFormat=output_format,
+        )
+
+    def table_schema(
+        self,
+        *,
+        tree_root: str | None = None,
+    ) -> str:
+        """Generate a Frictionless Table Schema, serialized as JSON.
+
+        :param tree_root: If defined, override the schema `tree_root` class with the one
+            provided.
+        """
+        return self._document(
+            "linkml_table_schema",
+            treeRoot=tree_root,
+        )
+
+    def graphql(
+        self,
+        *,
+        pruning_mode: str = "schema",
+        tree_root: str | None = None,
+    ) -> str:
+        """Generate a GraphQL schema: types, interfaces, scalars and enums, but no queries.
+
+        :param pruning_mode: How to prune the generated definitions, schemaRoot by default
+            (elements reachable from any root schema defined elements) to omit unnecessary
+            linkml:types scalar definitions.
+        :param tree_root: prune from this class instead of the schema's own `tree_root`. Only
+            valid with `pruning_mode="treeRoot"`.
+        """
+        return self._document(
+            "linkml_graphql",
+            pruningMode=_pruning(pruning_mode, tree_root),
+        )
+
+    def er_diagram(
+        self,
+        *,
+        pruning_mode: str = "schema",
+        tree_root: str | None = None,
+        optional_marker: bool = True,
+    ) -> str:
+        """Generate a Mermaid entity relationship diagram.
+
+        :param pruning_mode: How to prune the generated entities, schemaRoot by default (classes
+            reachable from any element defined in the root schema).
+        :param tree_root: prune from this class instead of the schema's own `tree_root`. Only
+            valid with `pruning_mode="treeRoot"`.
+        :param optional_marker: Whether to mark optional attributes with a trailing `?` on their
+            type. Mermaid understands this from 11.16 onwards; older renderers reject the whole
+            diagram rather than just the marker.
+        """
+        return self._document(
+            "linkml_er_diagram",
+            pruningMode=_pruning(pruning_mode, tree_root),
+            optionalMarker=optional_marker,
+        )
+
+    def scala(
+        self,
+        *,
+        package: str = "eu.neverblink.linkml.metamodel",
+        generate_emit_prefixes: bool = True,
+    ) -> dict[str, str]:
+        """Generate Scala classes, as a filename to source mapping.
+
+        :param package: Scala package to generate the classes in.
+        :param generate_emit_prefixes: Whether to generate a `Prefixes` object holding the
+            model's `emit_prefixes`.
+        """
+        return self._json(
+            "linkml_scala",
+            package=package,
+            generateEmitPrefixes=generate_emit_prefixes,
+        )

--- a/python/linkml_scala/_generated.py
+++ b/python/linkml_scala/_generated.py
@@ -1,5 +1,5 @@
-# AUTO-GENERATED from the generators' Options case classes.
-# Do not edit by hand - regenerate with ./mill pyBindings.
+# AUTO-GENERATED from mill-build/src/Entrypoints.scala and the generators' Options case
+# classes. Do not edit by hand - regenerate with ./mill bindings.
 """The generator methods of :class:`linkml_scala.Schema`.
 
 Each one mirrors an ``Options`` case class in the Scala sources, so the keyword arguments,
@@ -109,7 +109,7 @@ class Generators:
     def linkml(
         self,
         *,
-        pruning_mode: str = "treeRoot",
+        pruning_mode: str = "skip",
         tree_root: str | None = None,
         skip_class_derivation: bool = False,
         output_format: str = "yaml",
@@ -178,8 +178,7 @@ class Generators:
         :param tree_root: prune from this class instead of the schema's own `tree_root`. Only
             valid with `pruning_mode="treeRoot"`.
         :param optional_marker: Whether to mark optional attributes with a trailing `?` on their
-            type. Mermaid understands this from 11.16 onwards; older renderers reject the whole
-            diagram rather than just the marker.
+            type, which requires Mermaid 11.16 or newer.
         """
         return self._document(
             "linkml_er_diagram",

--- a/python/linkml_scala/_runtime.py
+++ b/python/linkml_scala/_runtime.py
@@ -1,6 +1,10 @@
-"""Loading the shared library, and talking to it.
+"""Loading the shared library, and calling into it.
 
-Everything ctypes-shaped lives here. The public API in ``__init__`` only deals in dicts.
+Everything ctypes-shaped lives here. The public API in ``__init__`` deals in strings and dicts.
+
+The library exports one function per operation. Options travel as one JSON string, which may be NULL
+for defaults, so the common case never builds any JSON at all. Documents come back as plain strings,
+so a multi-megabyte SHACL graph is not escaped into JSON and parsed straight back out.
 """
 
 from __future__ import annotations
@@ -11,7 +15,9 @@ import os
 import sys
 import threading
 from pathlib import Path
-from typing import Any
+from typing import Any, Mapping
+
+from ._generated import DOCUMENT_FUNCTIONS
 
 __all__ = ["Runtime", "LinkMlError", "NativeLibraryNotFound", "library_path", "runtime"]
 
@@ -21,8 +27,13 @@ _EXPECTED_ABI_VERSION = 1
 _LIB_STEM = "liblinkml_scala"
 
 
+# char*, kept as POINTER(c_char) rather than c_char_p: ctypes turns the latter into bytes and
+# discards the pointer, leaving nothing to hand to linkml_free.
+_Chars = ctypes.POINTER(ctypes.c_char)
+
+
 class LinkMlError(Exception):
-    """The library rejected a request, or failed while handling it."""
+    """The library rejected a call, or failed while handling it."""
 
 
 class NativeLibraryNotFound(LinkMlError):
@@ -33,7 +44,6 @@ def _library_filename() -> str:
     if sys.platform == "darwin":
         return f"{_LIB_STEM}.dylib"
     if sys.platform == "win32":
-        # native-image keeps the lib prefix on Windows too.
         return f"{_LIB_STEM}.dll"
     return f"{_LIB_STEM}.so"
 
@@ -52,7 +62,7 @@ def _candidates() -> list[Path]:
     # Installed by `./mill nativelib.installPythonLib`.
     found.append(Path(__file__).parent / "_lib" / filename)
 
-    # A source checkout that has run `./mill nativelib.sharedLibrary` but not installed it.
+    # A source checkout that built the library but did not install it.
     repo_root = Path(__file__).resolve().parents[2]
     found.append(repo_root / "out" / "nativelib" / "sharedLibrary.dest" / filename)
 
@@ -75,12 +85,26 @@ def library_path() -> Path:
     )
 
 
+def _options(options: Mapping[str, Any] | None) -> bytes | None:
+    """Encode an options mapping, dropping unset values.
+
+    Returns None, which reaches C as NULL, when there is nothing to say. The library then applies
+    its own defaults and no JSON is built or parsed on either side.
+    """
+    if not options:
+        return None
+    present = {key: value for key, value in options.items() if value is not None}
+    if not present:
+        return None
+    return json.dumps(present).encode("utf-8")
+
+
 class Runtime:
     """One GraalVM isolate, and the calls into it.
 
-    An isolate is a self-contained heap: the library can hold several, but one is all we need, and
-    schema handles are scoped to it. Threads have to attach to an isolate before calling in, which
-    happens on demand and is remembered per thread.
+    An isolate is a self-contained heap. Schema handles only mean anything within the isolate that
+    made them. Threads have to attach before calling in, which happens on demand and is remembered
+    per thread.
 
     Thread-safe. Prefer the process-wide instance from :func:`runtime` over building your own.
     """
@@ -100,7 +124,7 @@ class Runtime:
         self._threads = threading.local()
         self._threads.handle = main_thread
 
-        version = self.call({"op": "version"})["abiVersion"]
+        version = self._lib.linkml_abi_version(self._thread())
         if version != _EXPECTED_ABI_VERSION:
             raise LinkMlError(
                 f"{self._path} speaks ABI version {version}, but this package expects "
@@ -112,24 +136,108 @@ class Runtime:
         """The library file backing this runtime."""
         return self._path
 
-    def call(self, request: dict[str, Any]) -> dict[str, Any]:
-        """Send one request and return its response, minus the ``ok`` flag.
+    # Loading
 
-        :raises LinkMlError: if the library reports a failure.
+    def load_file(
+        self, path: str, options: Mapping[str, Any] | None = None
+    ) -> tuple[int, dict[str, Any]]:
+        """Load a schema from the file system.
+
+        :return: the schema handle, 0 if the schema had fatal problems, and the validation report.
         """
-        payload = json.dumps(request).encode("utf-8")
-        pointer = self._lib.linkml_call(self._thread(), payload)
+        report, error = _Chars(), _Chars()
+        handle = self._lib.linkml_load_file(
+            self._thread(),
+            path.encode("utf-8"),
+            _options(options),
+            ctypes.byref(report),
+            ctypes.byref(error),
+        )
+        return self._loaded(handle, report, error)
+
+    def load_string(
+        self,
+        path: str | None,
+        schema: str | None,
+        imports: Mapping[str, str] | None = None,
+        options: Mapping[str, Any] | None = None,
+    ) -> tuple[int, dict[str, Any]]:
+        """Load a schema from memory, resolving imports against ``imports``.
+
+        :param path: the root schema's own key in ``imports``, or None to load ``schema`` directly.
+        :param schema: the root schema as YAML. Ignored when ``path`` is given.
+        :return: the schema handle, 0 if the schema had fatal problems, and the validation report.
+        """
+        # The map goes over as two parallel arrays rather than JSON: it holds whole schemas, and
+        # escaping megabytes of YAML only to parse it back out would undo the point of the split.
+        entries = dict(imports or {})
+        count = len(entries)
+        names = (ctypes.c_char_p * count)(*(key.encode("utf-8") for key in entries))
+        bodies = (ctypes.c_char_p * count)(*(value.encode("utf-8") for value in entries.values()))
+
+        report, error = _Chars(), _Chars()
+        handle = self._lib.linkml_load_string(
+            self._thread(),
+            None if path is None else path.encode("utf-8"),
+            None if schema is None else schema.encode("utf-8"),
+            names if count else None,
+            bodies if count else None,
+            count,
+            _options(options),
+            ctypes.byref(report),
+            ctypes.byref(error),
+        )
+        return self._loaded(handle, report, error)
+
+    def close(self, handle: int) -> None:
+        """Release a schema handle. Releasing one that is already gone does nothing."""
+        self._lib.linkml_close(self._thread(), handle)
+
+    # Generating
+
+    def document(
+        self, function: str, handle: int, options: Mapping[str, Any] | None = None
+    ) -> str:
+        """Call a generator and return its document.
+
+        :param function: the exported name, e.g. ``linkml_shacl``.
+        :raises LinkMlError: if the library reported a failure.
+        """
+        error = _Chars()
+        result = getattr(self._lib, function)(
+            self._thread(), handle, _options(options), ctypes.byref(error)
+        )
+        # Take both, so neither leaks whichever way the call went.
+        message = self._take(error)
+        text = self._take(result)
+        if text is None:
+            raise LinkMlError(message or f"{function} failed without saying why")
+        return text
+
+    def json_document(
+        self, function: str, handle: int, options: Mapping[str, Any] | None = None
+    ) -> Any:
+        """Call a generator whose result is JSON, and return it parsed."""
+        return json.loads(self.document(function, handle, options))
+
+    # Internals
+
+    def _loaded(self, handle: int, report: Any, error: Any) -> tuple[int, dict[str, Any]]:
+        message = self._take(error)
+        report_json = self._take(report)
+        if message is not None:
+            raise LinkMlError(message)
+        return handle, json.loads(report_json) if report_json else {}
+
+    def _take(self, pointer: Any) -> str | None:
+        """Read a string the library allocated, and release it. None if the pointer was NULL."""
         if not pointer:
-            raise LinkMlError("linkml_call returned NULL")
+            return None
         try:
             raw = ctypes.cast(pointer, ctypes.c_char_p).value
         finally:
             self._lib.linkml_free(self._thread(), pointer)
-
-        response = json.loads(raw.decode("utf-8"))
-        if not response.pop("ok", False):
-            raise LinkMlError(response.get("error", "the native library reported no reason"))
-        return response
+        return None if raw is None else raw.decode("utf-8")
 
     def _thread(self) -> ctypes.c_void_p:
         """This thread's isolate thread, attaching it to the isolate on first use."""
@@ -144,20 +252,56 @@ class Runtime:
 
     def _declare_signatures(self) -> None:
         void_p = ctypes.c_void_p
-        # Returned as POINTER(c_char) rather than c_char_p: ctypes would turn the latter into bytes
-        # and throw the pointer away, leaving us nothing to hand to linkml_free.
-        char_p = ctypes.POINTER(ctypes.c_char)
+        handle = ctypes.c_longlong
+        chars_out = ctypes.POINTER(_Chars)
+        strings = ctypes.POINTER(ctypes.c_char_p)
 
-        self._lib.graal_create_isolate.argtypes = [void_p, ctypes.POINTER(void_p), ctypes.POINTER(void_p)]
+        self._lib.graal_create_isolate.argtypes = [
+            void_p,
+            ctypes.POINTER(void_p),
+            ctypes.POINTER(void_p),
+        ]
         self._lib.graal_create_isolate.restype = ctypes.c_int
 
         self._lib.graal_attach_thread.argtypes = [void_p, ctypes.POINTER(void_p)]
         self._lib.graal_attach_thread.restype = ctypes.c_int
 
-        self._lib.linkml_call.argtypes = [void_p, ctypes.c_char_p]
-        self._lib.linkml_call.restype = char_p
+        self._lib.linkml_abi_version.argtypes = [void_p]
+        self._lib.linkml_abi_version.restype = ctypes.c_int
 
-        self._lib.linkml_free.argtypes = [void_p, char_p]
+        self._lib.linkml_load_file.argtypes = [
+            void_p,
+            ctypes.c_char_p,
+            ctypes.c_char_p,
+            chars_out,
+            chars_out,
+        ]
+        self._lib.linkml_load_file.restype = handle
+
+        self._lib.linkml_load_string.argtypes = [
+            void_p,
+            ctypes.c_char_p,
+            ctypes.c_char_p,
+            strings,
+            strings,
+            ctypes.c_int,
+            ctypes.c_char_p,
+            chars_out,
+            chars_out,
+        ]
+        self._lib.linkml_load_string.restype = handle
+
+        self._lib.linkml_close.argtypes = [void_p, handle]
+        self._lib.linkml_close.restype = None
+
+        # linkml_lint has the same shape but is not a generator, so it is not in the generated
+        # list and gets declared alongside it.
+        for name in (*DOCUMENT_FUNCTIONS, "linkml_lint"):
+            function = getattr(self._lib, name)
+            function.argtypes = [void_p, handle, ctypes.c_char_p, chars_out]
+            function.restype = _Chars
+
+        self._lib.linkml_free.argtypes = [void_p, _Chars]
         self._lib.linkml_free.restype = None
 
 

--- a/python/test_bindings.py
+++ b/python/test_bindings.py
@@ -181,7 +181,7 @@ class LoadTest(unittest.TestCase):
 
     def test_load_needs_a_schema_or_a_path(self):
         with self.assertRaises(LinkMlError):
-            linkml_scala.runtime().call({"op": "load"})
+            linkml_scala.runtime().load_string(None, None)
 
 
 class GeneratorTest(unittest.TestCase):
@@ -226,7 +226,7 @@ class GeneratorTest(unittest.TestCase):
     def test_linkml(self):
         # Deriving pushes inherited and referenced slots down into each class' attributes.
         self.assertIn("attributes:", self.schema.linkml())
-        self.assertIn('"attributes"', self.schema.linkml(format="json"))
+        self.assertIn('"attributes"', self.schema.linkml(output_format="json"))
 
     def test_linkml_pruning_drops_unreachable_classes(self):
         unreachable = schema(
@@ -264,14 +264,15 @@ class GeneratorTest(unittest.TestCase):
         self.assertIn('Person ||--o| Animal : "pet"', generated)
 
     def test_scala(self):
-        files = self.schema.scala("com.example.model")
+        files = self.schema.scala(package="com.example.model")
         self.assertIn("Person.scala", files)
         self.assertIn("package com.example.model", files["Person.scala"])
 
-    def test_unknown_generator(self):
-        with self.assertRaises(LinkMlError) as caught:
-            self.schema._generate("cuneiform")
-        self.assertIn("cuneiform", str(caught.exception))
+    def test_an_unexported_function_cannot_be_called(self):
+        # Each generator is its own exported symbol now, so a name that does not exist fails at the
+        # ctypes layer rather than being dispatched and rejected by the library.
+        with self.assertRaises(AttributeError):
+            linkml_scala.runtime().document("linkml_cuneiform", self.schema._handle)
 
     def test_unknown_pruning_mode(self):
         with self.assertRaises(LinkMlError) as caught:
@@ -280,13 +281,8 @@ class GeneratorTest(unittest.TestCase):
 
     def test_an_unknown_option_is_rejected_rather_than_ignored(self):
         with self.assertRaises(LinkMlError) as caught:
-            linkml_scala.runtime().call(
-                {
-                    "op": "generate",
-                    "handle": self.schema._handle,
-                    "generator": "json-schema",
-                    "options": {"opne": True},
-                }
+            linkml_scala.runtime().document(
+                "linkml_json_schema", self.schema._handle, {"opne": True}
             )
         self.assertIn("opne", str(caught.exception))
 
@@ -345,12 +341,13 @@ class HandleTest(unittest.TestCase):
 
     def test_an_unknown_handle_raises(self):
         with self.assertRaises(LinkMlError) as caught:
-            linkml_scala.runtime().call({"op": "lint", "handle": 999_999})
+            linkml_scala.runtime().document("linkml_lint", 999_999)
         self.assertIn("999999", str(caught.exception))
 
-    def test_a_missing_handle_raises(self):
+    def test_handle_zero_raises(self):
+        # 0 is what loading returns when it refused, so it must never be usable.
         with self.assertRaises(LinkMlError):
-            linkml_scala.runtime().call({"op": "lint"})
+            linkml_scala.runtime().document("linkml_lint", 0)
 
     def test_handles_are_independent(self):
         with linkml_scala.load_string(PERSON) as first:


### PR DESCRIPTION
- Move the big arguments & return values to individual strings, to skip JSON ser/des overhead.
- Keep generator options in JSONs to avoid changing the ABI every time we add a generator option.
- Move generator options to case classes, so that we can keep a stable Scala/Java API as well, and only change the fields in the case classes.
- Autogenerate bindings as much as possible.
- Add tests to ensure all bindings are in sync. There is a lot of these now!
- Tidy up release & test CI jobs.