### PR TITLE
Yet more efficient yaml parsing

### DIFF
--- a/build.mill
+++ b/build.mill
@@ -141,7 +141,7 @@ object yaml extends Module {
 
   trait YamlModule extends CommonModule {
     def mvnDeps = Seq(
-      mvn"com.github.plokhotnyuk.scala-yaml::scala-yaml::0.3.14",
+      mvn"com.github.plokhotnyuk.scala-yaml::scala-yaml::0.3.15",
     )
   }
 }

--- a/cli/src/eu/neverblink/linkml/cli/GenerateImpl.scala
+++ b/cli/src/eu/neverblink/linkml/cli/GenerateImpl.scala
@@ -1,7 +1,7 @@
 package eu.neverblink.linkml.cli
 
 import caseapp.*
-import com.github.plokhotnyuk.jsoniter_scala.core.*
+import com.github.plokhotnyuk.jsoniter_scala.core.{writeToStream, *}
 import eu.neverblink.linkml.generator.erdiagram.ErDiagramGenerator
 import eu.neverblink.linkml.generator.graphql.GraphQlGenerator
 import eu.neverblink.linkml.generator.jsonschema.JsonSchemaGenerator
@@ -245,15 +245,17 @@ final case class TableSchemaOptions(
     treeRoot: Option[String] = None,
 ) extends HasGenerateOptions
 
-object TableSchema extends StringGenerate[TableSchemaOptions] {
+object TableSchema extends StreamGenerate[TableSchemaOptions] {
   override protected def generatorName: String = "table-schema"
 
-  override protected[cli] def generate(
-      options: TableSchemaOptions,
-  )(using SchemaView): Iterable[(String, String)] =
-    Seq(
-      ("", TableSchemaGenerator().serialize(TableSchemaGenerator.Options(options.treeRoot))),
-    )
+  override protected[cli] def generate(options: TableSchemaOptions, out: OutputStream)(using
+      SchemaView,
+  ): Unit =
+    writeToStream(
+      TableSchemaGenerator().generate(TableSchemaGenerator.Options(options.treeRoot)),
+      out,
+      WriterConfig.withIndentionStep(2),
+    )(using TableSchemaGenerator.codec)
 }
 
 // GraphQL

--- a/generator/src/eu/neverblink/linkml/generator/tableschema/TableSchemaGenerator.scala
+++ b/generator/src/eu/neverblink/linkml/generator/tableschema/TableSchemaGenerator.scala
@@ -135,7 +135,7 @@ class TableSchemaGenerator(using sv: SchemaView) {
     writeToString(
       generate(options),
       WriterConfig.withIndentionStep(2),
-    )(using TableSchemaGenerator.tableDescriptorCodec)
+    )(using TableSchemaGenerator.codec)
 }
 
 object TableSchemaGenerator {
@@ -149,7 +149,7 @@ object TableSchemaGenerator {
       treeRoot: Option[String] = None,
   )
 
-  private[tableschema] implicit val tableDescriptorCodec: JsonValueCodec[TableDescriptor] =
+  implicit val codec: JsonValueCodec[TableDescriptor] =
     JsonCodecMaker.make(
       CodecMakerConfig.withEncodingOnly(true)
         .withDiscriminatorFieldName(None)

--- a/generator/src/eu/neverblink/linkml/generator/util/JsonUtil.scala
+++ b/generator/src/eu/neverblink/linkml/generator/util/JsonUtil.scala
@@ -28,9 +28,9 @@ object JsonUtil {
         } else if ((tag eq Tag.int) || (tag eq Tag.float)) {
           val value = s.value.trim
           // some valid YAML numbers cannot be serialized as JSON numbers
-          val bytes = s.value.getBytes
-          if (isJsonNumber(bytes)) out.writeRawVal(bytes)
-          else out.writeVal(value)
+          val bytes = value.getBytes
+          if (isJsonNumber(bytes)) out.writeRawVal(bytes) // serialize as JSON number
+          else out.writeVal(value) // serialize as JSON string
         } else out.writeVal(s.value)
       case m: Node.MappingNode =>
         out.writeObjectStart()


### PR DESCRIPTION
Below are throughput results using JDK 25 on MacBook

Before:
```txt
Benchmark                                    (schema)   Mode  Cnt    Score   Error  Units
GeneratorBench.jsonSchemaFromYaml      cgmes-core.yml  thrpt    5  239.350 ± 2.720  ops/s
GeneratorBench.jsonSchemaFromYaml  cgmes-dynamics.yml  thrpt    5   64.022 ± 2.259  ops/s
GeneratorBench.jsonSchemaFromYaml         TC57CIM.yml  thrpt    5   11.307 ± 0.563  ops/s
GeneratorBench.linkmlFromYaml          cgmes-core.yml  thrpt    5  171.744 ± 0.665  ops/s
GeneratorBench.linkmlFromYaml      cgmes-dynamics.yml  thrpt    5   51.275 ± 2.027  ops/s
GeneratorBench.linkmlFromYaml             TC57CIM.yml  thrpt    5    9.138 ± 0.604  ops/s
GeneratorBench.shaclFromYaml           cgmes-core.yml  thrpt    5  152.843 ± 0.551  ops/s
GeneratorBench.shaclFromYaml       cgmes-dynamics.yml  thrpt    5   56.521 ± 1.288  ops/s
GeneratorBench.shaclFromYaml              TC57CIM.yml  thrpt    5    9.505 ± 0.356  ops/s
```

After:
```txt
Benchmark                                    (schema)   Mode  Cnt    Score   Error  Units
GeneratorBench.jsonSchemaFromYaml      cgmes-core.yml  thrpt    5  256.267 ± 4.182  ops/s
GeneratorBench.jsonSchemaFromYaml  cgmes-dynamics.yml  thrpt    5   67.365 ± 1.899  ops/s
GeneratorBench.jsonSchemaFromYaml         TC57CIM.yml  thrpt    5   12.490 ± 0.617  ops/s
GeneratorBench.linkmlFromYaml          cgmes-core.yml  thrpt    5  179.552 ± 1.927  ops/s
GeneratorBench.linkmlFromYaml      cgmes-dynamics.yml  thrpt    5   53.053 ± 2.115  ops/s
GeneratorBench.linkmlFromYaml             TC57CIM.yml  thrpt    5    9.739 ± 0.593  ops/s
GeneratorBench.shaclFromYaml           cgmes-core.yml  thrpt    5  160.560 ± 1.715  ops/s
GeneratorBench.shaclFromYaml       cgmes-dynamics.yml  thrpt    5   58.960 ± 1.735  ops/s
GeneratorBench.shaclFromYaml              TC57CIM.yml  thrpt    5   10.283 ± 0.133  ops/s
```

While on existing schemas the speed up is not so impressive, but in fact the parser improvement fixes O(n^2) algorithmic complexity for mapping nodes with a lot of entries
