### PR TITLE
Update Scala to 3.9.0 LTS

### DIFF
--- a/build.mill
+++ b/build.mill
@@ -31,7 +31,7 @@ import millbuild.*
 
 import java.net.InetSocketAddress
 
-val scala = "3.8.4"
+val scala = "3.9.0"
 val scalaJS = "1.22.0"
 val rdf4j = "6.0.1"
 
@@ -766,7 +766,7 @@ object tests extends Module {
 
 trait CommonModule
     extends ScalaModule,
-      CommonPublishModule,
+      PublishModule,
       PlatformScalaModule,
       ScalafixModule,
       ScalafmtModule,
@@ -858,25 +858,11 @@ trait CommonTestModule extends ScalaModule, TestModule.ScalaTest, ScalafixModule
   override def scalaTestVersion = Task("3.2.20")
 }
 
-trait CommonScalaJSModule extends ScalaJSModule, CommonPublishModule {
+trait CommonScalaJSModule extends ScalaJSModule, PublishModule {
   def scalaJSVersion = scalaJS
 
   def moduleKind = Task {
     ModuleKind.ESModule
-  }
-}
-
-trait CommonPublishModule extends ScalaModule, PublishModule {
-  override def docJar = Task {
-    val outDir = Task.dest
-    val filteredDir = outDir / "filtered-javadoc"
-    val jarPath = outDir / "javadoc.jar"
-    os.copy(scalaDocGenerated().path, filteredDir)
-    os.remove.all(filteredDir / "fonts")
-    os.remove.all(filteredDir / "webfonts")
-    os.remove.all(filteredDir / "scripts" / "inkuire")
-    mill.util.Jvm.createJar(jarPath, Seq(filteredDir))
-    PathRef(jarPath)
   }
 }
 

--- a/generator/src/eu/neverblink/linkml/generator/jsonschema/JsonSchemaGenerator.scala
+++ b/generator/src/eu/neverblink/linkml/generator/jsonschema/JsonSchemaGenerator.scala
@@ -86,23 +86,23 @@ class JsonSchemaGenerator(using sv: SchemaView)
         case _: AnyView => Schema.Empty
         case ClassInlineAttributeView(_, _, classView, inlineType) =>
           val mappedClassName = className(classView)
-          val $ref = "#/$defs/".concat(mappedClassName)
+          val ref = "#/$defs/".concat(mappedClassName)
           inlineType match {
             case InlineType.plain =>
-              new Schema($ref = new Some($ref))
+              new Schema($ref = new Some(ref))
             case InlineType.optional =>
-              new Schema($ref = new Some($ref)) // TODO LNK-34: or null
+              new Schema($ref = new Some(ref)) // TODO LNK-34: or null
             case InlineType.list =>
-              new Schema($ref = new Some($ref)).arrayOf // TODO LNK-34: or null
+              new Schema($ref = new Some(ref)).arrayOf // TODO LNK-34: or null
             case InlineType.dict(CollectionForm.CompactDict(key)) =>
               needKeyless.add((mappedClassName, slotName(classView.derivedAttributes(key))))
               new Schema(
-                $ref = new Some($ref.concat("__identifier_optional")),
+                $ref = new Some(ref.concat("__identifier_optional")),
               ).dictOf // TODO LNK-34: or null
             case InlineType.dict(CollectionForm.SimpleDict(key, value)) =>
               needValue.add((mappedClassName, slotName(classView.derivedAttributes(value))))
               new Schema($ref =
-                new Some($ref.concat("__simple_dict_value")),
+                new Some(ref.concat("__simple_dict_value")),
               ).dictOf // TODO LNK-34: or null
           }
         case ClassReferenceAttributeView(slotView, _, classView, identifierView) =>

--- a/schemaview/src/eu/neverblink/linkml/schemaview/Case.scala
+++ b/schemaview/src/eu/neverblink/linkml/schemaview/Case.scala
@@ -51,24 +51,23 @@ object Case {
     val sb = new java.lang.StringBuilder(len << 1)
     var i = 0
     var isPrecedingNotUpperCased = false
-    while (i < len) isPrecedingNotUpperCased = {
+    while (i < len) {
       val ch = name.charAt(i)
       i += 1
       if (ch == '_' || ch == '-' || ch == ' ') {
-        if (i > 1 && i < len && !isAlphabetic(name.charAt(i))) isPrecedingNotUpperCased
-        else {
+        if (i <= 1 || i >= len || isAlphabetic(name.charAt(i))) {
           sb.append(separator)
-          false
+          isPrecedingNotUpperCased = false
         }
       } else if (!isUpperCase(ch)) {
         sb.append(ch)
-        true
+        isPrecedingNotUpperCased = true
       } else {
         if (isPrecedingNotUpperCased || i > 1 && i < len && isLowerCase(name.charAt(i))) {
           sb.append(separator)
         }
         sb.append(toLowerCase(ch))
-        false
+        isPrecedingNotUpperCased = false
       }
     }
     sb.toString
@@ -110,15 +109,16 @@ object Case {
     } else {
       var i = 0
       var isPrecedingDash = toPascal
-      while (i < len) isPrecedingDash = {
+      while (i < len) {
         val ch = name.charAt(i)
         i += 1
-        (ch == '_' || ch == '-' || ch == ' ') || {
+        if (ch == '_' || ch == '-' || ch == ' ') isPrecedingDash = true
+        else {
           val fixedCh =
             if (isPrecedingDash) toUpperCase(ch)
             else toLowerCase(ch)
           sb.append(fixedCh)
-          false
+          isPrecedingDash = false
         }
       }
     }


### PR DESCRIPTION
The standard library is now optimized with the Scala backend optimizer.
See https://www.scala-lang.org/news/3.9/

Also:
- the w/a for smaller ScalaDoc artifacts was removed
- fixed Scala compiler warnings