### PR TITLE
Update to metamodel with langstrings, fix tests

### DIFF
--- a/.agents/skills/linkml/900-metaslots.tsv
+++ b/.agents/skills/linkml/900-metaslots.tsv
@@ -69,7 +69,7 @@ deprecated	common_metadata	string	single	basic	Description of why and when this 
 deprecated element has exact replacement	common_metadata	uriorcurie	single	-	When an element is deprecated, it can be automatically replaced by this uri or curie
 deprecated element has possible replacement	common_metadata	uriorcurie	single	-	When an element is deprecated, it can be potentially replaced by this uri or curie
 derivation	UnitOfMeasure	string	single	-	Expression for deriving this unit from other units
-description	common_metadata,permissible_value	string	single	basic	a textual description of the element's purpose and use
+description	common_metadata,permissible_value	langstring	single	basic	a textual description of the element's purpose and use
 descriptive_name	UnitOfMeasure	string	single	-	the spelled out name of the unit, for example, meter
 designates_type	slot_definition	boolean	single	spec	True means that the key slot(s) is used to determine the instantiation (types) relation b…
 dimensions	array_expression	dimension_expression	multi	-	definitions of each axis in the array
@@ -230,7 +230,7 @@ symbol	UnitOfMeasure	string	single	-	name of the unit encoded as a symbol
 symmetric	slot_definition	string	single	spec	If s is symmetric, and i.s=v, then v.s=i
 syntax	pattern_expression	string	single	spec	the string value of the slot must conform to this regular expression expressed in the str…
 text	permissible_value	string	single	spec,basic	The actual permissible value itself
-title	common_metadata	string	single	basic	A concise human-readable display label for the element. The title should mirror the name,…
+title	common_metadata	langstring	single	basic	A concise human-readable display label for the element. The title should mirror the name,…
 todos	common_metadata	string	multi	basic	Outstanding issues that needs resolution
 transitive	slot_definition	string	single	spec	If s is transitive, and i.s=z, and s.s=j, then i.s=j
 transitive_form_of	slot_definition	slot_definition	single	spec	If s transitive_form_of d, then (1) s holds whenever d holds (2) s is transitive (3) d ho…

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -65,8 +65,9 @@ jobs:
         run: ./mill --no-server generator.jvm.test.mermaidValidator
 
       - name: Build and test
+        # testForked, not test: otherwise tests in the `tests` module don't run...
         run: |
-          ./mill --no-server -j 0 __.test
+          ./mill --no-server -j 0 __.testForked
 
       - name: Verify npm package (examples run + types compile)
         if: matrix.java == 17

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -16,7 +16,7 @@ Common tasks with mill:
 - Start the browser UI: `./mill ui`
 - Scan the mill project structure: `./mill resolve _`
 - Compile all modules: `./mill __.compile`
