### PR TITLE
Playground: add button to load schema from URL

### DIFF
--- a/ui/app.ts
+++ b/ui/app.ts
@@ -11,6 +11,8 @@ import {
 import type { GenerateRequest, GenerateResponse } from "./worker.js";
 
 const INPUT_STORAGE_KEY = "linkml-ui-input";
+// Query parameter holding the link the schema was loaded from, so the address bar is a share link.
+const URL_PARAM = "url";
 // Resolved against dist/app.js at runtime, so it lands on the sibling dist/worker.js. Built from a
 // variable rather than a literal to keep esbuild from trying to resolve it at bundle time.
 const WORKER_URL = "./worker.js";
@@ -92,6 +94,9 @@ let busyTimer: ReturnType<typeof setTimeout> | undefined;
 // burst of tab clicks would otherwise let a slow earlier result land on top of a fast later one.
 let requestId = 0;
 let pendingId: number | null = null;
+// The schema as the link served it, while one is loaded. The change listener compares against it
+// to tell "this is what the link gives you" apart from "the user has edited it since".
+let remoteText: string | null = null;
 
 // ── DOM refs ────────────────────────────────────────────────────────────────
 
@@ -109,6 +114,7 @@ const $statusPill = $("statusPill");
 const $autoGenerate = $<HTMLInputElement>("autoGenerate");
 const $copyOutput = $<HTMLButtonElement>("copyOutput");
 const $loadExample = $<HTMLButtonElement>("loadExample");
+const $loadUrl = $<HTMLButtonElement>("loadUrl");
 const $clearInput = $<HTMLButtonElement>("clearInput");
 const $themeToggle = $<HTMLButtonElement>("themeToggle");
 const $themeIconMoon = $("themeIconMoon");
@@ -119,6 +125,9 @@ const $themeIconSun = $("themeIconSun");
 const storedInput = localStorage.getItem(INPUT_STORAGE_KEY);
 const inputView = createInput($("inputEditor"), storedInput ?? EXAMPLE_SCHEMA, (value) => {
   localStorage.setItem(INPUT_STORAGE_KEY, value);
+  // Once the text on screen differs from what the link serves, a shared address would hand the
+  // other person something other than what you are looking at, so drop the link.
+  if (value !== remoteText) clearUrlParam();
   scheduleGenerate();
 });
 const outputView = createOutput($("outputEditor"));
@@ -852,6 +861,125 @@ $copyOutput.addEventListener("click", async () => {
   }
 });
 
