### PR TITLE
LNK-189: Make GraphQL use split interface/implementation when concrete inheritance is found.

### DIFF
--- a/generator/src/eu/neverblink/linkml/generator/graphql/GraphQlGenerator.scala
+++ b/generator/src/eu/neverblink/linkml/generator/graphql/GraphQlGenerator.scala
@@ -23,7 +23,7 @@ class GraphQlGenerator(using sv: SchemaView)
     val builder = Map.newBuilder[String, ClassView]
     sv.classes.foreach { (_, child) =>
       child.parents.foreach { cls =>
-        if !cls.cls.`abstract` || !cls.cls.mixin then builder.addOne((cls.name, cls))
+        if !cls.cls.`abstract` && !cls.cls.mixin then builder.addOne((cls.name, cls))
       }
     }
     builder.result()

--- a/generator/src/eu/neverblink/linkml/generator/graphql/GraphQlGenerator.scala
+++ b/generator/src/eu/neverblink/linkml/generator/graphql/GraphQlGenerator.scala
@@ -15,6 +15,20 @@ import scala.util.matching.Regex
 
 class GraphQlGenerator(using sv: SchemaView)
     extends CharDocumentGenerator[GraphQlGenerator.Options] {
+
+  /** Set of classes that are instantiable and have child classes. They need to have a split
+    * interface/implementation, with the implementation only inheriting from the interface.
+    */
+  lazy val concreteInheritance: Map[String, ClassView] = {
+    val builder = Map.newBuilder[String, ClassView]
+    sv.classes.foreach { (_, child) =>
+      child.parents.foreach { cls =>
+        if !cls.cls.`abstract` || !cls.cls.mixin then builder.addOne((cls.name, cls))
+      }
+    }
+    builder.result()
+  }
+
   import GraphQlGenerator.*
 
   override protected def defaultOptions: Options = Options()
@@ -74,7 +88,7 @@ class GraphQlGenerator(using sv: SchemaView)
   /** Generate a GraphQL definition corresponding to the provided class, or None if the class is
     * linkml:Any
     */
-  def generateClass(cls: ClassView): Option[GraphQlDefinition] = {
+  def generateClass(cls: ClassView): Iterable[GraphQlDefinition] = {
     lazy val fields = cls.attributeViews.values.map(av => {
       val range: String = av match {
         case AnyView(_, _) =>
@@ -90,30 +104,54 @@ class GraphQlGenerator(using sv: SchemaView)
         range,
       )
     })
-    if cls.isAny then None
+    if cls.isAny then Seq.empty
     else if cls.cls.`abstract` || cls.cls.mixin then
-      Some(
+      Seq(
         GraphQlInterfaceDefinition(
           cls,
           fields,
-          cls.parents.collect {
-            case cv if cv.cls.`abstract` || cv.cls.mixin => escaped(cv.aliasedName)
-          },
+          cls.parents.map(getInterfaceName),
         ),
       )
-    else
-      Some(
+    else if concreteInheritance.contains(cls.name) then
+      Seq(
+        GraphQlInterfaceDefinition(
+          cls,
+          fields,
+          cls.parents.map(getInterfaceName),
+          Some(splitInterfaceName(cls)),
+        ),
         GraphQlTypeDefinition(
           cls,
           fields,
-          // Break the inheritance chain on concrete -> concrete inheritance
-          // We still need to use the derived slots and interfaces and types anyway
-          cls.parents.collect {
-            case cv if cv.cls.`abstract` || cv.cls.mixin => escaped(cv.aliasedName)
-          },
+          Seq(splitInterfaceName(cls)),
+        ),
+      )
+    else
+      Seq(
+        GraphQlTypeDefinition(
+          cls,
+          fields,
+          cls.parents.map(getInterfaceName),
         ),
       )
   }
+
+  /** Get the interface name for a class, for inheritance. Handles classes split into
+    * interface/implementation.
+    */
+  def getInterfaceName(cls: ClassView): String = {
+    // Class is split, we need to refer to the interface instead
+    if concreteInheritance.contains(cls.name) then splitInterfaceName(cls)
+    // Class is interface-only, we can refer to it directly
+    else escaped(cls.aliasedName)
+  }
+
+  /** Get the interface name of a split class. Assumes [[cls]] is a split class:
+    * `concreteInheritance.contains(cls.name)` is true.
+    */
+  def splitInterfaceName(cls: ClassView): String =
+    escaped(cls.aliasedName) + "Interface"
 
   /** Write the GraphQL definitions.
     */
@@ -188,11 +226,14 @@ trait GraphQlDefinition extends GraphQlElement
   *   Field definitions to include
   * @param inherits
   *   Aliased names to use for inheritance
+  * @param nameOverride
+  *   Name of the interface, if it should be different (like when generating split classes)
   */
 case class GraphQlInterfaceDefinition(
     classView: ClassView,
     fields: Iterable[GraphQlField],
     inherits: Seq[String],
+    nameOverride: Option[String] = None,
 ) extends GraphQlDefinition:
   val inheritsList: String =
     if inherits.isEmpty then "" else "implements " + inherits.mkString(" & ")
@@ -210,9 +251,11 @@ case class GraphQlInterfaceDefinition(
               |""".stripMargin
   }
 
+  val name: String = nameOverride.getOrElse(escaped(classView.aliasedName))
+
   override def print: String =
     indent"""${wrapDescription(classView.cls.description)}
-            |interface ${escaped(classView.aliasedName)} $inheritsList $body
+            |interface $name $inheritsList $body
             |""".stripMargin
 
 /** Container for information needed to generate an object ("type") definition

--- a/generator/src/eu/neverblink/linkml/generator/graphql/GraphQlGenerator.scala
+++ b/generator/src/eu/neverblink/linkml/generator/graphql/GraphQlGenerator.scala
@@ -94,7 +94,7 @@ class GraphQlGenerator(using sv: SchemaView)
         case AnyView(_, _) =>
           "Any"
         case classAttributeView: ClassAttributeView =>
-          classAttributeView.classView.aliasedName
+          getInterfaceName(classAttributeView.classView)
         case tav: TypeAttributeView =>
           remappedType(tav.typeView)
         case EnumAttributeView(_, _, enumView) => enumView.aliasedName
@@ -137,8 +137,8 @@ class GraphQlGenerator(using sv: SchemaView)
       )
   }
 
-  /** Get the interface name for a class, for inheritance. Handles classes split into
-    * interface/implementation.
+  /** Get the interface name for a class' interface, if it has an interface/implementation split.
+    * Otherwise, gets the class' GraphQL name.
     */
   def getInterfaceName(cls: ClassView): String = {
     // Class is split, we need to refer to the interface instead

--- a/generator/test/src/eu/neverblink/linkml/generator/graphql/GraphQlGeneratorSpec.scala
+++ b/generator/test/src/eu/neverblink/linkml/generator/graphql/GraphQlGeneratorSpec.scala
@@ -178,7 +178,21 @@ class GraphQlGeneratorSpec extends AnyWordSpec, Matchers {
       Seq(
         "interface BaseClassInterface",
         "type BaseClass implements BaseClassInterface",
-        "type ChildClass implements BaseClassInterface"
+        "type ChildClass implements BaseClassInterface",
+      ).foreach { snippet =>
+        result should include(snippet)
+      }
+    }
+
+    "generate interface ranges when concrete inheritance" in {
+      given SchemaView = ModelCatalogue.inheritance.model
+
+      val result = GraphQlGenerator().serialize()
+      Seq(
+        "interface BaseRefClassInterface",
+        "type BaseRefClass implements BaseRefClassInterface",
+        "yet_another_slot: BaseRefClassInterface!",
+        "type RefClass implements BaseRefClassInterface",
       ).foreach { snippet =>
         result should include(snippet)
       }

--- a/generator/test/src/eu/neverblink/linkml/generator/graphql/GraphQlGeneratorSpec.scala
+++ b/generator/test/src/eu/neverblink/linkml/generator/graphql/GraphQlGeneratorSpec.scala
@@ -171,6 +171,19 @@ class GraphQlGeneratorSpec extends AnyWordSpec, Matchers {
       }
     }
 
+    "generate split interface/implementation when concrete inheritance" in {
+      given SchemaView = ModelCatalogue.inheritance.model
+
+      val result = GraphQlGenerator().serialize()
+      Seq(
+        "interface BaseClassInterface",
+        "type BaseClass implements BaseClassInterface",
+        "type ChildClass implements BaseClassInterface"
+      ).foreach { snippet =>
+        result should include(snippet)
+      }
+    }
+
     "prune unused linkml:types elements by default" in {
       given SchemaView = ModelCatalogue.reference.model
 

--- a/metamodel/src/eu/neverblink/linkml/metamodel/AnonymousClassExpression.scala
+++ b/metamodel/src/eu/neverblink/linkml/metamodel/AnonymousClassExpression.scala
@@ -12,7 +12,7 @@ final case class AnonymousClassExpressionImpl(
     title: Option[String] = None,
     description: Option[String] = None,
     @named("is_a")
-    isA: Option[Reference[Definition]] = None,
+    isA: Option[Reference[ClassDefinition]] = None,
     rank: Option[Int] = None,
     @named("any_of")
     anyOf: Seq[AnonymousClassExpressionImpl] = Seq(),
@@ -89,17 +89,12 @@ final case class AnonymousClassExpressionImpl(
   */
 abstract class AnonymousClassExpression extends AnonymousExpression, ClassExpression {
 
-  /** A primary parent class or slot from which inheritable metaslots are propagated from. While
-    * multiple inheritance is not allowed, mixins can be provided effectively providing the same
-    * thing. The semantics are the same when translated to formalisms that allow MI (e.g. RDFS/OWL).
-    * When translating to a SI framework (e.g. java classes, python classes) then is a is used. When
-    * translating a framework without polymorphism (e.g. json-schema, solr document schema) then is
-    * a and mixins are recursively unfolded
+  /** A class that any instance satisfying this expression must also be an instance of
     *
     * @see
     *   From schema: https://w3id.org/linkml/meta
     */
-  def isA: Option[Reference[Definition]]
+  def isA: Option[Reference[ClassDefinition]]
 
   /** Fill in the slots that have an `equals_expression` with their computed values, and check that
     * the values already present agree with what their expressions infer.

--- a/tests/resources/models/inheritance/model.yaml
+++ b/tests/resources/models/inheritance/model.yaml
@@ -1,11 +1,6 @@
 id: https://neverblink.eu/linkml/tests/inheritance/
 name: inheritance
 
-instantiates:
-  - https://neverblink.eu/linkml/tests/Metadata
-extensions:
-  derived_equals: basic
-
 imports:
   - linkml:types
 
@@ -18,6 +13,13 @@ classes:
     is_a: BaseClass
     slots:
       - some_slot
+      - yet_another_slot
+  BaseRefClass:
+    attributes:
+      id:
+        identifier: true
+  RefClass:
+    is_a: BaseRefClass
 slots:
   some_slot:
     rank: 1
@@ -25,4 +27,8 @@ slots:
   some_other_slot:
     rank: 2
     range: integer
+    required: true
+  yet_another_slot:
+    rank: 3
+    range: BaseRefClass
     required: true


### PR DESCRIPTION
Like Scala but marking interfaces rather than impl. This requires running checks in the generator to figure out how to refer to a class. Ranges still point to concrete classes.

Also a candidate to extract to SchemaView, it will be useful when we make final and/or sealed scala gen