### PR TITLE
Enable LTO, fix target glibc version

### DIFF
--- a/.github/workflows/native-build.yml
+++ b/.github/workflows/native-build.yml
@@ -30,8 +30,10 @@ jobs:
         ${{ contains(github.event.pull_request.labels.*.name, 'full-wheels')
         && '[{"os":"macos-14","platform":"macos-arm64"},
              {"os":"macos-15-intel","platform":"macos-x86_64"},
-             {"os":"ubuntu-22.04","platform":"linux-x86_64"},
-             {"os":"ubuntu-22.04-arm","platform":"linux-arm64"},
+             {"os":"ubuntu-22.04","platform":"linux-x86_64",
+              "container":"quay.io/pypa/manylinux_2_28_x86_64"},
+             {"os":"ubuntu-22.04-arm","platform":"linux-arm64",
+              "container":"quay.io/pypa/manylinux_2_28_aarch64"},
              {"os":"windows-latest","platform":"windows-x86_64"},
              {"os":"windows-11-arm","platform":"windows-arm64"}]'
         || '[{"os":"windows-11-arm","platform":"windows-arm64"}]' }}

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -12,8 +12,10 @@ on:
         default: >-
           [{"os":"macos-14","platform":"macos-arm64"},
            {"os":"macos-15-intel","platform":"macos-x86_64"},
-           {"os":"ubuntu-22.04","platform":"linux-x86_64"},
-           {"os":"ubuntu-22.04-arm","platform":"linux-arm64"},
+           {"os":"ubuntu-22.04","platform":"linux-x86_64",
+            "container":"quay.io/pypa/manylinux_2_28_x86_64"},
+           {"os":"ubuntu-22.04-arm","platform":"linux-arm64",
+            "container":"quay.io/pypa/manylinux_2_28_aarch64"},
            {"os":"windows-latest","platform":"windows-x86_64"},
            {"os":"windows-11-arm","platform":"windows-arm64"}]
       musl:
@@ -38,8 +40,10 @@ on:
         default: >-
           [{"os":"macos-14","platform":"macos-arm64"},
            {"os":"macos-15-intel","platform":"macos-x86_64"},
-           {"os":"ubuntu-22.04","platform":"linux-x86_64"},
-           {"os":"ubuntu-22.04-arm","platform":"linux-arm64"},
+           {"os":"ubuntu-22.04","platform":"linux-x86_64",
+            "container":"quay.io/pypa/manylinux_2_28_x86_64"},
+           {"os":"ubuntu-22.04-arm","platform":"linux-arm64",
+            "container":"quay.io/pypa/manylinux_2_28_aarch64"},
            {"os":"windows-latest","platform":"windows-x86_64"},
            {"os":"windows-11-arm","platform":"windows-arm64"}]
       musl:
@@ -61,6 +65,8 @@ jobs:
   library:
     name: Library and wheel for ${{ matrix.platform }}
     runs-on: ${{ matrix.os }}
+    # Use a container to target a lower glibc.
+    container: ${{ matrix.container }}
     strategy:
       matrix:
         include: ${{ fromJSON(inputs.targets) }}
@@ -98,9 +104,16 @@ jobs:
           arch: ${{ matrix.platform == 'windows-arm64' && 'arm64' || 'x64' }}
 
       - name: Setup Python
+        if: '!matrix.container'
         uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.platform == 'windows-arm64' && '3.12' || '3.10' }}
+
+      - name: Setup the manylinux Toolchain
+        if: matrix.container
+        run: |
+          dnf install -y -q clang
+          echo "/opt/python/cp310-cp310/bin" >> "$GITHUB_PATH"
 
       - name: Show the LLVM toolchain
         run: clang --version