-- Run all tests: `./mill __.test` (prefer specific test running for faster feedback, like `./mill generator.jvm.test`)
+- Run all tests: `./mill __.testForked` (prefer specific test running for faster feedback, like `./mill generator.jvm.test`).
 - Run the JMH benchmarks: `./mill benchmark.runJmh` (see [Benchmarks](#benchmarks))
 - Lint the project: `./mill lint` (scalafix + scalafmt)
 - Re-generate the metamodel classes: `./mill metamodel.regenerate`

--- a/generator/src/eu/neverblink/linkml/generator/graphql/GraphQlGenerator.scala
+++ b/generator/src/eu/neverblink/linkml/generator/graphql/GraphQlGenerator.scala
@@ -6,7 +6,7 @@ import eu.neverblink.linkml.generator.CharDocumentGenerator
 import eu.neverblink.linkml.generator.util.PruningMode.schemaRoot
 import eu.neverblink.linkml.generator.util.{CharSink, Printable, PruningMode, indent}
 import eu.neverblink.linkml.metamodel.PermissibleValue
-import eu.neverblink.linkml.runtime.{PrefixResolver, UriOrCurie}
+import eu.neverblink.linkml.runtime.{LocalizedText, PrefixResolver, UriOrCurie}
 import eu.neverblink.linkml.schemaview
 import eu.neverblink.linkml.schemaview.*
 import GraphQlGenerator.escaped
@@ -212,8 +212,8 @@ object GraphQlGenerator {
 trait GraphQlElement extends Printable:
   /** Process an optional description into a proper graphql description
     */
-  final def wrapDescription(in: Option[String]): String = {
-    in.map("\"\"\"\n" + _ + "\n\"\"\"").getOrElse("")
+  final def wrapDescription(in: Option[LocalizedText]): String = {
+    in.map("\"\"\"\n" + _.plain + "\n\"\"\"").getOrElse("")
   }
 
 trait GraphQlDefinition extends GraphQlElement
@@ -374,7 +374,7 @@ case class GraphQlField(
   val multivalued: Boolean = slotView.slot.multivalued
 
   /** Description of the field */
-  val description: Option[String] = slotView.slot.description
+  val description: Option[LocalizedText] = slotView.slot.description
 
   /** Stringy expression to put in the type position of the GraphQL field definition */
   val typeExpr: String = {

--- a/generator/src/eu/neverblink/linkml/generator/jsonschema/JsonSchemaGenerator.scala
+++ b/generator/src/eu/neverblink/linkml/generator/jsonschema/JsonSchemaGenerator.scala
@@ -129,8 +129,8 @@ class JsonSchemaGenerator(using sv: SchemaView)
       }
       val sv = attribute.slotView
       slotSchema.copy(
-        title = sv.slot.title,
-        description = sv.slot.description,
+        title = sv.slot.title.mapFast(_.plain),
+        description = sv.slot.description.mapFast(_.plain),
       )
     }
 
@@ -159,8 +159,8 @@ class JsonSchemaGenerator(using sv: SchemaView)
           properties =
             immutable.ListMap.newBuilder.addAll(properties).result(), // avoids O(n^2) complexity
           additionalProperties = new Some(if (open) AnySchema.Anything else AnySchema.Nothing),
-          title = cls.cls.title,
-          description = cls.cls.description,
+          title = cls.cls.title.mapFast(_.plain),
+          description = cls.cls.description.mapFast(_.plain),
         ),
       )
     }
@@ -215,16 +215,16 @@ class JsonSchemaGenerator(using sv: SchemaView)
         objectSchema.copy(
           `type` = new Some(List(SchemaType.String)),
           `enum` = new Some(enumValues),
-          title = enum_.title,
-          description = enum_.description,
+          title = enum_.title.mapFast(_.plain),
+          description = enum_.description.mapFast(_.plain),
         ),
       )
     }
     baseSchema.copy(
       $schema = new Some("https://json-schema.org/draft/2020-12/schema"),
       $id = new Some(sv.root.id.uri(using sv.rootPrefixResolver)),
-      title = sv.root.title.orElse(new Some(sv.root.name)),
-      description = sv.root.description,
+      title = sv.root.title.mapFast(_.plain).orElse(new Some(sv.root.name)),
+      description = sv.root.description.mapFast(_.plain),
       $defs = new Some(
         immutable.ListMap.newBuilder[String, SchemaLike].addAll(
           defs,

--- a/generator/src/eu/neverblink/linkml/generator/rdfs/RdfsGenerator.scala
+++ b/generator/src/eu/neverblink/linkml/generator/rdfs/RdfsGenerator.scala
@@ -18,10 +18,10 @@ class RdfsGenerator(using sv: SchemaView) extends RdfGenerator[RdfsGenerator.Opt
       cms: Seq[CommonMetadata],
   ): Unit = {
     cms.flatMap(_.title).distinct.foreach { t =>
-      sink.triple(subject, Rdfs.label, Literal(t, XmlSchema.string))
+      langStringProperty(sink, subject, Rdfs.label, t)
     }
     cms.flatMap(_.description).distinct.foreach { d =>
-      sink.triple(subject, Rdfs.comment, Literal(d, XmlSchema.string))
+      langStringProperty(sink, subject, Rdfs.comment, d)
     }
   }
 

--- a/generator/src/eu/neverblink/linkml/generator/scala/ScalaGenerator.scala
+++ b/generator/src/eu/neverblink/linkml/generator/scala/ScalaGenerator.scala
@@ -794,7 +794,7 @@ object ScalaGenerator {
         pr: PrefixResolver,
     ): ScalaDoc = {
       new ScalaDoc(
-        metadata.description.foldFast("")(_.capitalize),
+        metadata.description.foldFast("")(_.plain.capitalize),
         metadata.seeAlso.map(_.uri) ++
           metadata.aliases.reduceOption(_ + ", " + _).mapFast("Aliases: ".concat) ++
           Seq("From schema: ".concat(fromSchema.uri)),

--- a/generator/src/eu/neverblink/linkml/generator/shacl/ShaclGenerator.scala
+++ b/generator/src/eu/neverblink/linkml/generator/shacl/ShaclGenerator.scala
@@ -136,10 +136,10 @@ class ShaclGenerator(using sv: SchemaView) extends RdfGenerator[ShaclGenerator.O
     val property = blankNode()
     sink.triple(propertyDomain, Shacl.property, property)
     slot.title.foreachFast { t =>
-      sink.triple(property, Shacl.name, Literal(t))
+      langStringProperty(sink, property, Shacl.name, t)
     }
     slot.description.foreachFast { d =>
-      sink.triple(property, Shacl.description, Literal(d))
+      langStringProperty(sink, property, Shacl.description, d)
     }
     slot.slotGroup.foreachFast { groupRef =>
       sv.resolve(groupRef.asInstanceOf[Reference[SlotView]]).foreachFast { groupView =>
@@ -178,13 +178,12 @@ class ShaclGenerator(using sv: SchemaView) extends RdfGenerator[ShaclGenerator.O
     groups.values.foreach { g =>
       val groupIri = new Iri(g.uriStr)
       sink.triple(groupIri, Rdf.`type`, Shacl.PropertyGroup)
-      sink.triple(
-        groupIri,
-        Rdfs.label,
-        Literal(g.slot.title.getOrElseFast(g.name), XmlSchema.string),
-      )
+      g.slot.title match {
+        case Some(t) => langStringProperty(sink, groupIri, Rdfs.label, t)
+        case None => sink.triple(groupIri, Rdfs.label, Literal(g.name, XmlSchema.string))
+      }
       g.slot.description.foreachFast { d =>
-        sink.triple(groupIri, Rdfs.comment, Literal(d))
+        langStringProperty(sink, groupIri, Rdfs.comment, d)
       }
       g.slot.rank.foreachFast { r =>
         sink.triple(groupIri, Shacl.order, Literal(r.toString, XmlSchema.integer))
@@ -215,7 +214,7 @@ class ShaclGenerator(using sv: SchemaView) extends RdfGenerator[ShaclGenerator.O
       val classNameIri = new Iri(c.uriStr)
       sink.triple(classNameIri, Rdf.`type`, Shacl.NodeShape)
       c.cls.description.foreachFast { d =>
-        sink.triple(classNameIri, Rdfs.comment, Literal(d))
+        langStringProperty(sink, classNameIri, Rdfs.comment, d)
       }
       val closed = !(open || c.cls.`abstract` || c.cls.mixin)
       sink.triple(classNameIri, Shacl.closed, Literal(closed.toString, XmlSchema.boolean))

--- a/generator/src/eu/neverblink/linkml/generator/tableschema/TableSchemaGenerator.scala
+++ b/generator/src/eu/neverblink/linkml/generator/tableschema/TableSchemaGenerator.scala
@@ -61,8 +61,8 @@ class TableSchemaGenerator(using sv: SchemaView)
       yield {
         val base = FieldDescriptor(
           name = slotName(slotView),
-          title = slotView.slot.title,
-          description = slotView.slot.description,
+          title = slotView.slot.title.mapFast(_.plain),
+          description = slotView.slot.description.mapFast(_.plain),
           constraints = new Some(new Constraints(required = new Some(slotView.slot.required))),
         )
         slotView.derivedRange.resolve.get match {

--- a/metamodel/src/eu/neverblink/linkml/metamodel/AnonymousClassExpression.scala
+++ b/metamodel/src/eu/neverblink/linkml/metamodel/AnonymousClassExpression.scala
@@ -9,8 +9,8 @@ import eu.neverblink.linkml.runtime.*
   * @inheritdoc
   */
 final case class AnonymousClassExpressionImpl(
-    title: Option[String] = None,
-    description: Option[String] = None,
+    title: Option[LocalizedText] = None,
+    description: Option[LocalizedText] = None,
     @named("is_a")
     isA: Option[Reference[ClassDefinition]] = None,
     rank: Option[Int] = None,

--- a/metamodel/src/eu/neverblink/linkml/metamodel/AnonymousSlotExpression.scala
+++ b/metamodel/src/eu/neverblink/linkml/metamodel/AnonymousSlotExpression.scala
@@ -9,8 +9,8 @@ import eu.neverblink.linkml.runtime.*
   * @inheritdoc
   */
 final case class AnonymousSlotExpressionImpl(
-    title: Option[String] = None,
-    description: Option[String] = None,
+    title: Option[LocalizedText] = None,
+    description: Option[LocalizedText] = None,
     multivalued: Boolean = false,
     required: Boolean = false,
     recommended: Boolean = false,

--- a/metamodel/src/eu/neverblink/linkml/metamodel/ArrayExpression.scala
+++ b/metamodel/src/eu/neverblink/linkml/metamodel/ArrayExpression.scala
@@ -9,8 +9,8 @@ import eu.neverblink.linkml.runtime.*
   * @inheritdoc
   */
 final case class ArrayExpressionImpl(
-    title: Option[String] = None,
-    description: Option[String] = None,
+    title: Option[LocalizedText] = None,
+    description: Option[LocalizedText] = None,
     rank: Option[Int] = None,
     aliases: Seq[String] = Seq(),
     @named("alt_descriptions")

--- a/metamodel/src/eu/neverblink/linkml/metamodel/ClassDefinition.scala
+++ b/metamodel/src/eu/neverblink/linkml/metamodel/ClassDefinition.scala
@@ -13,8 +13,8 @@ final case class ClassDefinitionImpl(
     name: String,
     @named("class_uri")
     classUri: Option[UriOrCurie] = None,
-    title: Option[String] = None,
-    description: Option[String] = None,
+    title: Option[LocalizedText] = None,
+    description: Option[LocalizedText] = None,
     alias: Option[String] = None,
     @named("is_a")
     isA: Option[Reference[ClassDefinition]] = None,

--- a/metamodel/src/eu/neverblink/linkml/metamodel/ClassRule.scala
+++ b/metamodel/src/eu/neverblink/linkml/metamodel/ClassRule.scala
@@ -9,8 +9,8 @@ import eu.neverblink.linkml.runtime.*
   * @inheritdoc
   */
 final case class ClassRuleImpl(
-    title: Option[String] = None,
-    description: Option[String] = None,
+    title: Option[LocalizedText] = None,
+    description: Option[LocalizedText] = None,
     rank: Option[Int] = None,
     preconditions: Option[AnonymousClassExpressionImpl] = None,
     postconditions: Option[AnonymousClassExpressionImpl] = None,

--- a/metamodel/src/eu/neverblink/linkml/metamodel/CommonMetadata.scala
+++ b/metamodel/src/eu/neverblink/linkml/metamodel/CommonMetadata.scala
@@ -19,7 +19,7 @@ trait CommonMetadata {
     * @see
     *   From schema: https://w3id.org/linkml/meta
     */
-  def title: Option[String]
+  def title: Option[LocalizedText]
 
   /** A textual description of the element's purpose and use
     *
@@ -28,7 +28,7 @@ trait CommonMetadata {
     * @see
     *   From schema: https://w3id.org/linkml/meta
     */
-  def description: Option[String]
+  def description: Option[LocalizedText]
 
   /** The relative order in which the element occurs, lower values are given precedence
     *

--- a/metamodel/src/eu/neverblink/linkml/metamodel/DimensionExpression.scala
+++ b/metamodel/src/eu/neverblink/linkml/metamodel/DimensionExpression.scala
@@ -9,8 +9,8 @@ import eu.neverblink.linkml.runtime.*
   * @inheritdoc
   */
 final case class DimensionExpressionImpl(
-    title: Option[String] = None,
-    description: Option[String] = None,
+    title: Option[LocalizedText] = None,
+    description: Option[LocalizedText] = None,
     alias: Option[String] = None,
     rank: Option[Int] = None,
     aliases: Seq[String] = Seq(),

--- a/metamodel/src/eu/neverblink/linkml/metamodel/EnumBinding.scala
+++ b/metamodel/src/eu/neverblink/linkml/metamodel/EnumBinding.scala
@@ -9,8 +9,8 @@ import eu.neverblink.linkml.runtime.*
   * @inheritdoc
   */
 final case class EnumBindingImpl(
-    title: Option[String] = None,
-    description: Option[String] = None,
+    title: Option[LocalizedText] = None,
+    description: Option[LocalizedText] = None,
     rank: Option[Int] = None,
     aliases: Seq[String] = Seq(),
     @named("alt_descriptions")

--- a/metamodel/src/eu/neverblink/linkml/metamodel/EnumDefinition.scala
+++ b/metamodel/src/eu/neverblink/linkml/metamodel/EnumDefinition.scala
@@ -11,8 +11,8 @@ import eu.neverblink.linkml.runtime.*
 final case class EnumDefinitionImpl(
     @id
     name: String,
-    title: Option[String] = None,
-    description: Option[String] = None,
+    title: Option[LocalizedText] = None,
+    description: Option[LocalizedText] = None,
     @named("is_a")
     isA: Option[Reference[Definition]] = None,
     mixins: Seq[Reference[Definition]] = Seq(),

--- a/metamodel/src/eu/neverblink/linkml/metamodel/ImportExpression.scala
+++ b/metamodel/src/eu/neverblink/linkml/metamodel/ImportExpression.scala
@@ -9,8 +9,8 @@ import eu.neverblink.linkml.runtime.*
   * @inheritdoc
   */
 final case class ImportExpressionImpl(
-    title: Option[String] = None,
-    description: Option[String] = None,
+    title: Option[LocalizedText] = None,
+    description: Option[LocalizedText] = None,
     rank: Option[Int] = None,
     aliases: Seq[String] = Seq(),
     @named("alt_descriptions")

--- a/metamodel/src/eu/neverblink/linkml/metamodel/PathExpression.scala
+++ b/metamodel/src/eu/neverblink/linkml/metamodel/PathExpression.scala
@@ -9,8 +9,8 @@ import eu.neverblink.linkml.runtime.*
   * @inheritdoc
   */
 final case class PathExpressionImpl(
-    title: Option[String] = None,
-    description: Option[String] = None,
+    title: Option[LocalizedText] = None,
+    description: Option[LocalizedText] = None,
     rank: Option[Int] = None,
     @named("any_of")
     anyOf: Seq[PathExpressionImpl] = Seq(),

--- a/metamodel/src/eu/neverblink/linkml/metamodel/PatternExpression.scala
+++ b/metamodel/src/eu/neverblink/linkml/metamodel/PatternExpression.scala
@@ -9,8 +9,8 @@ import eu.neverblink.linkml.runtime.*
   * @inheritdoc
   */
 final case class PatternExpressionImpl(
-    title: Option[String] = None,
-    description: Option[String] = None,
+    title: Option[LocalizedText] = None,
+    description: Option[LocalizedText] = None,
     rank: Option[Int] = None,
     aliases: Seq[String] = Seq(),
     @named("alt_descriptions")

--- a/metamodel/src/eu/neverblink/linkml/metamodel/PermissibleValue.scala
+++ b/metamodel/src/eu/neverblink/linkml/metamodel/PermissibleValue.scala
@@ -11,8 +11,8 @@ import eu.neverblink.linkml.runtime.*
 final case class PermissibleValueImpl(
     @id
     text: String,
-    title: Option[String] = None,
-    description: Option[String] = None,
+    title: Option[LocalizedText] = None,
+    description: Option[LocalizedText] = None,
     @named("is_a")
     isA: Option[Reference[PermissibleValue]] = None,
     mixins: Seq[Reference[PermissibleValue]] = Seq(),
@@ -108,7 +108,7 @@ abstract class PermissibleValue extends Extensible, Annotatable, CommonMetadata 
     * @see
     *   From schema: https://w3id.org/linkml/meta
     */
-  def description: Option[String]
+  def description: Option[LocalizedText]
 
   /** A primary parent class or slot from which inheritable metaslots are propagated from. While
     * multiple inheritance is not allowed, mixins can be provided effectively providing the same

--- a/metamodel/src/eu/neverblink/linkml/metamodel/SchemaDefinition.scala
+++ b/metamodel/src/eu/neverblink/linkml/metamodel/SchemaDefinition.scala
@@ -15,11 +15,11 @@ final case class SchemaDefinitionImpl(
     id: Uri,
     @compactDict
     classes: Map[String, ClassDefinitionImpl] = Map(),
-    title: Option[String] = None,
+    title: Option[LocalizedText] = None,
     @named("slots")
     @compactDict
     slotDefinitions: Map[String, SlotDefinitionImpl] = Map(),
-    description: Option[String] = None,
+    description: Option[LocalizedText] = None,
     @compactDict
     enums: Map[String, EnumDefinitionImpl] = Map(),
     @compactDict

--- a/metamodel/src/eu/neverblink/linkml/metamodel/SlotDefinition.scala
+++ b/metamodel/src/eu/neverblink/linkml/metamodel/SlotDefinition.scala
@@ -13,8 +13,8 @@ final case class SlotDefinitionImpl(
     name: String,
     @named("slot_uri")
     slotUri: Option[UriOrCurie] = None,
-    title: Option[String] = None,
-    description: Option[String] = None,
+    title: Option[LocalizedText] = None,
+    description: Option[LocalizedText] = None,
     identifier: Boolean = false,
     alias: Option[String] = None,
     multivalued: Boolean = false,

--- a/metamodel/src/eu/neverblink/linkml/metamodel/StructuredAlias.scala
+++ b/metamodel/src/eu/neverblink/linkml/metamodel/StructuredAlias.scala
@@ -9,8 +9,8 @@ import eu.neverblink.linkml.runtime.*
   * @inheritdoc
   */
 final case class StructuredAliasImpl(
-    title: Option[String] = None,
-    description: Option[String] = None,
+    title: Option[LocalizedText] = None,
+    description: Option[LocalizedText] = None,
     rank: Option[Int] = None,
     @named("contexts")
     aliasContexts: Seq[Uri] = Seq(),

--- a/metamodel/src/eu/neverblink/linkml/metamodel/SubsetDefinition.scala
+++ b/metamodel/src/eu/neverblink/linkml/metamodel/SubsetDefinition.scala
@@ -11,8 +11,8 @@ import eu.neverblink.linkml.runtime.*
 final case class SubsetDefinitionImpl(
     @id
     name: String,
-    title: Option[String] = None,
-    description: Option[String] = None,
+    title: Option[LocalizedText] = None,
+    description: Option[LocalizedText] = None,
     rank: Option[Int] = None,
     aliases: Seq[String] = Seq(),
     @named("alt_descriptions")

--- a/metamodel/src/eu/neverblink/linkml/metamodel/TypeDefinition.scala
+++ b/metamodel/src/eu/neverblink/linkml/metamodel/TypeDefinition.scala
@@ -13,8 +13,8 @@ final case class TypeDefinitionImpl(
     name: String,
     @named("uri")
     typeUri: Option[UriOrCurie] = None,
-    title: Option[String] = None,
-    description: Option[String] = None,
+    title: Option[LocalizedText] = None,
+    description: Option[LocalizedText] = None,
     typeof: Option[Reference[TypeDefinition]] = None,
     base: Option[String] = None,
     repr: Option[String] = None,

--- a/metamodel/src/eu/neverblink/linkml/metamodel/TypeMapping.scala
+++ b/metamodel/src/eu/neverblink/linkml/metamodel/TypeMapping.scala
@@ -12,8 +12,8 @@ final case class TypeMappingImpl(
     @id
     @named("framework")
     frameworkKey: String,
-    title: Option[String] = None,
-    description: Option[String] = None,
+    title: Option[LocalizedText] = None,
+    description: Option[LocalizedText] = None,
     rank: Option[Int] = None,
     aliases: Seq[String] = Seq(),
     @named("alt_descriptions")

--- a/metamodel/src/eu/neverblink/linkml/metamodel/UniqueKey.scala
+++ b/metamodel/src/eu/neverblink/linkml/metamodel/UniqueKey.scala
@@ -15,8 +15,8 @@ final case class UniqueKeyImpl(
     @value
     @named("unique_key_slots")
     uniqueKeySlots: Seq[Reference[SlotDefinition]],
-    title: Option[String] = None,
-    description: Option[String] = None,
+    title: Option[LocalizedText] = None,
+    description: Option[LocalizedText] = None,
     rank: Option[Int] = None,
     aliases: Seq[String] = Seq(),
     @named("alt_descriptions")

--- a/runtime/src/eu/neverblink/linkml/runtime/LocalizedText.scala
+++ b/runtime/src/eu/neverblink/linkml/runtime/LocalizedText.scala
@@ -3,15 +3,26 @@ package eu.neverblink.linkml.runtime
 /** ADT for handling text that may be multilingual. In JSON maps to a string or an object. In RDF
   * converts to xsd:string / rdf:langString.
   */
-sealed trait LocalizedText
+sealed trait LocalizedText:
+  /** Render as a single plain string, for output formats that don't support multilingual text, such
+    * as JSON Schema.
+    *
+    * This will use (1) the plain text if available, (2) the English text if available, or (3) the
+    * text of the alphabetically first language tag. If there is no text at all, it will return an
+    * empty string.
+    */
+  def plain: String
 
 /** A plain string, which does not carry any language information
   */
-case class PlainText(value: String) extends LocalizedText
+case class PlainText(value: String) extends LocalizedText:
+  override def plain: String = value
 
 /** */
 type LanguageTag = String
 
 /** Multi-language text - a mapping of the language tag to the localized text
   */
-case class MultilingualText(mapping: Map[LanguageTag, String]) extends LocalizedText
+case class MultilingualText(mapping: Map[LanguageTag, String]) extends LocalizedText:
+  override def plain: String =
+    mapping.getOrElse("en", if mapping.isEmpty then "" else mapping.minBy(_._1)._2)

--- a/runtime/test/src/eu/neverblink/linkml/runtime/LocalizedTextSpec.scala
+++ b/runtime/test/src/eu/neverblink/linkml/runtime/LocalizedTextSpec.scala
@@ -1,0 +1,32 @@
+package eu.neverblink.linkml.runtime
+
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
+
+class LocalizedTextSpec extends AnyWordSpec, Matchers {
+  "plain" should {
+    "return the value of a plain text" in {
+      PlainText("hello").plain shouldBe "hello"
+    }
+
+    "prefer the English text" in {
+      MultilingualText(
+        Map("pl" -> "cześć", "en" -> "hello", "de" -> "hallo"),
+      ).plain shouldBe "hello"
+    }
+
+    "fall back to the alphabetically first language tag" in {
+      MultilingualText(Map("pl" -> "cześć", "de" -> "hallo")).plain shouldBe "hallo"
+    }
+
+    "not depend on the order the languages were given in" in {
+      val one = MultilingualText(Map("pl" -> "cześć", "de" -> "hallo"))
+      val other = MultilingualText(Map("de" -> "hallo", "pl" -> "cześć"))
+      one.plain shouldBe other.plain
+    }
+
+    "return an empty string when there is no text at all" in {
+      MultilingualText(Map()).plain shouldBe ""
+    }
+  }
+}

--- a/schemaview/test/src/eu/neverblink/linkml/schemaview/ClassDerivationSpec.scala
+++ b/schemaview/test/src/eu/neverblink/linkml/schemaview/ClassDerivationSpec.scala
@@ -1,7 +1,7 @@
 package eu.neverblink.linkml.schemaview
 
 import eu.neverblink.linkml.metamodel.*
-import eu.neverblink.linkml.runtime.{Reference, UriOrCurie, Uri}
+import eu.neverblink.linkml.runtime.{PlainText, Reference, UriOrCurie, Uri}
 import eu.neverblink.linkml.schemaview.SchemaViewSpec.{compact, reference}
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
@@ -11,7 +11,7 @@ class ClassDerivationSpec extends AnyWordSpec, Matchers {
     "inline slots as attributes" in {
       val slot = SlotDefinitionImpl(
         name = "slot1",
-        description = Some("Base description"),
+        description = Some(PlainText("Base description")),
         range = Some(Reference("child")),
       )
 
@@ -31,14 +31,16 @@ class ClassDerivationSpec extends AnyWordSpec, Matchers {
 
       val result = sv.classes("child")
       result.derivedAttributes("slot1").definingSchema shouldBe sv.root
-      result.derivedAttributes("slot1").slot.description shouldBe Some("Base description")
+      result.derivedAttributes("slot1").slot.description shouldBe Some(
+        PlainText("Base description"),
+      )
       result.derivedAttributes.keys should contain theSameElementsAs Seq("slot1")
     }
 
     "inherit slots as attributes" in {
       val slot = SlotDefinitionImpl(
         name = "slot1",
-        description = Some("Base description"),
+        description = Some(PlainText("Base description")),
         range = Some(Reference("child")),
       )
 
@@ -62,7 +64,9 @@ class ClassDerivationSpec extends AnyWordSpec, Matchers {
       )
 
       val result = sv.classes("child")
-      result.derivedAttributes("slot1").slot.description shouldBe Some("Base description")
+      result.derivedAttributes("slot1").slot.description shouldBe Some(
+        PlainText("Base description"),
+      )
       result.derivedAttributes.keys should contain theSameElementsAs Seq("slot1")
     }
 
@@ -70,7 +74,7 @@ class ClassDerivationSpec extends AnyWordSpec, Matchers {
       val slot = SlotDefinitionImpl(
         name = "slot1",
         identifier = true,
-        description = Some("Base description"),
+        description = Some(PlainText("Base description")),
         range = Some(Reference("child")),
       )
 
@@ -85,7 +89,7 @@ class ClassDerivationSpec extends AnyWordSpec, Matchers {
         slotUsage = Map(
           SlotDefinitionImpl(
             name = "slot1",
-            description = Some("Child description"),
+            description = Some(PlainText("Child description")),
             range = Some(Reference("child")),
           ).compact,
         ),
@@ -101,7 +105,9 @@ class ClassDerivationSpec extends AnyWordSpec, Matchers {
       )
 
       val result = sv.classes("child")
-      result.derivedAttributes("slot1").slot.description shouldBe Some("Child description")
+      result.derivedAttributes("slot1").slot.description shouldBe Some(
+        PlainText("Child description"),
+      )
       result.derivedAttributes("slot1").slot.identifier shouldBe true
       result.derivedAttributes.keys should contain theSameElementsAs Seq("slot1")
     }
@@ -109,7 +115,7 @@ class ClassDerivationSpec extends AnyWordSpec, Matchers {
     "merge slots and attributes into attributes" in {
       val slot = SlotDefinitionImpl(
         name = "slot1",
-        description = Some("Base description"),
+        description = Some(PlainText("Base description")),
         range = Some(Reference("base")),
       )
 
@@ -119,7 +125,7 @@ class ClassDerivationSpec extends AnyWordSpec, Matchers {
         attributes = Map(
           SlotDefinitionImpl(
             name = "slot2",
-            description = Some("Other description"),
+            description = Some(PlainText("Other description")),
             range = Some(Reference("base")),
           ).compact,
         ),
@@ -136,8 +142,12 @@ class ClassDerivationSpec extends AnyWordSpec, Matchers {
 
       val result = sv.classes("base")
       result.derivedAttributes.keys should contain theSameElementsAs Seq("slot1", "slot2")
-      result.derivedAttributes("slot1").slot.description shouldBe Some("Base description")
-      result.derivedAttributes("slot2").slot.description shouldBe Some("Other description")
+      result.derivedAttributes("slot1").slot.description shouldBe Some(
+        PlainText("Base description"),
+      )
+      result.derivedAttributes("slot2").slot.description shouldBe Some(
+        PlainText("Other description"),
+      )
     }
 
     "derive the class's URI" in {

--- a/schemaview/test/src/eu/neverblink/linkml/schemaview/SchemaViewSpec.scala
+++ b/schemaview/test/src/eu/neverblink/linkml/schemaview/SchemaViewSpec.scala
@@ -285,7 +285,7 @@ class SchemaViewSpec extends AnyWordSpec, Matchers {
         )
       sv.classes.size shouldBe 2
       sv.slotDefinitions.size shouldBe 4
-      sv.types.size shouldBe 21
+      sv.types.size shouldBe 22
       sv.enums.size shouldBe 2
       sv.classes("main_class").uriStr shouldBe "https://neverblink.eu/main#MainClass"
       sv.classes("imported_class").uriStr shouldBe "https://neverblink.eu/imported#ImportedClass"
@@ -614,7 +614,7 @@ object SchemaViewSpec:
 
   val class1: ClassDefinitionImpl = ClassDefinitionImpl(
     name = "class1",
-    description = Some("This is a first class"),
+    description = Some(PlainText("This is a first class")),
     slots = Seq(
       Reference("slot2"),
       Reference("slot_e1"),
@@ -627,7 +627,7 @@ object SchemaViewSpec:
   val class2: ClassDefinitionImpl = ClassDefinitionImpl(
     name = "class2",
     classUri = Some(UriOrCurie("https://neverblink.eu/example#classNumberTwo")),
-    description = Some("This is a second class"),
+    description = Some(PlainText("This is a second class")),
     slots = Seq(
       Reference("slot1"),
       Reference("slot_t1"),
@@ -638,7 +638,7 @@ object SchemaViewSpec:
   val class3: ClassDefinitionImpl = ClassDefinitionImpl(
     name = "class3",
     classUri = Some(UriOrCurie("https://neverblink.eu/example#classNumber3")),
-    description = Some("This is a third class"),
+    description = Some(PlainText("This is a third class")),
     slots = Seq(
       Reference("slot3"),
     ),
@@ -715,52 +715,52 @@ object SchemaViewSpec:
 
   val slot1: SlotDefinitionImpl = SlotDefinitionImpl(
     name = "slot1",
-    description = Some("This is a slot pointing to class 1"),
+    description = Some(PlainText("This is a slot pointing to class 1")),
     range = Some(Reference("class1")),
   )
 
   val slot2: SlotDefinitionImpl = SlotDefinitionImpl(
     name = "slot2",
     slotUri = Some(UriOrCurie("https://neverblink.eu/example#slotNumberTwo")),
-    description = Some("This is a slot pointing to class 2"),
+    description = Some(PlainText("This is a slot pointing to class 2")),
     range = Some(Reference("class2")),
   )
 
   val slotGrandparent: SlotDefinitionImpl = SlotDefinitionImpl(
     name = "slot_grandparent",
-    description = Some("This is a slot pointing to class grandparent"),
+    description = Some(PlainText("This is a slot pointing to class grandparent")),
     range = Some(classGrandparent.reference),
   )
 
   val slotParent: SlotDefinitionImpl = SlotDefinitionImpl(
     name = "slot_parent",
     isA = Some(slotGrandparent.reference),
-    description = Some("This is a slot pointing to class parent"),
+    description = Some(PlainText("This is a slot pointing to class parent")),
     range = Some(classParent.reference),
   )
 
   val slot3: SlotDefinitionImpl = SlotDefinitionImpl(
     name = "slot3",
     isA = Some(slotParent.reference),
-    description = Some("This is a slot pointing to class 3"),
+    description = Some(PlainText("This is a slot pointing to class 3")),
     range = Some(Reference("class3")),
   )
 
   val slot_t1: SlotDefinitionImpl = SlotDefinitionImpl(
     name = "slot_t1",
-    description = Some("This is a slot pointing to type 1"),
+    description = Some(PlainText("This is a slot pointing to type 1")),
     range = Some(Reference("type1")),
   )
 
   val slot_e1: SlotDefinitionImpl = SlotDefinitionImpl(
     name = "slot_e1",
-    description = Some("This is a slot pointing to enum 1"),
+    description = Some(PlainText("This is a slot pointing to enum 1")),
     range = Some(Reference("enum1")),
   )
 
   val slotRangeless: SlotDefinitionImpl = SlotDefinitionImpl(
     name = "slot_rangeless",
-    description = Some("This slot should use the default range of the schema."),
+    description = Some(PlainText("This slot should use the default range of the schema.")),
   )
 
   val slots: Map[String, SlotDefinitionImpl] = Map(
@@ -777,7 +777,7 @@ object SchemaViewSpec:
 
   val type1: TypeDefinitionImpl = TypeDefinitionImpl(
     name = "type1",
-    description = Some("Type 1"),
+    description = Some(PlainText("Type 1")),
   )
 
   val types: Map[String, TypeDefinitionImpl] = Map(
@@ -786,13 +786,13 @@ object SchemaViewSpec:
 
   val enum1: EnumDefinitionImpl = EnumDefinitionImpl(
     name = "enum1",
-    description = Some("Enum 1"),
+    description = Some(PlainText("Enum 1")),
   )
 
   val enum2: EnumDefinitionImpl = EnumDefinitionImpl(
     name = "enum2",
     enumUri = Some(UriOrCurie("https://neverblink.eu/example#enumNumberTwo")),
-    description = Some("Enum 2"),
+    description = Some(PlainText("Enum 2")),
   )
 
   val enums: Map[String, EnumDefinitionImpl] = Map(
@@ -802,7 +802,7 @@ object SchemaViewSpec:
 
   val subset1: SubsetDefinitionImpl = SubsetDefinitionImpl(
     name = "subset1",
-    description = Some("Subset 1"),
+    description = Some(PlainText("Subset 1")),
   )
 
   val subsets: Map[String, SubsetDefinitionImpl] = Map(

--- a/schemaview/test/src/eu/neverblink/linkml/schemaview/SlotDerivationSpec.scala
+++ b/schemaview/test/src/eu/neverblink/linkml/schemaview/SlotDerivationSpec.scala
@@ -12,7 +12,7 @@ class SlotDerivationSpec extends AnyWordSpec, Matchers {
     "inherit slot slots from class ancestors" in {
       val slot = SlotDefinitionImpl(
         name = "slot1",
-        description = Some("Base description"),
+        description = Some(PlainText("Base description")),
         range = Some(Reference("child")),
       )
 
@@ -36,13 +36,13 @@ class SlotDerivationSpec extends AnyWordSpec, Matchers {
       )
 
       val result = sv.classes("child").derivedAttributes("slot1").slot
-      result.description shouldBe Some("Base description")
+      result.description shouldBe Some(PlainText("Base description"))
     }
 
     "override slot slots from class ancestors with child class slot usage" in {
       val slot = SlotDefinitionImpl(
         name = "slot1",
-        description = Some("Base description"),
+        description = Some(PlainText("Base description")),
         range = Some(Reference("child")),
       )
 
@@ -54,7 +54,7 @@ class SlotDerivationSpec extends AnyWordSpec, Matchers {
       val child = ClassDefinitionImpl(
         name = "child",
         isA = Some(base.reference),
-        slotUsage = Map(slot.copy(description = Some("Child description")).compact),
+        slotUsage = Map(slot.copy(description = Some(PlainText("Child description"))).compact),
       )
 
       val sv = SchemaView.single(
@@ -67,7 +67,7 @@ class SlotDerivationSpec extends AnyWordSpec, Matchers {
       )
 
       val result = sv.classes("child").derivedAttributes("slot1").slot
-      result.description shouldBe Some("Child description")
+      result.description shouldBe Some(PlainText("Child description"))
     }
 
     "ignore schema-level slots if slot comes from an attribute" in {
@@ -82,7 +82,7 @@ class SlotDerivationSpec extends AnyWordSpec, Matchers {
         attributes = Map(
           SlotDefinitionImpl(
             name = "slot1",
-            description = Some("Attribute description"),
+            description = Some(PlainText("Attribute description")),
             range = Some(Reference("child")),
           ).compact,
         ),
@@ -99,7 +99,7 @@ class SlotDerivationSpec extends AnyWordSpec, Matchers {
 
       val result = sv.classes("child").derivedAttributes("slot1").slot
       result.identifier shouldBe false
-      result.description shouldBe Some("Attribute description")
+      result.description shouldBe Some(PlainText("Attribute description"))
     }
 
     "override is_a with mixins" in {
@@ -108,7 +108,7 @@ class SlotDerivationSpec extends AnyWordSpec, Matchers {
         attributes = Map(
           SlotDefinitionImpl(
             name = "slot1",
-            description = Some("Base description"),
+            description = Some(PlainText("Base description")),
             range = Some(Reference("base")),
           ).compact,
         ),
@@ -120,7 +120,7 @@ class SlotDerivationSpec extends AnyWordSpec, Matchers {
         attributes = Map(
           SlotDefinitionImpl(
             name = "slot1",
-            description = Some("Mixin description"),
+            description = Some(PlainText("Mixin description")),
             range = Some(Reference("base")),
           ).compact,
         ),
@@ -141,7 +141,7 @@ class SlotDerivationSpec extends AnyWordSpec, Matchers {
       )
 
       val result = sv.classes("child").derivedAttributes("slot1").slot
-      result.description shouldBe Some("Mixin description")
+      result.description shouldBe Some(PlainText("Mixin description"))
     }
 
     "override attributes with slot_usage" in {
@@ -150,7 +150,7 @@ class SlotDerivationSpec extends AnyWordSpec, Matchers {
         attributes = Map(
           SlotDefinitionImpl(
             name = "slot1",
-            description = Some("Base description"),
+            description = Some(PlainText("Base description")),
             range = Some(Reference("base")),
           ).compact,
         ),
@@ -162,7 +162,7 @@ class SlotDerivationSpec extends AnyWordSpec, Matchers {
         slotUsage = Map(
           SlotDefinitionImpl(
             name = "slot1",
-            description = Some("Slot usage description"),
+            description = Some(PlainText("Slot usage description")),
             range = Some(Reference("base")),
           ).compact,
         ),
@@ -177,7 +177,7 @@ class SlotDerivationSpec extends AnyWordSpec, Matchers {
       )
 
       val result = sv.classes("child").derivedAttributes("slot1").slot
-      result.description shouldBe Some("Slot usage description")
+      result.description shouldBe Some(PlainText("Slot usage description"))
     }
 
     "merge Seq slots" in {
@@ -382,7 +382,7 @@ class SlotDerivationSpec extends AnyWordSpec, Matchers {
     "not inherit non-inheritable values from parent slots " in {
       val slotParent = SlotDefinitionImpl(
         name = "slotParent",
-        description = Some("Base description"),
+        description = Some(PlainText("Base description")),
         range = Some(Reference("base")),
       )
 
@@ -477,13 +477,13 @@ class SlotDerivationSpec extends AnyWordSpec, Matchers {
     "not apply slot usages to slots with different ids" in {
       val slot = SlotDefinitionImpl(
         name = "slot1",
-        title = Some("Slot 1"),
+        title = Some(PlainText("Slot 1")),
         range = Some(Reference("child")),
       )
 
       val slot2 = SlotDefinitionImpl(
         name = "slot2",
-        title = Some("Slot 2"),
+        title = Some(PlainText("Slot 2")),
         range = Some(Reference("child")),
       )
 
@@ -498,7 +498,7 @@ class SlotDerivationSpec extends AnyWordSpec, Matchers {
           ).compact,
           SlotDefinitionImpl(
             name = "slot2",
-            description = Some("desc"),
+            description = Some(PlainText("desc")),
             range = Some(Reference("child")),
           ).compact,
         ),
@@ -516,18 +516,18 @@ class SlotDerivationSpec extends AnyWordSpec, Matchers {
       val result = sv.classes("child").derivedAttributes("slot1").slot
       result.identifier shouldBe true
       result.description shouldBe None
-      result.title shouldBe Some("Slot 1")
+      result.title shouldBe Some(PlainText("Slot 1"))
 
       val result2 = sv.classes("child").derivedAttributes("slot2").slot
       result2.identifier shouldBe false
-      result2.description shouldBe Some("desc")
-      result2.title shouldBe Some("Slot 2")
+      result2.description shouldBe Some(PlainText("desc"))
+      result2.title shouldBe Some(PlainText("Slot 2"))
     }
 
     "infer the slot's URI" in {
       val slot = SlotDefinitionImpl(
         name = "slot1",
-        title = Some("Slot 1"),
+        title = Some(PlainText("Slot 1")),
         range = Some(Reference("child")),
       )
       val child = ClassDefinitionImpl(

--- a/tests/resources/models/equalsExpression/model.yaml
+++ b/tests/resources/models/equalsExpression/model.yaml
@@ -15,99 +15,131 @@ classes:
     tree_root: true
     attributes:
       reference_value:
+        rank: 1
         range: string
       optional_message:
+        rank: 2
         range: string
         equals_expression: "Unknown reference to element '{reference_value}'"
       required_message:
+        rank: 3
         range: string
         required: true
         equals_expression: "ref is {reference_value}"
       required_source:
+        rank: 4
         range: string
         required: true
       from_required:
+        rank: 5
         range: string
         equals_expression: "{required_source} / {required_source}"
       literal_only:
+        rank: 6
         range: string
         equals_expression: "no substitutions here"
       with_escapes:
+        rank: 7
         range: string
         equals_expression: "braces {{like this}} and a \"quote\""
       no_expression:
+        rank: 8
         range: string
       # Reaching into inlined classes with dot notation
       optional_nested:
+        rank: 9
         range: Nested
         inlined: true
       required_nested:
+        rank: 10
         range: Nested
         inlined: true
         required: true
       from_optional_nested:
+        rank: 11
         range: string
         equals_expression: "{optional_nested.leaf}"
       from_required_nested:
+        rank: 12
         range: string
         equals_expression: "{required_nested.required_leaf} at {required_nested.deeper.bottom}"
       # Non-string ranges are stringified automatically
       count:
+        rank: 13
         range: integer
       ratio:
+        rank: 14
         range: double
       flag:
+        rank: 15
         range: boolean
       created:
+        rank: 16
         range: date
       from_numbers:
+        rank: 17
         range: string
         equals_expression: "{count} items, ratio {ratio}, flag {flag}, on {created}"
       # URIs and CURIEs stringify to the value as written, with no prefix resolution
       homepage:
+        rank: 18
         range: uri
         required: true
       term:
+        rank: 19
         range: curie
       either:
+        rank: 20
         range: uriorcurie
       from_uris:
+        rank: 21
         range: string
         equals_expression: "{homepage} | {term} | {either}"
       # Multivalued slots are joined with ", "
       tags:
+        rank: 22
         range: string
         multivalued: true
       codes:
+        rank: 23
         range: curie
         multivalued: true
       from_multivalued:
+        rank: 24
         range: string
         equals_expression: "tags: [{tags}], codes: [{codes}]"
       # A reference stringifies to the identifier it holds
       target:
+        rank: 25
         range: Identified
       targets:
+        rank: 26
         range: Identified
         multivalued: true
       from_references:
+        rank: 27
         range: string
         equals_expression: "{target} <- {targets}"
       # Enums stringify to their LinkML text, which is not the generated case name
       status:
+        rank: 28
         range: StatusEnum
       statuses:
+        rank: 29
         range: StatusEnum
         multivalued: true
       from_enum:
+        rank: 30
         range: string
         equals_expression: "{status} of ({statuses})"
       # Out of scope: not a single-valued string, so the expression must be ignored
       multivalued_ignored:
+        rank: 31
         range: string
         multivalued: true
         equals_expression: "{reference_value}"
       integer_ignored:
+        rank: 32
         range: integer
         equals_expression: "{reference_value}"
 

--- a/tests/resources/models/ifabsent/enums/model.yaml
+++ b/tests/resources/models/ifabsent/enums/model.yaml
@@ -9,18 +9,23 @@ classes:
     tree_root: true
     attributes:
       some_slot:
+        rank: 1
         range: SomeEnum
         ifabsent: SomeEnum(SOME_OPTION)
       some_other_slot:
+        rank: 2
         range: SomeEnum
         ifabsent: SomeEnum(SOME_OTHER_OPTION)
       yet_another_slot:
+        rank: 3
         range: SomeEnum
         ifabsent: SomeEnum(YET_ANOTHER_OPTION)
       with_spaces:
+        rank: 4
         range: SomeEnum
         ifabsent: SomeEnum(option with spaces)
       no_ifabsent:
+        rank: 5
         range: SomeEnum
 
 enums:

--- a/tests/resources/models/inlines/inlineAbstract/model.yaml
+++ b/tests/resources/models/inlines/inlineAbstract/model.yaml
@@ -26,15 +26,19 @@ classes:
     tree_root: true
     attributes:
       to_abstract:
+        rank: 1
         range: AbstractRange
         inlined: true
       to_mixin:
+        rank: 2
         range: MixinRange
         inlined: true
       to_concrete:
+        rank: 3
         range: ConcreteRange
         inlined: true
       many_abstract:
+        rank: 4
         range: AbstractRange
         inlined: true
         multivalued: true


### PR DESCRIPTION
Had to do that (sorry Kacper), because I can't do any work on the implementation otherwise.

I implemented a minimal fallback behavior for langstrings in generators, this can be adjusted further in follow-up PRs.

Also it turned out that the CI was not running tests in the `tests` module, so I fixed that... along with 3 tests that were failing because of this (missing ranks in the catalogue).