### PR TITLE
Add wheel builds & PyPI publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -114,6 +114,23 @@ jobs:
             ./mill nativelib.pythonTest
           fi
 
+      - name: Pick the Shared Library This Platform Ships
+        shell: bash
+        run: |
+          if [ "$RUNNER_OS" == "Linux" ]; then
+            echo "LIB_MODULE=nativelib.linux.glibc" >> "$GITHUB_ENV"
+            echo "LIB_DEST=out/nativelib/linux/glibc/sharedLibrary.dest" >> "$GITHUB_ENV"
+            echo "WHEEL_DEST=out/nativelib/linux/glibc/pythonWheel.dest/dist" >> "$GITHUB_ENV"
+          else
+            echo "LIB_MODULE=nativelib" >> "$GITHUB_ENV"
+            echo "LIB_DEST=out/nativelib/sharedLibrary.dest" >> "$GITHUB_ENV"
+            echo "WHEEL_DEST=out/nativelib/pythonWheel.dest/dist" >> "$GITHUB_ENV"
+          fi
+
+      - name: Build the Shipped Shared Library (Linux only)
+        if: runner.os == 'Linux'
+        run: ./mill nativelib.linux.glibc.sharedLibrary
+
       # The archive is what people actually download, so build it here and check a C program can
       # compile against it and run. This is the only place the Windows import library and the
       # macOS dylib get tested.
@@ -128,7 +145,7 @@ jobs:
           ubuntu-22.04-arm) platform=linux-arm64 ;;
           windows-latest) platform=windows-x86_64 ;;
           esac
-          nativelib/package.sh "$version" "$platform" out/nativelib/sharedLibrary.dest dist
+          nativelib/package.sh "$version" "$platform" "$LIB_DEST" dist
           if [ "$RUNNER_OS" == "Windows" ]; then
             unzip -q "dist/linkml-scala-lib-$platform.zip" -d dist
           else
@@ -140,7 +157,52 @@ jobs:
         uses: actions/upload-artifact@v7
         with:
           name: linkml-nativelib-${{ matrix.os }}