--- a/build.mill
+++ b/build.mill
@@ -627,8 +627,7 @@ object nativelib extends Module, NativeOptional {
       * Turning LTO on also switches Scala Native to the C++ exception backend, so a throw starts
       * inside libstdc++. On ARM64 that is a frame with a signed return address, and Scala Native's
       * vendored libunwind is compiled without `_LIBUNWIND_IS_NATIVE_ONLY`, so it refuses to step
-      * out of one. Nothing is ever caught and the process aborts. Reported upstream; the fix is one
-      * define in nativelib's scala-native.properties.
+      * out of one.
       */
     override def nativeLTO = Task {
       val arch = nativeTarget()

--- a/build.mill
+++ b/build.mill
@@ -622,19 +622,20 @@ object nativelib extends Module, NativeOptional {
     override def releaseMode = Task { ReleaseMode.ReleaseFast }
     override def nativeTarget = Task.Input { Task.env.get("LINKML_SCALA_TARGET") }
 
-    /** Link-time optimisation, on x86-64 only.
-      *
-      * Turning LTO on also switches Scala Native to the C++ exception backend, so a throw starts
-      * inside libstdc++. On ARM64 that is a frame with a signed return address, and Scala Native's
-      * vendored libunwind is compiled without `_LIBUNWIND_IS_NATIVE_ONLY`, so it refuses to step
-      * out of one.
+    /** Link-time optimisation, on x86-64 only. Thin LTO is not supported on macOS. ARM64 does not
+      * seem to work with LTO at all at the moment due to a bug in C++ exception handling.
       */
     override def nativeLTO = Task {
-      val arch = nativeTarget()
+      val triple = nativeTarget()
+      val arch = triple
         .map(_.takeWhile(_ != '-'))
         .getOrElse(_root_.scala.util.Properties.propOrElse("os.arch", ""))
-      if Set("x86_64", "amd64", "x64").contains(arch.toLowerCase) then LTO.Thin
-      else LTO.None
+      val isMac = triple
+        .map(t => t.contains("apple") || t.contains("darwin"))
+        .getOrElse(_root_.scala.util.Properties.isMac)
+      if !Set("x86_64", "amd64", "x64").contains(arch.toLowerCase) then LTO.None
+      else if isMac then LTO.Full
+      else LTO.Thin
     }
 
     /** Override needed for Scala Native 0.15.2. Remove after upgrading. */

--- a/build.mill
+++ b/build.mill
@@ -23,7 +23,7 @@ import mill.scalajslib.*
 import mill.scalajslib.api.ModuleKind
 import scalalib.*
 import scalanativelib.*
-import mill.scalanativelib.api.{BuildTarget, ReleaseMode}
+import mill.scalanativelib.api.{BuildTarget, LTO, ReleaseMode}
 import io.github.alexarchambault.millnativeimage.NativeImage
 import com.carlosedp.aliases.*
 import mill.contrib.buildinfo.BuildInfo
@@ -621,6 +621,22 @@ object nativelib extends Module, NativeOptional {
 
     override def releaseMode = Task { ReleaseMode.ReleaseFast }
     override def nativeTarget = Task.Input { Task.env.get("LINKML_SCALA_TARGET") }
+
+    /** Link-time optimisation, on x86-64 only.
+      *
+      * Turning LTO on also switches Scala Native to the C++ exception backend, so a throw starts
+      * inside libstdc++. On ARM64 that is a frame with a signed return address, and Scala Native's
+      * vendored libunwind is compiled without `_LIBUNWIND_IS_NATIVE_ONLY`, so it refuses to step
+      * out of one. Nothing is ever caught and the process aborts. Reported upstream; the fix is one
+      * define in nativelib's scala-native.properties.
+      */
+    override def nativeLTO = Task {
+      val arch = nativeTarget()
+        .map(_.takeWhile(_ != '-'))
+        .getOrElse(_root_.scala.util.Properties.propOrElse("os.arch", ""))
+      if Set("x86_64", "amd64", "x64").contains(arch.toLowerCase) then LTO.Thin
+      else LTO.None
+    }
 
     /** Override needed for Scala Native 0.15.2. Remove after upgrading. */
     override def runClasspath = Task {

--- a/build.mill
+++ b/build.mill
@@ -622,20 +622,12 @@ object nativelib extends Module, NativeOptional {
     override def releaseMode = Task { ReleaseMode.ReleaseFast }
     override def nativeTarget = Task.Input { Task.env.get("LINKML_SCALA_TARGET") }
 
-    /** Link-time optimisation, on x86-64 only. Thin LTO is not supported on macOS. ARM64 does not
-      * seem to work with LTO at all at the moment due to a bug in C++ exception handling.
-      */
+    /** Link-time optimisation. Thin LTO is not supported on macOS. */
     override def nativeLTO = Task {
-      val triple = nativeTarget()
-      val arch = triple
-        .map(_.takeWhile(_ != '-'))
-        .getOrElse(_root_.scala.util.Properties.propOrElse("os.arch", ""))
-      val isMac = triple
+      val isMac = nativeTarget()
         .map(t => t.contains("apple") || t.contains("darwin"))
         .getOrElse(_root_.scala.util.Properties.isMac)
-      if !Set("x86_64", "amd64", "x64").contains(arch.toLowerCase) then LTO.None
-      else if isMac then LTO.Full
-      else LTO.Thin
+      if isMac then LTO.Full else LTO.Thin
     }
 
     /** Override needed for Scala Native 0.15.2. Remove after upgrading. */
@@ -655,8 +647,11 @@ object nativelib extends Module, NativeOptional {
       if _root_.scala.util.Properties.isMac then Seq(s"-mmacosx-version-min=14.0")
       else Seq.empty
 
+    /** _LIBUNWIND_IS_NATIVE_ONLY: see https://github.com/scala-native/scala-native/pull/5034
+      */
     override def nativeCompileOptions = Task {
-      super.nativeCompileOptions() ++ macosTarget :+ "-O3"
+      super.nativeCompileOptions() ++ macosTarget ++
+        Seq("-O3", "-D_LIBUNWIND_IS_NATIVE_ONLY")
     }
 
     override def nativeLinkingOptions = Task {


### PR DESCRIPTION
~~LTO is broken only on ARM64, on x86-64 it works just fine. The ARM bug looks to be quite silly, I will file an issue for that.~~ nevermind, managed to work around it, we now have LTO everywhere, hooray.

On Mac only the Full LTO mode is supported.

I've also changed it so that we target a lower glibc version by building the wheel in a container, for maximum compatibility.