+// ── Load from URL ────────────────────────────────────────────────────────
+
+const $urlDialog = $<HTMLDialogElement>("urlDialog");
+const $urlForm = $<HTMLFormElement>("urlForm");
+const $urlInput = $<HTMLInputElement>("urlInput");
+const $urlError = $("urlError");
+const $urlSubmit = $<HTMLButtonElement>("urlSubmit");
+
+function sharedLink(): string | null {
+  return new URL(location.href).searchParams.get(URL_PARAM);
+}
+
+function setUrlParam(link: string): void {
+  const here = new URL(location.href);
+  here.searchParams.set(URL_PARAM, link);
+  history.replaceState(null, "", here);
+}
+
+function clearUrlParam(): void {
+  const here = new URL(location.href);
+  if (!here.searchParams.has(URL_PARAM)) return;
+  here.searchParams.delete(URL_PARAM);
+  history.replaceState(null, "", here);
+}
+
+/** Turns a link to a file's web page into a link to the file itself. Copying what is in the
+ * address bar is the obvious thing to do, and on GitHub or GitLab that address serves HTML. */
+function rawFileUrl(u: URL): URL {
+  const parts = u.pathname.split("/").filter(Boolean);
+  if (u.hostname === "github.com" && parts[2] === "blob" && parts.length > 3) {
+    // /owner/repo/blob/ref/path -> raw.githubusercontent.com/owner/repo/ref/path
+    return new URL(`https://raw.githubusercontent.com/${parts[0]}/${parts[1]}/${parts.slice(3).join("/")}`);
+  }
+  // Matched on the path rather than the host, so that self-hosted GitLab instances work too.
+  if (u.pathname.includes("/-/blob/")) {
+    const raw = new URL(u.href);
+    raw.pathname = u.pathname.replace("/-/blob/", "/-/raw/");
+    raw.search = "";
+    return raw;
+  }
+  return u;
+}
+
+type LoadResult = { ok: true } | { ok: false; error: string };
+
+/** Downloads a schema and puts it in the input pane. The link, as pasted, goes into the address
+ * bar rather than the schema itself: it stays short enough to paste anywhere. */
+async function loadFromUrl(link: string): Promise<LoadResult> {
+  let target: URL;
+  try {
+    target = rawFileUrl(new URL(link));
+  } catch {
+    return { ok: false, error: "That is not a URL. It has to start with https://" };
+  }
+  if (target.protocol !== "https:" && target.protocol !== "http:") {
+    return { ok: false, error: "Only http and https links can be loaded." };
+  }
+  // The deployed playground is https, and a browser refuses to fetch http from an https page
+  // (mixed content). That refusal looks exactly like a CORS block, so name the real reason.
+  if (target.protocol === "http:" && location.protocol === "https:") {
+    return { ok: false, error: "This page is served over HTTPS, so the browser will not load an http:// link. Try https:// instead." };
+  }
+
+  let text: string;
+  try {
+    const res = await fetch(target.href);
+    if (!res.ok) return { ok: false, error: `The server answered ${res.status} ${res.statusText}.` };
+    text = await res.text();
+  } catch {
+    // A cross-origin block and being offline both surface as the same detail-free TypeError.
+    return {
+      ok: false,
+      error: "Could not fetch that link. The server may not allow being read from other sites (CORS), or you may be offline.",
+    };
+  }
+  if (/^\s*<(!doctype|html)/i.test(text)) {
+    return { ok: false, error: "That link returned a web page, not a schema. Link straight to the raw file." };
+  }
+
+  // Set before the change lands, so the listener sees an unedited document either way.
+  remoteText = text;
+  setDoc(inputView, text);
+  setUrlParam(link);
+  scheduleGenerate(0);
+  return { ok: true };
+}
+
+function showUrlError(message: string): void {
+  $urlError.textContent = message;
+  $urlError.hidden = false;
+}
+
+$loadUrl.addEventListener("click", () => {
+  $urlInput.value = sharedLink() ?? "";
+  $urlError.hidden = true;
+  $urlDialog.showModal();
+  $urlInput.select();
+});
+
+$urlForm.addEventListener("submit", async (e) => {
+  // Handled here rather than by the browser: the dialog stays open when the fetch fails.
+  e.preventDefault();
+  const link = $urlInput.value.trim();
+  if (!link) return;
+  $urlSubmit.disabled = true;
+  $urlSubmit.textContent = "Loading…";
+  const res = await loadFromUrl(link);
+  $urlSubmit.disabled = false;
+  $urlSubmit.textContent = "Load";
+  if (res.ok) $urlDialog.close();
+  else showUrlError(res.error);
+});
+
+$urlDialog.querySelector<HTMLButtonElement>(".modal-close")!.addEventListener("click", () => $urlDialog.close());
+$urlDialog.querySelector<HTMLButtonElement>(".url-cancel")!.addEventListener("click", () => $urlDialog.close());
+$urlDialog.addEventListener("click", (e) => {
+  if (e.target === $urlDialog) $urlDialog.close();
+});
+
 // ── Theme ──────────────────────────────────────────────────────────────────
 
 function applyTheme(theme: string): void {
@@ -882,7 +1010,7 @@ const $faqDialog = $<HTMLDialogElement>("faqDialog");
 const openFaq = () => $faqDialog.showModal();
 $<HTMLButtonElement>("helpToggle").addEventListener("click", openFaq);
 $<HTMLButtonElement>("aboutLink").addEventListener("click", openFaq);
-$faqDialog.querySelector<HTMLButtonElement>(".faq-close")!.addEventListener("click", () => $faqDialog.close());
+$faqDialog.querySelector<HTMLButtonElement>(".modal-close")!.addEventListener("click", () => $faqDialog.close());
 // Click on the backdrop (the dialog element itself, since content fills it) closes it.
 $faqDialog.addEventListener("click", (e) => {
   if (e.target === $faqDialog) $faqDialog.close();
@@ -928,6 +1056,22 @@ function renderRepoStats(stars: number, forks: number): void {
 
 renderTargetTabs();
 renderOptions();
-// Starts the worker, which begins loading the LinkML bundle immediately. The request waits on
-// that load inside the worker, so the page is interactive while the multi-MB bundle parses.
-scheduleGenerate(0);
+
+const initialLink = sharedLink();
+if (initialLink === null) {
+  // Starts the worker, which begins loading the LinkML bundle immediately. The request waits on
+  // that load inside the worker, so the page is interactive while the multi-MB bundle parses.
+  scheduleGenerate(0);
+} else {
+  // Same warm-up, minus the request: the download generates once it lands, so asking for a
+  // generation here as well would parse the previous session's schema for nothing.
+  getWorker();
+  void loadFromUrl(initialLink).then((res) => {
+    if (res.ok) return;
+    // Nothing on screen would explain a link that failed, so hand it back in the dialog to fix.
+    $urlInput.value = initialLink;
+    showUrlError(res.error);
+    $urlDialog.showModal();
+    scheduleGenerate(0);
+  });
+}

--- a/ui/index.html
+++ b/ui/index.html
@@ -102,6 +102,7 @@
       <a href="https://github.com/NeverBlink-OSS/linkml-scala" target="_blank" rel="noopener">GitHub</a>
       <a href="https://discord.gg/HGksVAJ6ss" target="_blank" rel="noopener">Discord</a>
       <a href="https://www.npmjs.com/package/@neverblink/linkml" target="_blank" rel="noopener">npm</a>
+      <a href="https://pypi.org/project/neverblink-linkml/" target="_blank" rel="noopener">PyPI</a>
       <a href="https://central.sonatype.com/namespace/eu.neverblink.linkml" target="_blank" rel="noopener">Maven Central</a>
       <button type="button" id="aboutLink">About</button>
     </nav>

--- a/ui/index.html
+++ b/ui/index.html
@@ -167,7 +167,7 @@
       <h3>Where is my data processed?</h3>
       <p><strong>Entirely on your device.</strong> Your schema is never uploaded &ndash; all generation
         happens locally in this browser tab. There is no server, no account, and no analytics.</p>
-      <p>This app make on your behalf one request in <em>Load from URL</em>: it downloads the
+      <p>This app makes an external request in <em>Load from URL</em>: it downloads the
         file from the link you paste, so that server sees the request. Your schema still stays here.</p>
     </section>
     <section>

--- a/ui/index.html
+++ b/ui/index.html
@@ -69,6 +69,7 @@
           <span class="panel-title">Input <span class="panel-title-sub">LinkML YAML</span></span>
           <div class="panel-actions">
             <button id="loadExample" class="btn btn-secondary btn-sm">Load example</button>
+            <button id="loadUrl" class="btn btn-secondary btn-sm" aria-haspopup="dialog">Load from URL</button>
             <button id="clearInput" class="btn btn-secondary btn-sm">Clear</button>
           </div>
         </div>
@@ -107,10 +108,33 @@
   </footer>
 </div>
 
-<dialog id="faqDialog" class="faq-dialog" aria-labelledby="faqTitle">
-  <div class="faq-head">
+<dialog id="urlDialog" class="modal url-dialog" aria-labelledby="urlTitle">
+  <form id="urlForm">
+    <div class="modal-head">
+      <h2 id="urlTitle">Load schema from URL</h2>
+      <button type="button" class="modal-close icon-btn" aria-label="Close">
+        <svg class="ic" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M18 6 6 18M6 6l12 12"/></svg>
+      </button>
+    </div>
+    <div class="url-body">
+      <label class="url-label" for="urlInput">Link to a LinkML schema (YAML)</label>
+      <input id="urlInput" class="url-input" type="url" inputmode="url" spellcheck="false"
+             placeholder="https://raw.githubusercontent.com/&hellip;/schema.yaml" required>
+      <p class="url-hint">A GitHub link to a file is turned into a raw link for you. Other hosts have
+        to allow being read from another site (CORS).</p>
+      <p class="url-error" id="urlError" hidden></p>
+    </div>
+    <div class="url-foot">
+      <button type="button" class="btn btn-secondary url-cancel">Cancel</button>
+      <button type="submit" class="btn btn-primary" id="urlSubmit">Load</button>
+    </div>
+  </form>
+</dialog>
+
+<dialog id="faqDialog" class="modal faq-dialog" aria-labelledby="faqTitle">
+  <div class="modal-head">
     <h2 id="faqTitle">Help &amp; FAQ</h2>
-    <button class="faq-close icon-btn" aria-label="Close help">
+    <button class="modal-close icon-btn" aria-label="Close help">
       <svg class="ic" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M18 6 6 18M6 6l12 12"/></svg>
     </button>
   </div>
@@ -142,6 +166,8 @@
       <h3>Where is my data processed?</h3>
       <p><strong>Entirely on your device.</strong> Your schema is never uploaded &ndash; all generation
         happens locally in this browser tab. There is no server, no account, and no analytics.</p>
+      <p>This app make on your behalf one request in <em>Load from URL</em>: it downloads the
+        file from the link you paste, so that server sees the request. Your schema still stays here.</p>
     </section>
     <section>
       <h3>Where is the code?</h3>

--- a/ui/styles.css
+++ b/ui/styles.css
@@ -169,13 +169,11 @@ body { background: var(--bg); }
 .theme-toggle:hover,
 .help-toggle:hover { background: var(--accent-soft); border-color: var(--accent-border); color: var(--text); }
 
-/* ── Help / FAQ dialog ── */
-.faq-dialog {
+/* ── Dialogs ── */
+.modal {
   /* `* { margin: 0 }` in the reset kills the UA margin:auto that centres a modal
      dialog, pinning it top-left – restore it. */
   margin: auto;
-  width: min(640px, calc(100vw - 32px));
-  max-height: min(80vh, 720px);
   padding: 0;
   border: 1px solid var(--border);
   border-radius: var(--radius);
@@ -183,8 +181,8 @@ body { background: var(--bg); }
   color: var(--text);
   box-shadow: 0 12px 40px rgba(0, 0, 0, 0.35);
 }
-.faq-dialog::backdrop { background: rgba(0, 0, 0, 0.5); }
-.faq-head {
+.modal::backdrop { background: rgba(0, 0, 0, 0.5); }
+.modal-head {
   position: sticky;
   top: 0;
   display: flex;
@@ -194,9 +192,48 @@ body { background: var(--bg); }
   background: var(--surface);
   border-bottom: 1px solid var(--border-subtle);
 }
-.faq-head h2 { font-size: 16px; font-weight: 700; }
-.faq-close { width: 32px; height: 32px; color: var(--text-secondary); }
-.faq-close:hover { background: var(--accent-soft); color: var(--text); }
+.modal-head h2 { font-size: 16px; font-weight: 700; }
+.modal-close { width: 32px; height: 32px; color: var(--text-secondary); }
+.modal-close:hover { background: var(--accent-soft); color: var(--text); }
+
+/* ── Load from URL dialog ── */
+.url-dialog { width: min(520px, calc(100vw - 32px)); }
+.url-body { display: flex; flex-direction: column; gap: 8px; padding: 16px 20px; }
+.url-label { font-size: 13px; font-weight: 600; }
+.url-input {
+  font: inherit;
+  font-size: 13px;
+  padding: 8px 10px;
+  border-radius: var(--radius-sm);
+  border: 1px solid var(--border);
+  background: var(--surface-2);
+  color: var(--text);
+  outline: none;
+}
+.url-input:focus { border-color: var(--accent); }
+.url-hint { font-size: 12px; line-height: 1.45; color: var(--text-muted); }
+.url-error {
+  font-size: 12.5px;
+  line-height: 1.45;
+  color: var(--danger);
+  background: var(--danger-soft);
+  border: 1px solid var(--danger-border);
+  border-radius: var(--radius-sm);
+  padding: 7px 9px;
+}
+.url-foot {
+  display: flex;
+  justify-content: flex-end;
+  gap: 8px;
+  padding: 12px 20px 16px;
+  border-top: 1px solid var(--border-subtle);
+}
+
+/* ── Help / FAQ dialog ── */
+.faq-dialog {
+  width: min(640px, calc(100vw - 32px));
+  max-height: min(80vh, 720px);
+}
 .faq-body { padding: 8px 20px 20px; overflow-y: auto; }
 .faq-body section { padding: 12px 0; border-bottom: 1px solid var(--border-subtle); }
 .faq-body h3 { font-size: 13.5px; font-weight: 600; color: var(--text); margin-bottom: 5px; }


### PR DESCRIPTION
The URL is then added to the playground's URL, so it becomes shareable. This will be useful for demoing how LinkML-Scala works with different schemas.