-          path: out/nativelib/sharedLibrary.dest/*
+          path: ${{ env.LIB_DEST }}/*
+
+      - name: Build the Python Wheel and Test the Installed Package
+        shell: bash
+        env:
+          PYTHON: python # so `pip install build` and Mill use the same interpreter on every OS
+        run: |
+          python -m pip install --quiet build
+          if [ "$RUNNER_OS" == "Windows" ]; then
+            ./mill.bat "$LIB_MODULE.pythonWheelTest"
+          else
+            ./mill "$LIB_MODULE.pythonWheelTest"
+          fi
+
+      - name: Upload Python Wheel
+        uses: actions/upload-artifact@v7
+        with:
+          name: linkml-wheel-${{ matrix.os }}
+          path: ${{ env.WHEEL_DEST }}/*.whl
+
+      # musl is cross-compiled on Linux
+      - name: Build the musl Wheel (Linux only)
+        if: runner.os == 'Linux'
+        env:
+          PYTHON: python
+        run: |
+          sudo nativelib/install-musl-toolchain.sh
+          ./mill nativelib.linux.musl.pythonWheel
+
+      # we must run musl binary in a musl container
+      - name: Test the musl Wheel in Alpine (Linux only)
+        if: runner.os == 'Linux'
+        run: |
+          wheel="$(ls out/nativelib/linux/musl/pythonWheel.dest/dist/*.whl)"
+          docker run --rm -v "$PWD:/work:ro" -e LINKML_SCALA_REPO=/work python:3.12-alpine sh -c "
+            set -e
+            pip install --quiet '/work/$wheel'
+            cp /work/python/test_bindings.py /tmp/
+            cd /tmp && python -m unittest test_bindings -v"
+
+      - name: Upload musl Python Wheel
+        if: runner.os == 'Linux'
+        uses: actions/upload-artifact@v7
+        with:
+          name: linkml-wheel-musl-${{ matrix.os }}
+          path: out/nativelib/linux/musl/pythonWheel.dest/dist/*.whl
 
   publish:
     name: Publish to Maven and GitHub
@@ -236,6 +298,30 @@ jobs:
           MILL_PGP_SECRET_BASE64: ${{ secrets.MILL_PGP_SECRET_BASE64 }}
           MILL_PGP_PASSPHRASE: ${{ secrets.PGP_PASSPHRASE }}
         run: ./mill mill.javalib.SonatypeCentralPublishModule/
+
+  pypi-publish:
+    name: Publish Python wheels to PyPI
+    needs: publish
+    runs-on: ubuntu-latest
+    environment: pypi
+    permissions:
+      id-token: write # Required for PyPI trusted publishing (OIDC)
+    steps:
+      - name: Download Wheels
+        uses: actions/download-artifact@v8
+        with:
+          pattern: linkml-wheel-*
+          path: wheels
+          merge-multiple: true
+
+      - name: List Wheels
+        run: ls -l wheels
+
+      - name: Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          packages-dir: wheels
+          skip-existing: true
 
   npm-publish:
     # Independent of the JVM/native jobs: publishes the Scala.js library to npm.

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -153,9 +153,6 @@ jobs:
           "$PYTHON" -m pip install --quiet build
           ./mill --no-server nativelib.pythonWheelTest
 
-      # The wheel Linux users actually get: linked inside manylinux2014 so it runs on far older
-      # distributions than this runner. Exercised here so that a release is not the first time it
-      # runs. See nativelib/build-shared.sh.
       - name: Build the manylinux wheel and test the installed package
         env:
           PYTHON: ${{ steps.python-oldest.outputs.python-path }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -144,6 +144,36 @@ jobs:
           PYTHON: ${{ steps.python-newest.outputs.python-path }}
         run: ./mill --no-server nativelib.pythonTest
 
+      # Builds the wheel that gets published on release, installs it into a clean virtualenv and
+      # runs it from there, so the packaging is tested and not just the sources.
+      - name: Build the Python wheel and test the installed package
+        env:
+          PYTHON: ${{ steps.python-oldest.outputs.python-path }}
+        run: |
+          "$PYTHON" -m pip install --quiet build
+          ./mill --no-server nativelib.pythonWheelTest
+
+      # The wheel Linux users actually get: linked inside manylinux2014 so it runs on far older
+      # distributions than this runner. Exercised here so that a release is not the first time it
+      # runs. See nativelib/build-shared.sh.
+      - name: Build the manylinux wheel and test the installed package
+        env:
+          PYTHON: ${{ steps.python-oldest.outputs.python-path }}
+        run: ./mill --no-server nativelib.linux.glibc.pythonWheelTest
+
+      - name: Build the musl wheel and test it in Alpine
+        env:
+          PYTHON: ${{ steps.python-oldest.outputs.python-path }}
+        run: |
+          sudo nativelib/install-musl-toolchain.sh
+          ./mill --no-server nativelib.linux.musl.pythonWheel
+          wheel="$(ls out/nativelib/linux/musl/pythonWheel.dest/dist/*.whl)"
+          docker run --rm -v "$PWD:/work:ro" -e LINKML_SCALA_REPO=/work python:3.12-alpine sh -c "
+            set -e
+            pip install --quiet '/work/$wheel'
+            cp /work/python/test_bindings.py /tmp/
+            cd /tmp && python -m unittest test_bindings -v"
+
       # Builds the release archive, then compiles and runs a C program against the unpacked copy.
       - name: Check that the release archive works from C
         run: |

--- a/.gitignore
+++ b/.gitignore
@@ -46,6 +46,8 @@ ui/dist/
 __pycache__/
 # The shared library the Python bindings load, put there by `./mill nativelib.installPythonLib`
 /python/linkml_scala/_lib/
+# Wheels, if `python -m build` is run in python/ by hand rather than through Mill
+/python/dist/
 
 # Shared library release archives, from nativelib/package.sh
 /dist/

--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@
 [![GitHub stars](https://img.shields.io/github/stars/NeverBlink-OSS/linkml-scala?style=flat-square&logo=github&logoColor=white&label=stars&color=yellow)](https://github.com/NeverBlink-OSS/linkml-scala/stargazers)
 [![Maven Central](https://img.shields.io/maven-central/v/eu.neverblink.linkml/generator_3?style=flat-square&logo=apachemaven&logoColor=white&label=maven%20central)](https://central.sonatype.com/namespace/eu.neverblink.linkml)
 [![npm](https://img.shields.io/npm/v/@neverblink/linkml?style=flat-square&logo=npm&logoColor=white&label=npm)](https://www.npmjs.com/package/@neverblink/linkml)
+[![PyPI](https://img.shields.io/pypi/v/neverblink-linkml?style=flat-square&logo=pypi&logoColor=white&label=pypi)](https://pypi.org/project/neverblink-linkml/)
 [![CLI release](https://img.shields.io/github/v/release/NeverBlink-OSS/linkml-scala?style=flat-square&logo=github&logoColor=white&label=CLI%20release&color=blue)](https://github.com/NeverBlink-OSS/linkml-scala/releases/latest)
 
 [![Platforms](https://img.shields.io/badge/platforms-JVM_·_JS_·_native-4B8BBE?style=flat-square)](#-quick-start-installation)
@@ -48,7 +49,7 @@ For Java, Scala, Kotlin and other JVM languages, LinkML-Scala is available on **
 
 It starts up immediately and runs fast, even on extra-large LinkML models. **[See the installation instructions.](#cli-tool-installation)**
 
-We also have experimental [Python and native bindings](docs/python_bindings.md), so you can use LinkML-Scala from Python, C, C++, or Rust.
+We also have experimental [Python and native bindings](docs/python_bindings.md), so you can use LinkML-Scala from Python (`pip install neverblink-linkml`), C, C++, or Rust.
 
 ### 🛡️ Consistent, reliable, and with great error reporting
 
@@ -183,6 +184,24 @@ import map, immune to cyclic imports involving the root), then run `jsonSchema`,
 `rdfs`, `linkml`, `scala`, `tableSchema`, `graphQl`, `erDiagram`, or `lint` against the returned
 handle.
 See [generator/npm/README.md](generator/npm/README.md) for details.
+
+## Python library (experimental)
+
+Install it:
+
+```shell
+pip install neverblink-linkml
+```
+
+```python
+import linkml_scala
+
+with linkml_scala.load_file("model.yaml") as schema:
+    print(schema.json_schema())
+    print(schema.shacl())
+```
+
+See [docs/python_bindings.md](docs/python_bindings.md) for the whole API, and for the C ABI for C, C++ and Rust.
 
 ## JVM library
 

--- a/build.mill
+++ b/build.mill
@@ -27,7 +27,7 @@ import com.carlosedp.aliases.*
 import mill.contrib.buildinfo.BuildInfo
 import com.sun.net.httpserver.SimpleFileServer
 import mill.api.Evaluator
-import millbuild.{CApiGen, NpmPackage, PyBindingsGen, TsDefsGen}
+import millbuild.*
 
 import java.net.InetSocketAddress
 
@@ -468,8 +468,8 @@ def bindings(args: String*) = Task.Command(exclusive = true) {
   * of it. See docs/python_bindings.md.
   *
   * Experimental. Deliberately does not extend `CommonModule`, so it stays out of
-  * `SonatypeCentralPublishModule` (which publishes every `PublishModule` in the build) until we
-  * decide to ship it.
+  * `SonatypeCentralPublishModule` (which publishes every `PublishModule` in the build). The wheel
+  * goes to PyPI instead, see `pythonWheel`.
   *
   * It extends `NativeImage` only to reuse `nativeImageGraalvmHome`, which fetches GraalVM (or
   * honours `GRAALVM_HOME`). The trait's own `nativeImage` task builds an executable and is unused
@@ -504,7 +504,7 @@ object nativelib extends ScalaModule, ScalafmtModule, ScalafixModule, NativeImag
 
   def nativeImageClassPath = runClasspath()
 
-  def nativeImageName = "liblinkml_scala"
+  def nativeImageName = NativeLib.name
 
   def nativeImageGraalVmJvmId = "graalvm-oracle:25"
 
@@ -528,29 +528,28 @@ object nativelib extends ScalaModule, ScalafmtModule, ScalafixModule, NativeImag
     * generates for it. Takes a few minutes.
     */
   def sharedLibrary = Task {
-    // `scala` at the top of this file is the version string, so the package needs spelling out.
-    val ext = if _root_.scala.util.Properties.isWin then ".cmd" else ""
-    val nativeImage = nativeImageGraalvmHome().path / "bin" / s"native-image$ext"
-    val classPath = nativeImageClassPath()
-      .map(_.path.toString)
-      .mkString(java.io.File.pathSeparator)
-
-    os.call(
-      (
-        nativeImage.toString,
-        "--shared",
+    PathRef(
+      NativeLib.build(
+        Task.dest,
+        nativeImageGraalvmHome().path,
+        nativeImageClassPath().map(_.path),
         nativeImageOptions(),
-        s"-H:Path=${Task.dest}",
-        s"-H:Name=${nativeImageName()}",
-        "-cp",
-        classPath,
+        mill.api.BuildCtx.workspaceRoot,
       ),
-      cwd = mill.api.BuildCtx.workspaceRoot,
-      stdout = os.Inherit,
-      stderr = os.Inherit,
     )
-    PathRef(Task.dest)
   }
+
+  /** The image classpath written to a file, so we can safely pass it to scripts.
+    */
+  def nativeImageClassPathFile = Task {
+    PathRef(NativeLib.classPathFile(Task.dest, nativeImageClassPath().map(_.path)))
+  }
+
+  /** The Python package: the sources, packaging metadata and tests. */
+  def pythonDir = Task.Source(mill.api.BuildCtx.workspaceRoot / "python")
+
+  /** Shipped inside the wheel. */
+  def licenseFile = Task.Source(mill.api.BuildCtx.workspaceRoot / "LICENSE")
 
   /** Where the Python package looks for the library when it is not told otherwise. */
   private def pythonLibDir = mill.api.BuildCtx.workspaceRoot / "python" / "linkml_scala" / "_lib"
@@ -559,9 +558,7 @@ object nativelib extends ScalaModule, ScalafmtModule, ScalafixModule, NativeImag
     * `import linkml_scala` works from a source checkout.
     */
   def installPythonLib() = Task.Command(exclusive = true) {
-    val built = sharedLibrary().path
-    os.makeDir.all(pythonLibDir)
-    os.list(built).filter(os.isFile).foreach(os.copy.into(_, pythonLibDir, replaceExisting = true))
+    Python.installLibrary(sharedLibrary().path, pythonLibDir)
     println(s"Installed the shared library into ${pythonLibDir.relativeTo(
         mill.api.BuildCtx.workspaceRoot,
       )}")
@@ -572,17 +569,113 @@ object nativelib extends ScalaModule, ScalafmtModule, ScalafixModule, NativeImag
     */
   def pythonTest(args: String*) = Task.Command(exclusive = true) {
     installPythonLib()()
-    val python = sys.env.getOrElse(
-      "PYTHON",
-      if _root_.scala.util.Properties.isWin then "python" else "python3",
+    Python.runTests(mill.api.BuildCtx.workspaceRoot)
+  }
+
+  /** Build the `neverblink-linkml` wheel for this platform.
+    */
+  def pythonWheel = Task {
+    PathRef(
+      Python.buildWheel(
+        Task.dest,
+        sharedLibrary().path,
+        pythonDir().path,
+        licenseFile().path,
+        wheelVersion(),
+      ),
     )
-    os.call(
-      (python, "-m", "unittest", "discover", "-s", "python", "-v"),
-      cwd = mill.api.BuildCtx.workspaceRoot,
-      stdout = os.Inherit,
-      stderr = os.Inherit,
+  }
+
+  /** The wheel's version in the PEP 440 format. */
+  def wheelVersion = Task {
+    PyPackage.version(build.generator.jvm.publishVersion())
+  }
+
+  /** Build the wheel, install it into a throwaway virtualenv and check the installed package works.
+    *
+    * Runs python/test_bindings.py from a temporary directory, so the import can only come from the
+    * wheel and never from `python/`.
+    */
+  def pythonWheelTest(args: String*) = Task.Command(exclusive = true) {
+    Python.testWheel(
+      Task.dest,
+      pythonWheel().path,
+      pythonDir().path,
+      mill.api.BuildCtx.workspaceRoot,
     )
-    ()
+  }
+
+  object linux extends Module {
+
+    /** glibc, built inside manylinux2014. */
+    object glibc extends Module {
+      def sharedLibrary = Task {
+        PathRef(
+          NativeLib.buildForLinux(
+            "glibc",
+            Task.dest,
+            build.nativelib.nativeImageGraalvmHome().path,
+            build.nativelib.nativeImageClassPathFile().path,
+            build.nativelib.nativeImageOptions(),
+            mill.api.BuildCtx.workspaceRoot,
+          ),
+        )
+      }
+
+      def pythonWheel = Task {
+        PathRef(
+          Python.buildWheel(
+            Task.dest,
+            sharedLibrary().path,
+            build.nativelib.pythonDir().path,
+            build.nativelib.licenseFile().path,
+            build.nativelib.wheelVersion(),
+          ),
+        )
+      }
+
+      /** Run it against the host's libc (usually much newer). */
+      def pythonWheelTest(args: String*) = Task.Command(exclusive = true) {
+        Python.testWheel(
+          Task.dest,
+          pythonWheel().path,
+          build.nativelib.pythonDir().path,
+          mill.api.BuildCtx.workspaceRoot,
+        )
+      }
+    }
+
+    /** musl, cross-linked for Alpine. Needs nativelib/install-musl-toolchain.sh first.
+      *
+      * There is deliberately no `pythonWheelTest` here: the wheel only loads under musl, so testing
+      * requires running it in an Alpine container. The release workflow does that.
+      */
+    object musl extends Module {
+      def sharedLibrary = Task {
+        PathRef(
+          NativeLib.buildForLinux(
+            "musl",
+            Task.dest,
+            build.nativelib.nativeImageGraalvmHome().path,
+            build.nativelib.nativeImageClassPathFile().path,
+            build.nativelib.nativeImageOptions(),
+            mill.api.BuildCtx.workspaceRoot,
+          ),
+        )
+      }
+
+      def pythonWheel = Task {
+        PathRef(
+          Python.buildWheel(
+            Task.dest,
+            sharedLibrary().path,
+            build.nativelib.pythonDir().path,
+            build.nativelib.licenseFile().path,
+            build.nativelib.wheelVersion(),
+          ),
+        )
+      }
+    }
   }
 }
 

--- a/docs/python_bindings.md
+++ b/docs/python_bindings.md
@@ -182,9 +182,3 @@ sudo nativelib/install-musl-toolchain.sh      # once, for the musl build
 Each release also attaches a prebuilt archive per platform, `linkml-scala-lib-<os>-<arch>`, laid out
 as a normal install prefix – `include/`, `lib/` and a pkg-config file – so C, C++ and Rust callers can
 use the same library. [`nativelib/smoke.c`](../nativelib/smoke.c) is a worked example in C.
-
-## TODO
-
-1. Type stubs, or type hints good enough to not need them. The reports are plain dicts today; a
-   `TypedDict` generated from `validation-report.yaml` would be better, and would help the
-   TypeScript bindings too (see [#127](https://github.com/NeverBlink-OSS/linkml-scala/issues/127)).

--- a/docs/python_bindings.md
+++ b/docs/python_bindings.md
@@ -4,8 +4,25 @@ LinkML-Scala compiled to a native shared library, called from Python through `ct
 subprocess per schema, and no dependency on the `linkml` Python package.
 
 > [!WARNING]
-> This is an experiment. Nothing here is published to PyPI yet and the API is not stable. 
+> This is an experiment.
 > Feedback is welcome in [Discussions](https://github.com/NeverBlink-OSS/linkml-scala/discussions).
+
+## Installation
+
+```shell
+pip install neverblink-linkml
+```
+
+The wheels on [PyPI](https://pypi.org/project/neverblink-linkml/) bundle the native library, so there is nothing else to install – no JVM, no compiler.
+
+| OS            | Architectures        |
+|---------------|----------------------|
+| Linux (glibc) | x86-64, ARM64        |
+| Linux (musl)  | x86-64, ARM64        |
+| macOS         | Apple silicon, Intel |
+| Windows       | x86-64               |
+
+Python 3.10 or newer, 64-bit only.
 
 ## Usage
 
@@ -20,65 +37,6 @@ with linkml_scala.load_file("model.yaml") as schema:
 ```
 
 A schema is parsed once and reused across generators, the same way the [JavaScript bindings](../generator/npm/README.md) work. All eight generators are available, plus the schema validator.
-
-## Building it
-
-You need JDK 17+ (Mill downloads GraalVM itself) and Python 3.10 or newer. Then:
-
-```shell
-./mill nativelib.installPythonLib
-```
-
-That runs `native-image --shared` over the `nativelib` module and copies the result into
-`python/linkml_scala/_lib/`, where the Python package looks for it. Takes about half a minute on a
-recent laptop, and produces a 22 MB `liblinkml_scala.so`.
-
-To use the package, put `python/` on your path:
-
-```shell
-PYTHONPATH=python python3 -c "import linkml_scala; print(linkml_scala.library_path())"
-```
-
-Run the tests with:
-
-```shell
-./mill nativelib.pythonTest
-```
-
-If you keep the library somewhere else, point `LINKML_SCALA_LIB` at the file (or at the directory
-holding it).
-
-Each release also attaches a prebuilt archive per platform, `linkml-scala-lib-<os>-<arch>`, laid out
-as a normal install prefix – `include/`, `lib/` and a pkg-config file – so C, C++ and Rust callers can
-use the same library. [`nativelib/smoke.c`](../nativelib/smoke.c) is a worked example in C.
-
-## How it works
-
-We export one function per operation:
-
-```c
-char* linkml_shacl      (graal_isolatethread_t*, long long handle, const char* opts, char** err);
-char* linkml_json_schema(graal_isolatethread_t*, long long handle, const char* opts, char** err);
-/* rdfs, linkml, table_schema, graphql, er_diagram, scala, lint – same shape */
-
-long long linkml_load_file(graal_isolatethread_t*, const char* path,
-                           const char* opts, char** report, char** err);
-void      linkml_close    (graal_isolatethread_t*, long long handle);
-void      linkml_free     (graal_isolatethread_t*, char*);
-```
-
-Conventions:
-
-**Options are one JSON string, and may be NULL.** Options are the part that changes as generators grow, so keeping them out of the signatures keeps the ABI stable. NULL means "use defaults":
-
-```c
-char *shacl = linkml_shacl(thread, handle, NULL, &err);               /* defaults */
-char *open  = linkml_shacl(thread, handle, "{\"open\":true}", &err);  /* one option */
-```
-
-**Failure is NULL plus a message.** A generator returns NULL and writes the reason to `*err`. Loading returns handle 0 and writes a validation report to `*report`. All returned strings must be freed by the caller with `linkml_free`.
-
-A loaded schema is an integer handle.
 
 ## The API
 
@@ -150,10 +108,83 @@ Here we measured only the time to generate the output, not the time to load the 
 | `cgmes-dynamics` | 812 KB |        2,039 ms |      20.8 ms | **98×** |
 | `cgmes-core`     | 196 KB |        1,196 ms |      15.0 ms | **80×** |
 
+## How it works
+
+We export one function per operation:
+
+```c
+char* linkml_shacl      (graal_isolatethread_t*, long long handle, const char* opts, char** err);
+char* linkml_json_schema(graal_isolatethread_t*, long long handle, const char* opts, char** err);
+/* rdfs, linkml, table_schema, graphql, er_diagram, scala, lint – same shape */
+
+long long linkml_load_file(graal_isolatethread_t*, const char* path,
+                           const char* opts, char** report, char** err);
+void      linkml_close    (graal_isolatethread_t*, long long handle);
+void      linkml_free     (graal_isolatethread_t*, char*);
+```
+
+Conventions:
+
+**Options are one JSON string, and may be NULL.** Options are the part that changes as generators grow, so keeping them out of the signatures keeps the ABI stable. NULL means "use defaults":
+
+```c
+char *shacl = linkml_shacl(thread, handle, NULL, &err);               /* defaults */
+char *open  = linkml_shacl(thread, handle, "{\"open\":true}", &err);  /* one option */
+```
+
+**Failure is NULL plus a message.** A generator returns NULL and writes the reason to `*err`. Loading returns handle 0 and writes a validation report to `*report`. All returned strings must be freed by the caller with `linkml_free`.
+
+A loaded schema is an integer handle.
+
+## Building it yourself
+
+You need JDK 17+ (Mill downloads GraalVM itself) and Python 3.10 or newer. Then:
+
+```shell
+./mill nativelib.installPythonLib
+```
+
+That runs `native-image --shared` over the `nativelib` module and copies the result into
+`python/linkml_scala/_lib/`, where the Python package looks for it. Takes about half a minute on a
+recent laptop, and produces a 22 MB `liblinkml_scala.so`.
+
+To use the package, put `python/` on your path:
+
+```shell
+PYTHONPATH=python python3 -c "import linkml_scala; print(linkml_scala.library_path())"
+```
+
+Run the tests with:
+
+```shell
+./mill nativelib.pythonTest
+```
+
+If you keep the library somewhere else, point `LINKML_SCALA_LIB` at the file (or at the directory
+holding it).
+
+### Building a wheel
+
+```shell
+pip install build
+./mill nativelib.pythonWheel      # writes out/nativelib/pythonWheel.dest/dist/*.whl
+./mill nativelib.pythonWheelTest  # installs it in a throwaway virtualenv and runs the tests there
+```
+
+For Linux, we support both glibc and musl. The glibc build is done inside a manylinux2014 container, so it can be used on any Linux distribution. The musl build is done on the host, but requires a musl toolchain to be installed first. This can be done with these scripts:
+
+```shell
+./mill nativelib.linux.glibc.pythonWheelTest  # glibc, built inside manylinux2014
+sudo nativelib/install-musl-toolchain.sh      # once, for the musl build
+./mill nativelib.linux.musl.pythonWheel       # musl, for Alpine
+```
+
+Each release also attaches a prebuilt archive per platform, `linkml-scala-lib-<os>-<arch>`, laid out
+as a normal install prefix – `include/`, `lib/` and a pkg-config file – so C, C++ and Rust callers can
+use the same library. [`nativelib/smoke.c`](../nativelib/smoke.c) is a worked example in C.
+
 ## TODO
 
-1. `pyproject.toml` and a wheel per platform, with the library bundled as package data. The release
-   workflow already builds and attaches the library itself; only the pip side is missing.
-2. Type stubs, or type hints good enough to not need them. The reports are plain dicts today; a
+1. Type stubs, or type hints good enough to not need them. The reports are plain dicts today; a
    `TypedDict` generated from `validation-report.yaml` would be better, and would help the
    TypeScript bindings too (see [#127](https://github.com/NeverBlink-OSS/linkml-scala/issues/127)).

--- a/generator/test/src-jvm/eu/neverblink/linkml/generator/BindingCoverageSpec.scala
+++ b/generator/test/src-jvm/eu/neverblink/linkml/generator/BindingCoverageSpec.scala
@@ -52,6 +52,14 @@ class BindingCoverageSpec extends AnyWordSpec, Matchers {
     block.split(',').map(_.trim).filter(_.nonEmpty).toSet
   }
 
+  /** The Python method names on `linkml_scala.Schema`, read from the generated bindings.
+    */
+  private def pythonMethods(root: os.Path): Seq[String] =
+    "\\n    def (\\w+)\\(".r
+      .findAllMatchIn(os.read(root / "python" / "linkml_scala" / "_generated.py"))
+      .map(_.group(1))
+      .toSeq
+
   /** The generator ids offered by the playground's target list. */
   private def playgroundTargets(root: os.Path): Set[String] =
     "id: \"(\\w+)\"".r
@@ -141,15 +149,17 @@ class BindingCoverageSpec extends AnyWordSpec, Matchers {
     "be documented in the Python bindings guide" in {
       val root = repoRoot.getOrElse(cancel("MILL_WORKSPACE_ROOT is not set"))
       val docs = os.read(root / "docs" / "python_bindings.md")
-      // The doc lists the Python method names, so check those rather than the Scala class names.
-      val pythonNames = "\\n    def (\\w+)\\(".r
-        .findAllMatchIn(os.read(root / "python" / "linkml_scala" / "_generated.py"))
-        .map(_.group(1))
-        .toSeq
-      val missing = pythonNames.filterNot(name => docs.contains(s"schema.$name("))
+      val missing = pythonMethods(root).filterNot(name => docs.contains(s"schema.$name("))
       withClue("add it to the Generating section of docs/python_bindings.md: ")(
         missing shouldBe empty,
       )
+    }
+
+    "be documented in the PyPI package's README" in {
+      val root = repoRoot.getOrElse(cancel("MILL_WORKSPACE_ROOT is not set"))
+      val readme = os.read(root / "python" / "README.md")
+      val missing = pythonMethods(root).filterNot(name => readme.contains(s"$name()"))
+      withClue("add it to the generator list in python/README.md: ")(missing shouldBe empty)
     }
   }
 }

--- a/mill-build/src/NativeLib.scala
+++ b/mill-build/src/NativeLib.scala
@@ -1,0 +1,86 @@
+package millbuild
+
+/** Compiling LinkML to a native shared library with a C ABI, via native-image.
+  *
+  * Plain functions taking paths rather than Mill tasks, for the same reason [[Python]] is shaped
+  * that way: Mill's macro only allows task lookups directly inside a `Task {...}` block, so
+  * build.mill resolves what it needs and these do the work.
+  */
+object NativeLib {
+
+  /** The library's base name. native-image adds the platform's prefix and extension. */
+  val name = "liblinkml_scala"
+
+  /** Join classpath entries the way the JVM on this platform expects. */
+  def classPath(entries: Seq[os.Path]): String =
+    entries.map(_.toString).mkString(java.io.File.pathSeparator)
+
+  /** The classpath written to a file, so nativelib/build-shared.sh can pass it on without a command
+    * line long enough to worry about. Returns the file.
+    */
+  def classPathFile(dest: os.Path, entries: Seq[os.Path]): os.Path = {
+    val file = dest / "classpath.txt"
+    os.write.over(file, classPath(entries))
+    file
+  }
+
+  /** Build the library on this machine, for this machine, into `dest`. Takes a few minutes.
+    *
+    * This is what macOS and Windows ship, and what a source checkout gets. Linux ships the builds
+    * from [[buildForLinux]] instead.
+    */
+  def build(
+      dest: os.Path,
+      graalvmHome: os.Path,
+      entries: Seq[os.Path],
+      options: Seq[String],
+      repoRoot: os.Path,
+  ): os.Path = {
+    val ext = if scala.util.Properties.isWin then ".cmd" else ""
+    os.call(
+      (
+        (graalvmHome / "bin" / s"native-image$ext").toString,
+        "--shared",
+        options,
+        s"-H:Path=$dest",
+        s"-H:Name=$name",
+        "-cp",
+        classPath(entries),
+      ),
+      cwd = repoRoot,
+      stdout = os.Inherit,
+      stderr = os.Inherit,
+    )
+    dest
+  }
+
+  /** Build the library for one Linux libc, through nativelib/build-shared.sh. Returns `dest`.
+    *
+    * `libc` is `glibc`, built inside manylinux2014 so that the minimum glibc is as low as it goes,
+    * or `musl`, cross-linked for Alpine. The script explains both.
+    */
+  def buildForLinux(
+      libc: String,
+      dest: os.Path,
+      graalvmHome: os.Path,
+      classPathFile: os.Path,
+      options: Seq[String],
+      repoRoot: os.Path,
+  ): os.Path = {
+    os.call(
+      (
+        "bash",
+        (repoRoot / "nativelib" / "build-shared.sh").toString,
+        libc,
+        graalvmHome.toString,
+        dest.toString,
+        classPathFile.toString,
+        options,
+      ),
+      cwd = repoRoot,
+      stdout = os.Inherit,
+      stderr = os.Inherit,
+    )
+    dest
+  }
+}

--- a/mill-build/src/PyPackage.scala
+++ b/mill-build/src/PyPackage.scala
@@ -1,0 +1,41 @@
+package millbuild
+
+/** Metadata for the `neverblink-linkml` PyPI package. */
+object PyPackage {
+  val name = "neverblink-linkml"
+  // `0.13.2-3-abc1234-SNAPSHOT`
+  private val Snapshot = """(.+?)-(\d+)-([0-9a-fA-F]+)-SNAPSHOT""".r
+  // `0.13.2-SNAPSHOT`, when there is no commit hash
+  private val PlainSnapshot = """(.+?)-SNAPSHOT""".r
+  private val PreRelease = """(.+?)-(a|alpha|b|beta|rc|RC)\.?(\d+)""".r
+  private val Release = """\d+(?:\.\d+)*""".r
+
+  /** Rewrite a Mill publish version into something compliant with PEP 440.
+    */
+  def version(millVersion: String): String = millVersion match {
+    case Snapshot(tag, commits, hash) => s"${release(tag)}+$commits.g$hash"
+    case PlainSnapshot(tag) => s"${release(tag)}+dev"
+    case tag => release(tag)
+  }
+
+  /** The release part on its own, without any snapshot suffix. */
+  private def release(tag: String): String = tag match {
+    case PreRelease(base, kind, number) => s"$base${marker(kind)}$number"
+    case Release() => tag
+    // A checkout with no tags at all, so there is no version to derive. Nothing to publish either.
+    case _ => "0.0.0"
+  }
+
+  private def marker(kind: String): String = kind.toLowerCase match {
+    case "a" | "alpha" => "a"
+    case "b" | "beta" => "b"
+    case _ => "rc"
+  }
+
+  /** The `_version.py` that goes into the wheel. */
+  def versionFile(version: String): String =
+    s"""\"\"\"The package version, written by `nativelib.pythonWheel` in build.mill.\"\"\"
+       |
+       |__version__ = "$version"
+       |""".stripMargin
+}

--- a/mill-build/src/Python.scala
+++ b/mill-build/src/Python.scala
@@ -1,0 +1,116 @@
+package millbuild
+
+/** Helper functions for Python packaging and testing.
+  */
+object Python {
+  def executable: String =
+    sys.env.getOrElse("PYTHON", if scala.util.Properties.isWin then "python" else "python3")
+
+  /** Copy a native-image build, headers and all, into where the package looks for the library.
+    */
+  def installLibrary(built: os.Path, libDir: os.Path): Unit = {
+    os.makeDir.all(libDir)
+    os.list(built).filter(os.isFile).foreach(os.copy.into(_, libDir, replaceExisting = true))
+  }
+
+  /** Run the binding test suite, against whichever library is installed in the package. */
+  def runTests(repoRoot: os.Path): Unit =
+    os.call(
+      (executable, "-m", "unittest", "discover", "-s", "python", "-v"),
+      cwd = repoRoot,
+      stdout = os.Inherit,
+      stderr = os.Inherit,
+    )
+
+  /** Assemble the package under `dest` and build a wheel from it. Returns the directory holding it.
+    *
+    * @param built
+    *   the native-image output directory to take the shared library from
+    * @param source
+    *   the repository's `python/` directory
+    * @param license
+    *   the license file to ship alongside the code
+    * @param version
+    *   the wheel's version, in the PEP 440 format
+    */
+  def buildWheel(
+      dest: os.Path,
+      built: os.Path,
+      source: os.Path,
+      license: os.Path,
+      version: String,
+  ): os.Path = {
+    val staging = dest / "package"
+    val dist = dest / "dist"
+
+    os.makeDir.all(staging / "linkml_scala")
+    Seq("pyproject.toml", "README.md", "hatch_build.py")
+      .foreach(name => os.copy.into(source / name, staging))
+    os.copy.into(license, staging)
+    os.list(source / "linkml_scala")
+      .filter(path => os.isFile(path) && (path.ext == "py" || path.last == "py.typed"))
+      .foreach(os.copy.into(_, staging / "linkml_scala"))
+
+    os.write.over(staging / "linkml_scala" / "_version.py", PyPackage.versionFile(version))
+
+    // Only the library itself: the headers beside it are for C callers, and ctypes has no use for
+    // the Windows import library.
+    val libraries = os.list(built)
+      .filter(path => os.isFile(path) && Set("so", "dylib", "dll").contains(path.ext))
+    val library = libraries match {
+      case Seq(only) => only
+      case found =>
+        throw new Exception(s"expected one shared library in $built, found ${found.mkString(", ")}")
+    }
+    os.makeDir.all(staging / "linkml_scala" / "_lib")
+    os.copy.into(library, staging / "linkml_scala" / "_lib")
+
+    println(s"Building the ${PyPackage.name} $version wheel from ${library.last}")
+    os.call(
+      (executable, "-m", "build", "--wheel", "--outdir", dist.toString, staging.toString),
+      stdout = os.Inherit,
+      stderr = os.Inherit,
+    )
+    dist
+  }
+
+  /** Install the wheel from `dist` into a fresh virtualenv under `dest` and run the binding tests
+    * against it.
+    *
+    * @param source
+    *   the repository's `python/` directory, holding `test_bindings.py`
+    */
+  def testWheel(dest: os.Path, dist: os.Path, source: os.Path, repoRoot: os.Path): Unit = {
+    val wheel = os.list(dist).find(_.ext == "whl").getOrElse(
+      throw new Exception(s"no wheel was built in $dist"),
+    )
+
+    val venv = dest / "venv"
+    os.call((executable, "-m", "venv", venv.toString), stdout = os.Inherit, stderr = os.Inherit)
+    val venvPython =
+      if scala.util.Properties.isWin then venv / "Scripts" / "python.exe"
+      else venv / "bin" / "python"
+
+    os.call(
+      (venvPython.toString, "-m", "pip", "install", "--quiet", wheel.toString),
+      stdout = os.Inherit,
+      stderr = os.Inherit,
+    )
+
+    val importedFrom = os.call(
+      (venvPython.toString, "-c", "import linkml_scala; print(linkml_scala.__file__)"),
+      cwd = dest,
+    ).out.trim()
+    if !importedFrom.startsWith(venv.toString) then
+      throw new Exception(s"linkml_scala was imported from $importedFrom, not from $venv")
+
+    os.copy.over(source / "test_bindings.py", dest / "test_bindings.py")
+    os.call(
+      (venvPython.toString, "-m", "unittest", "test_bindings", "-v"),
+      cwd = dest,
+      env = Map("LINKML_SCALA_REPO" -> repoRoot.toString),
+      stdout = os.Inherit,
+      stderr = os.Inherit,
+    )
+  }
+}

--- a/nativelib/build-shared.sh
+++ b/nativelib/build-shared.sh
@@ -1,0 +1,100 @@
+#!/usr/bin/env bash
+#
+# Build the shared library for both Linux libc flavours we publish wheels for.
+#
+#   glibc  Runs native-image inside a manylinux2014 container. There is no native-image flag for
+#          "target an older glibc", so linking against an old one is the only way to lower the
+#          minimum version of libc.
+#
+#   musl   Runs native-image on this machine, cross-linking against musl. No container: musl is a
+#          compilation target here, not a build environment. Needs the toolchain set up by
+#          install-musl-toolchain.sh.
+#
+# Usage: nativelib/build-shared.sh <libc> <graalvm-home> <out-dir> <classpath-file> [options...]
+#
+#   libc            glibc or musl
+#   graalvm-home    the GraalVM providing native-image
+#   out-dir         where to write liblinkml_scala.* and the generated C headers
+#   classpath-file  a file holding the image classpath, ':'-separated
+#   options...      the rest is passed to native-image as-is
+
+set -euo pipefail
+
+if [ "$#" -lt 4 ]; then
+  sed -n '2,29p' "$0" >&2
+  exit 2
+fi
+
+libc="$1"
+graalvm_home="$2"
+out_dir="$3"
+classpath_file="$4"
+shift 4
+
+case "$libc" in
+glibc | musl) ;;
+*)
+  echo "error: unknown libc '$libc', expected glibc or musl" >&2
+  exit 2
+  ;;
+esac
+
+repo_root="$(cd "$(dirname "$0")/.." && pwd)"
+out_dir="$(mkdir -p "$out_dir" && cd "$out_dir" && pwd)"
+classpath="$(cat "$classpath_file")"
+
+case "$(uname -m)" in
+x86_64) arch=x86_64 ;;
+aarch64 | arm64) arch=aarch64 ;;
+*)
+  echo "error: unsupported architecture $(uname -m)" >&2
+  exit 1
+  ;;
+esac
+
+case "$libc" in
+glibc)
+  image="quay.io/pypa/manylinux2014_${arch}"
+
+  # Mount stuff for the build: GraalVM, the repo (read-write, because of out/)
+  # and any classpath entry from elsewhere (coursier cache).
+  mounts=(-v "${repo_root}:${repo_root}" -v "${graalvm_home}:${graalvm_home}:ro")
+  while IFS= read -r entry; do
+    case "$entry" in
+    "${repo_root}"/* | "") continue ;;
+    esac
+    mounts+=(-v "${entry}:${entry}:ro")
+  done <<<"$(printf '%s' "$classpath" | tr ':' '\n' | sort -u)"
+
+  echo "building against glibc in ${image}" >&2
+  exec docker run --rm \
+    --user "$(id -u):$(id -g)" \
+    "${mounts[@]}" \
+    -w "$repo_root" \
+    "$image" \
+    "${graalvm_home}/bin/native-image" --shared "$@" \
+    "-H:Path=${out_dir}" -H:Name=liblinkml_scala -cp "$classpath"
+  ;;
+
+musl)
+  compiler="${arch}-linux-musl-gcc"
+  if ! command -v "$compiler" >/dev/null; then
+    echo "error: $compiler is not on PATH. Run nativelib/install-musl-toolchain.sh first." >&2
+    exit 1
+  fi
+
+  prefix="${MUSL_PREFIX:-/usr/local/${arch}-linux-musl}"
+  if [ ! -f "${prefix}/lib/libz.a" ]; then
+    echo "error: no musl zlib at ${prefix}/lib/libz.a." \
+      "Run nativelib/install-musl-toolchain.sh first." >&2
+    exit 1
+  fi
+  # -L on the linker command rather than LIBRARY_PATH in the environment: musl-gcc honours
+  # LIBRARY_PATH, but native-image builds a clean environment for the compiler it spawns, so an
+  # exported one never arrives and the link fails with "cannot find -lz".
+  echo "building against musl with ${compiler}" >&2
+  exec "${graalvm_home}/bin/native-image" --shared --libc=musl "$@" \
+    "-H:NativeLinkerOption=-L${prefix}/lib" \
+    "-H:Path=${out_dir}" -H:Name=liblinkml_scala -cp "$classpath"
+  ;;
+esac

--- a/nativelib/install-musl-toolchain.sh
+++ b/nativelib/install-musl-toolchain.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+#
+# Set up what native-image needs to cross-link the shared library against musl.
+#
+# We need a musl-flavor gcc and a zlib built against musl.
+#
+# Usage: sudo nativelib/install-musl-toolchain.sh [zlib-version]
+
+set -euo pipefail
+
+zlib_version="${1:-1.3.2}"
+
+# zlib.net only serves the current release at its root and moves everything else into /fossils/, so
+# a pinned version there 404s the moment a new one lands. The GitHub release for a tag never moves.
+case "$zlib_version" in
+1.3.2) zlib_sha256=bb329a0a2cd0274d05519d61c667c062e06990d72e125ee2dfa8de64f0119d16 ;;
+1.3.1) zlib_sha256=9a93b2b7dfdac77ceba5a558a580e74667dd6fede4585b91eefb60f03b72df23 ;;
+*)
+  echo "error: no known checksum for zlib ${zlib_version}. Add one to $0." >&2
+  exit 1
+  ;;
+esac
+
+case "$(uname -m)" in
+x86_64) arch=x86_64 ;;
+aarch64 | arm64) arch=aarch64 ;;
+*)
+  echo "error: unsupported architecture $(uname -m)" >&2
+  exit 1
+  ;;
+esac
+
+prefix="${MUSL_PREFIX:-/usr/local/${arch}-linux-musl}"
+
+export DEBIAN_FRONTEND=noninteractive
+apt-get update -qq
+apt-get install -y -qq musl-tools musl-dev gcc make curl
+
+# native-image insists on the architecture-prefixed name.
+ln -sf "$(command -v musl-gcc)" "/usr/local/bin/${arch}-linux-musl-gcc"
+
+work="$(mktemp -d)"
+trap 'rm -rf "$work"' EXIT
+echo "building zlib ${zlib_version} against musl into ${prefix}" >&2
+tarball="${work}/zlib.tar.gz"
+curl -sSfL -o "$tarball" \
+  "https://github.com/madler/zlib/releases/download/v${zlib_version}/zlib-${zlib_version}.tar.gz"
+# This ends up linked into a library we publish, so check we got what we expected.
+echo "${zlib_sha256}  ${tarball}" | sha256sum -c - >/dev/null
+tar xzf "$tarball" -C "$work"
+cd "${work}/zlib-${zlib_version}"
+CC=musl-gcc ./configure --static --prefix="$prefix" >/dev/null
+make -j"$(nproc)" >/dev/null
+make install >/dev/null
+
+echo "installed:" >&2
+ls -l "/usr/local/bin/${arch}-linux-musl-gcc" "${prefix}/lib/libz.a" >&2

--- a/python/README.md
+++ b/python/README.md
@@ -1,0 +1,62 @@
+# neverblink-linkml
+
+Fast and robust [LinkML](https://linkml.io/) schema validation and code generation for Python, backed by [LinkML-Scala](https://github.com/NeverBlink-OSS/linkml-scala) compiled to a native shared library.
+
+No JVM, no subprocess per schema, and no dependency on the `linkml` Python package. In our
+[benchmarks](https://github.com/NeverBlink-OSS/linkml-scala/blob/main/docs/benchmarks.md) the generators are 22.9–38.5x faster than the reference Python implementation.
+
+## Install
+
+```shell
+pip install neverblink-linkml
+```
+
+## Usage
+
+```python
+import linkml_scala
+
+with linkml_scala.load_file("model.yaml") as schema:
+    print(schema.json_schema())
+    print(schema.shacl())
+    for issue in schema.issues(linkml_scala.WARNING):
+        print(issue["severity"], issue["message"])
+```
+
+`load_file()` will automatically resolve imports and parse the schema. You can reuse the `Schema` object for multiple generator calls, and it will automatically cache the parsed form of any imported schemas.
+
+Generators available on a `Schema`: `json_schema()`, `shacl()`, `rdfs()`, `linkml()`,
+`table_schema()`, `graphql()`, `er_diagram()` and `scala()`, plus `lint()` for validation.
+
+To work from memory instead of the file system, use `load_string()` for a single schema or
+`load_path()` when imports are involved:
+
+```python
+schema = linkml_scala.load_path("model.yaml", {
+    "model.yaml": "...",
+    "person.yaml": "...",
+})
+```
+
+## Supported platforms
+
+| OS            | Architectures        |
+|---------------|----------------------|
+| Linux (glibc) | x86-64, ARM64        |
+| Linux (musl)  | x86-64, ARM64        |
+| macOS         | Apple silicon, Intel |
+| Windows       | x86-64               |
+
+Python 3.10 or newer, 64-bit only. Other platforms are currently not supported, and would require an alternative compilation path (e.g., Scala Native). Please [open an issue](https://github.com/NeverBlink-OSS/linkml-scala/issues/new) if you need a platform that is not listed above.
+
+## Documentation
+
+- [Python bindings guide](https://github.com/NeverBlink-OSS/linkml-scala/blob/main/docs/python_bindings.md)
+  – all the options, and how the C ABI underneath works
+- [LinkML-Scala README](https://github.com/NeverBlink-OSS/linkml-scala) – the CLI, the JVM library
+  and the JavaScript library
+- [Online playground](https://linkml.neverblink.eu/playground/)
+
+## License
+
+Apache 2.0.

--- a/python/hatch_build.py
+++ b/python/hatch_build.py
@@ -1,0 +1,231 @@
+"""Helpers for managing platform tags on the wheel built by hatchling.
+
+The platform tag must name the oldest system the library still runs on, so that pip installs the
+correct wheel. We read that out of the library itself:
+
+  * Linux: the highest ``GLIBC_x.y`` the library asks for (manylinux).
+  * macOS: the minimum OS version recorded in the Mach-O header.
+  * Windows: no such thing exists, so the tag is only the architecture.
+
+Set ``LINKML_SCALA_WHEEL_PLATFORM`` to override the whole platform tag. Run it like::
+
+    python hatch_build.py linkml_scala/_lib/liblinkml_scala.so
+"""
+
+from __future__ import annotations
+
+import os
+import platform
+import struct
+import sys
+from pathlib import Path
+
+LIBRARY_EXTENSIONS = (".so", ".dylib", ".dll")
+
+LINUX_ARCHITECTURES = {
+    "x86_64": "x86_64",
+    "amd64": "x86_64",
+    "aarch64": "aarch64",
+    "arm64": "aarch64",
+}
+MACOS_ARCHITECTURES = {"x86_64": "x86_64", "amd64": "x86_64", "arm64": "arm64", "aarch64": "arm64"}
+WINDOWS_ARCHITECTURES = {"amd64": "amd64", "x86_64": "amd64", "arm64": "arm64"}
+
+# musl does not record its version in the binary, so unlike glibc this cannot be derived. 1.2 is
+# what every currently supported Alpine has.
+MUSLLINUX_VERSION = (1, 2)
+
+
+def find_library(root: Path) -> Path:
+    """The one shared library staged inside the package."""
+    lib_dir = root / "linkml_scala" / "_lib"
+    found = sorted(p for p in lib_dir.glob("*") if p.suffix in LIBRARY_EXTENSIONS)
+    if len(found) != 1:
+        raise RuntimeError(
+            f"expected exactly one shared library in {lib_dir}, found {len(found)}. "
+            "Build it with `./mill nativelib.installPythonLib`."
+        )
+    return found[0]
+
+
+def platform_tag(library: Path) -> str:
+    """The platform part of the wheel tag for a library, e.g. ``manylinux_2_34_x86_64``."""
+    override = os.environ.get("LINKML_SCALA_WHEEL_PLATFORM")
+    if override:
+        return override
+
+    machine = platform.machine().lower()
+    if sys.platform.startswith("linux"):
+        return linux_tag(library, architecture(LINUX_ARCHITECTURES, machine))
+    if sys.platform == "darwin":
+        major, minor = macho_minimum_os(library)
+        return f"macosx_{major}_{minor}_{architecture(MACOS_ARCHITECTURES, machine)}"
+    if sys.platform == "win32":
+        return f"win_{architecture(WINDOWS_ARCHITECTURES, machine)}"
+    raise RuntimeError(f"no wheel platform tag known for {sys.platform}")
+
+
+def architecture(known: dict[str, str], machine: str) -> str:
+    if machine not in known:
+        raise RuntimeError(f"unsupported architecture {machine!r} on {sys.platform}")
+    return known[machine]
+
+
+def linux_tag(library: Path, arch: str) -> str:
+    """``manylinux_x_y_<arch>`` or ``musllinux_1_2_<arch>``, depending on which libc it links.
+
+    glibc puts a version on every symbol it exports, so anything linked against it asks for some
+    ``GLIBC_x.y``. musl does not version its symbols at all, so finding none means musl.
+    """
+    versions = elf_glibc_requirements(library)
+    if not versions:
+        return f"musllinux_{MUSLLINUX_VERSION[0]}_{MUSLLINUX_VERSION[1]}_{arch}"
+    major, minor = max(versions)
+    return f"manylinux_{major}_{minor}_{arch}"
+
+
+def elf_glibc_requirements(library: Path) -> list[tuple[int, int]]:
+    """Every ``GLIBC_x.y`` version the library asks for. Empty for a musl build.
+
+    Read from the ELF version-requirement table.
+    """
+    data = library.read_bytes()
+    if data[:4] != b"\x7fELF":
+        raise RuntimeError(f"{library} is not an ELF file")
+    if data[4] != 2:
+        raise RuntimeError(f"{library} is not 64-bit, and we only package 64-bit builds")
+    endian = "<" if data[5] == 1 else ">"
+
+    # ELF64 file header: the section table's offset, entry size and entry count.
+    (section_offset,) = struct.unpack_from(endian + "Q", data, 0x28)
+    entry_size, entry_count = struct.unpack_from(endian + "HH", data, 0x3A)
+
+    versions: list[tuple[int, int]] = []
+    for index in range(entry_count):
+        header = section_offset + index * entry_size
+        # ELF64 section header: sh_type at +0x04, sh_offset +0x18, sh_link +0x28, sh_info +0x2C.
+        (section_type,) = struct.unpack_from(endian + "I", data, header + 0x04)
+        if section_type != 0x6FFFFFFE:  # SHT_GNU_verneed, "needs these symbol versions"
+            continue
+        (table,) = struct.unpack_from(endian + "Q", data, header + 0x18)
+        strings_index, needed = struct.unpack_from(endian + "II", data, header + 0x28)
+        strings = strings_offset(data, endian, section_offset, entry_size, strings_index)
+        versions += verneed_versions(data, endian, table, needed, strings)
+
+    return versions
+
+
+def strings_offset(
+    data: bytes, endian: str, section_offset: int, entry_size: int, index: int
+) -> int:
+    """Where the string table a section points at starts in the file."""
+    (offset,) = struct.unpack_from(endian + "Q", data, section_offset + index * entry_size + 0x18)
+    return offset
+
+
+def verneed_versions(
+    data: bytes, endian: str, table: int, needed: int, strings: int
+) -> list[tuple[int, int]]:
+    """Walk the Verneed/Vernaux lists, collecting the GLIBC versions they point to."""
+    versions: list[tuple[int, int]] = []
+    entry = table
+    for _ in range(needed):
+        # Elf64_Verneed: vn_cnt at +0x02, vn_aux +0x08, vn_next +0x0C. Both offsets are relative
+        # to the entry they sit in.
+        (count,) = struct.unpack_from(endian + "H", data, entry + 0x02)
+        aux_offset, next_offset = struct.unpack_from(endian + "II", data, entry + 0x08)
+        aux = entry + aux_offset
+        for _ in range(count):
+            # Elf64_Vernaux: vna_name at +0x08, vna_next at +0x0C.
+            name_offset, aux_next = struct.unpack_from(endian + "II", data, aux + 0x08)
+            version = glibc_version(read_string(data, strings + name_offset))
+            if version is not None:
+                versions.append(version)
+            if aux_next == 0:
+                break
+            aux += aux_next
+        if next_offset == 0:
+            break
+        entry += next_offset
+    return versions
+
+
+def read_string(data: bytes, offset: int) -> str:
+    end = data.index(b"\0", offset)
+    return data[offset:end].decode("utf-8", "replace")
+
+
+def glibc_version(name: str) -> tuple[int, int] | None:
+    """``GLIBC_2.34`` to ``(2, 34)``. Anything else to None."""
+    if not name.startswith("GLIBC_"):
+        return None
+    parts = name[len("GLIBC_") :].split(".")
+    if len(parts) < 2 or not all(part.isdigit() for part in parts[:2]):
+        return None
+    return int(parts[0]), int(parts[1])
+
+
+def macho_minimum_os(library: Path) -> tuple[int, int]:
+    """The minimum macOS version the library needs, as ``(major, minor)``.
+
+    Falls back to the version of the machine doing the build, if the header cannot be read.
+    """
+    try:
+        return macho_load_commands(library.read_bytes())
+    except (RuntimeError, struct.error, IndexError) as problem:
+        running = platform.mac_ver()[0].split(".")
+        major = int(running[0])
+        minor = int(running[1]) if len(running) > 1 else 0
+        print(
+            f"warning: could not read the minimum OS version from {library.name} ({problem}); "
+            f"falling back to this machine's macOS {major}.{minor}",
+            file=sys.stderr,
+        )
+        return major, minor
+
+
+def macho_load_commands(data: bytes) -> tuple[int, int]:
+    (magic,) = struct.unpack_from("<I", data, 0)
+    if magic != 0xFEEDFACF:  # MH_MAGIC_64, little-endian; both arm64 and x86_64 are little-endian
+        raise RuntimeError(f"unexpected Mach-O magic {magic:#x}, expected a thin 64-bit library")
+    (command_count,) = struct.unpack_from("<I", data, 0x10)
+
+    offset = 0x20  # straight after the mach_header_64
+    for _ in range(command_count):
+        command, size = struct.unpack_from("<II", data, offset)
+        if command == 0x32:  # LC_BUILD_VERSION: platform, minos, sdk, ntools
+            (encoded,) = struct.unpack_from("<I", data, offset + 0x0C)
+            return decode_macho_version(encoded)
+        if command == 0x24:  # LC_VERSION_MIN_MACOSX: version, sdk
+            (encoded,) = struct.unpack_from("<I", data, offset + 0x08)
+            return decode_macho_version(encoded)
+        offset += size
+    raise RuntimeError("no LC_BUILD_VERSION or LC_VERSION_MIN_MACOSX load command")
+
+
+def decode_macho_version(encoded: int) -> tuple[int, int]:
+    """Mach-O packs X.Y.Z as ``xxxx.yy.zz`` in one 32-bit word."""
+    return (encoded >> 16) & 0xFFFF, (encoded >> 8) & 0xFF
+
+
+try:
+    from hatchling.builders.hooks.plugin.interface import BuildHookInterface
+except ImportError:  # Running this file directly, to see what tag a library would get.
+    BuildHookInterface = object  # type: ignore[assignment,misc]
+
+
+class CustomBuildHook(BuildHookInterface):  # type: ignore[misc]
+    """Tags the wheel for one platform, and marks it as containing a binary."""
+
+    def initialize(self, version: str, build_data: dict) -> None:
+        library = find_library(Path(self.root))
+        tag = f"py3-none-{platform_tag(library)}"
+        # Not pure Python, so the files belong in platlib rather than purelib.
+        build_data["pure_python"] = False
+        build_data["tag"] = tag
+        print(f"tagging the wheel {tag}, for {library.name}")
+
+
+if __name__ == "__main__":
+    target = Path(sys.argv[1]) if len(sys.argv) > 1 else find_library(Path(__file__).parent)
+    print(f"py3-none-{platform_tag(target)}")

--- a/python/linkml_scala/__init__.py
+++ b/python/linkml_scala/__init__.py
@@ -11,8 +11,8 @@ Load a schema once, then run as many generators over it as you like::
         print(schema.json_schema())
         print(schema.shacl())
 
-See docs/python_bindings.md in the LinkML-Scala repository for the whole story, including how to
-build the library.
+Install it with ``pip install neverblink-linkml``. See docs/python_bindings.md in the LinkML-Scala
+repository for more information, including how to build the library yourself.
 """
 
 from __future__ import annotations
@@ -28,11 +28,13 @@ from ._runtime import (
     library_path,
     runtime,
 )
+from ._version import __version__
 
 __all__ = [
     "FATAL",
     "ERROR",
     "WARNING",
+    "__version__",
     "LinkMlError",
     "NativeLibraryNotFound",
     "Runtime",

--- a/python/linkml_scala/_runtime.py
+++ b/python/linkml_scala/_runtime.py
@@ -59,12 +59,13 @@ def _candidates() -> list[Path]:
         path = Path(explicit)
         found.append(path / filename if path.is_dir() else path)
 
-    # Installed by `./mill nativelib.installPythonLib`.
+    # Shipped inside the wheel, or put there by `./mill nativelib.installPythonLib`.
     found.append(Path(__file__).parent / "_lib" / filename)
 
     # A source checkout that built the library but did not install it.
-    repo_root = Path(__file__).resolve().parents[2]
-    found.append(repo_root / "out" / "nativelib" / "sharedLibrary.dest" / filename)
+    built = Path(__file__).resolve().parents[2] / "out" / "nativelib" / "sharedLibrary.dest"
+    if built.is_dir():
+        found.append(built / filename)
 
     return found
 
@@ -81,7 +82,8 @@ def library_path() -> Path:
     listed = "\n  ".join(str(candidate) for candidate in candidates)
     raise NativeLibraryNotFound(
         f"Could not find {_library_filename()}. Looked in:\n  {listed}\n"
-        "Build it with `./mill nativelib.installPythonLib`, or point LINKML_SCALA_LIB at it."
+        "Install a wheel with `pip install neverblink-linkml`, build the library with "
+        "`./mill nativelib.installPythonLib`, or point LINKML_SCALA_LIB at one you already have."
     )
 
 

--- a/python/linkml_scala/_version.py
+++ b/python/linkml_scala/_version.py
@@ -1,0 +1,7 @@
+"""The package version.
+
+`nativelib.pythonWheel` in build.mill overwrites this when it builds a wheel, so that the version
+matches the one published to Maven Central and npm.
+"""
+
+__version__ = "0.0.0+dev"

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -1,0 +1,52 @@
+[build-system]
+requires = ["hatchling>=1.27"]
+build-backend = "hatchling.build"
+
+[project]
+name = "neverblink-linkml"
+dynamic = ["version"]
+description = "Fast (natively-compiled) and robust LinkML implementation, supporting validation and code generation."
+readme = "README.md"
+requires-python = ">=3.10"
+license = "Apache-2.0"
+license-files = ["LICENSE"]
+authors = [{ name = "NeverBlink" }]
+keywords = [
+    "linkml",
+    "json-schema",
+    "shacl",
+    "rdf",
+    "schema",
+    "validation",
+    "code-generation",
+]
+classifiers = [
+    "Development Status :: 4 - Beta",
+    "Intended Audience :: Developers",
+    "Intended Audience :: Science/Research",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3 :: Only",
+    "Topic :: Software Development :: Code Generators",
+    "Topic :: Software Development :: Libraries :: Python Modules",
+    "Typing :: Typed",
+]
+
+[project.urls]
+Homepage = "https://github.com/NeverBlink-OSS/linkml-scala"
+Documentation = "https://github.com/NeverBlink-OSS/linkml-scala/blob/main/docs/python_bindings.md"
+Source = "https://github.com/NeverBlink-OSS/linkml-scala"
+Issues = "https://github.com/NeverBlink-OSS/linkml-scala/issues"
+Changelog = "https://github.com/NeverBlink-OSS/linkml-scala/releases"
+
+[tool.hatch.version]
+path = "linkml_scala/_version.py"
+
+[tool.hatch.build.targets.wheel]
+packages = ["linkml_scala"]
+# _lib holds the prebuilt shared library, which is gitignored, so it has to be named here or
+# hatchling leaves it out.
+artifacts = ["linkml_scala/_lib/*"]
+
+# Resolves the platform tags in hatchling build.
+[tool.hatch.build.targets.wheel.hooks.custom]
+path = "hatch_build.py"

--- a/python/test_bindings.py
+++ b/python/test_bindings.py
@@ -3,6 +3,10 @@
 Run them with ``./mill nativelib.pythonTest``, which rebuilds the shared library first. To run them
 against a library you already have, ``python -m unittest discover -s python``.
 
+``./mill nativelib.pythonWheelTest`` runs this same file against an installed wheel, from a copy in
+a temporary directory so that the sources here cannot shadow the package under test. That is what
+``LINKML_SCALA_REPO`` is for: from there, the fixtures are no longer two directories up.
+
 These check the binding, not the generators: that every call reaches the library, comes back with
 plausible output, and that failures surface as exceptions rather than crashes. The generators
 themselves are covered by the Scala test suite.
@@ -11,6 +15,7 @@ themselves are covered by the Scala test suite.
 from __future__ import annotations
 
 import json
+import os
 import textwrap
 import threading
 import unittest
@@ -19,7 +24,7 @@ from pathlib import Path
 import linkml_scala
 from linkml_scala import LinkMlError, SchemaLoadError
 
-REPO_ROOT = Path(__file__).resolve().parents[1]
+REPO_ROOT = Path(os.environ.get("LINKML_SCALA_REPO") or Path(__file__).resolve().parents[1])
 
 
 def schema(name: str, body: str) -> str:


### PR DESCRIPTION
It's eehhh a bit convoluted because I wanted the linux build to support fairly old libc and also musl, for broad compatibility. Partially solves #178, but not for the CLI binary, only the .so.

The python package is a wrapper around a native library, so we can support only the platforms that are supported by graal. If we ever want to expand this, then we could try invoking the arcane magic of the GraalVM LLVM backend: https://github.com/oracle/graal/blob/master/substratevm/src/com.oracle.svm.core.graal.llvm/src/com/oracle/svm/core/graal/llvm/LLVMBackend.md

*(fun fact: graal can both JIT LLVM bitcode AND compile programs to LLVM bitcode. why? no idea)*

Ooor by compiling to Wasm which is also an option. Because Wasm interpreters for Python exist, this would theoretically allow for a platform-independent package? Sure.

Anyway, this should work, I think. I have no way to test the MacOS part – I propose we just try to run this on the next release and see what happens.