### PR TITLE
Fix round-tripping and validating unique_keys

### DIFF
--- a/generator/src/eu/neverblink/linkml/generator/jsonschema/JsonSchemaGenerator.scala
+++ b/generator/src/eu/neverblink/linkml/generator/jsonschema/JsonSchemaGenerator.scala
@@ -101,10 +101,9 @@ class JsonSchemaGenerator(using sv: SchemaView)
                 $ref = new Some(ref.concat("__identifier_optional")),
               ).dictOf // TODO LNK-34: or null
             case InlineType.dict(CollectionForm.SimpleDict(key, value)) =>
+              needKeyless.add((mappedClassName, slotName(classView.derivedAttributes(key))))
               needValue.add((mappedClassName, slotName(classView.derivedAttributes(value))))
-              new Schema($ref =
-                new Some(ref.concat("__simple_dict_value")),
-              ).dictOf // TODO LNK-34: or null
+              simpleDictSchema(ref).dictOf // TODO LNK-34: or null
           }
         case ClassReferenceAttributeView(slotView, _, classView, identifierView) =>
           typeToRuntime(identifierView.typeView)
@@ -189,10 +188,9 @@ class JsonSchemaGenerator(using sv: SchemaView)
           ).dictOf
         case InlineType.dict(CollectionForm.SimpleDict(key, value)) =>
           val mappedClassName = className(treeRoot)
+          needKeyless.add((mappedClassName, slotName(treeRoot.derivedAttributes(key))))
           needValue.add((mappedClassName, slotName(treeRoot.derivedAttributes(value))))
-          new Schema(
-            $ref = new Some("#/$defs/" + mappedClassName + "__simple_dict_value"),
-          ).dictOf
+          simpleDictSchema("#/$defs/" + mappedClassName).dictOf
       }
     }
     // Generate the needed keyless/value refs
@@ -306,6 +304,21 @@ object JsonSchemaGenerator {
 
   type MappedClassName = String
   type MappedSlotName = String
+
+  /** Schema for one entry of a dict inlined in the SimpleDict form: either the bare primary value,
+    * or the full object with the key slot made optional. Both should be in principle accepted by
+    * LinkML parsers.
+    *
+    * @param ref
+    *   `$defs` reference of the inlined class, without a form suffix
+    */
+  private def simpleDictSchema(ref: String): Schema = Schema.oneOf(
+    List(
+      new Schema($ref = Some(ref.concat("__simple_dict_value"))),
+      new Schema($ref = Some(ref.concat("__identifier_optional"))),
+    ),
+    discriminator = None,
+  )
 
   extension (schema: Schema)
     /** Wrap this Schema in an array

--- a/generator/test/src/eu/neverblink/linkml/generator/jsonschema/JsonSchemaGeneratorSpec.scala
+++ b/generator/test/src/eu/neverblink/linkml/generator/jsonschema/JsonSchemaGeneratorSpec.scala
@@ -6,13 +6,22 @@ import eu.neverblink.linkml.tests.ModelCatalogue
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
 import sttp.apispec.circe.encoderSchema
-import sttp.apispec.{ExampleSingleValue, Pattern, Schema, SchemaType}
+import sttp.apispec.{ExampleSingleValue, Pattern, Schema, SchemaLike, SchemaType}
 
 class JsonSchemaGeneratorSpec extends AnyWordSpec, Matchers {
   import JsonSchemaGeneratorSpec.skipModels
   def load(schemaYaml: String): SchemaView = {
     SchemaIssues.orThrow(SchemaView.loadSchemaViewFromString(schemaYaml))
   }
+
+  /** Assert that one entry of a dict inlined in the SimpleDict form accepts both the bare primary
+    * value and the full object with an optional key.
+    */
+  def shouldBeSimpleDictEntryOf(entry: SchemaLike, cls: String): Unit =
+    entry.asInstanceOf[Schema].oneOf.map(_.asInstanceOf[Schema].$ref) shouldBe List(
+      Some(s"#/$$defs/${cls}__simple_dict_value"),
+      Some(s"#/$$defs/${cls}__identifier_optional"),
+    )
 
   "JsonSchemaGenerator" should {
     // Shared part of the schema
@@ -222,8 +231,7 @@ class JsonSchemaGeneratorSpec extends AnyWordSpec, Matchers {
 
       val someSlot = c.properties("some_slot").asInstanceOf[Schema]
       someSlot.`type` shouldBe Some(List(SchemaType.Object))
-      someSlot.additionalProperties.get.asInstanceOf[Schema]
-        .$ref shouldBe Some("#/$defs/SomeOtherClass__simple_dict_value")
+      shouldBeSimpleDictEntryOf(someSlot.additionalProperties.get, "SomeOtherClass")
       schema.$defs.get.keys.toSeq should contain("SomeOtherClass__simple_dict_value")
       val value = schema.$defs.get("SomeOtherClass__simple_dict_value").asInstanceOf[Schema]
       value.`type` shouldBe Some(List(SchemaType.String))
@@ -269,8 +277,7 @@ class JsonSchemaGeneratorSpec extends AnyWordSpec, Matchers {
 
       val someSlot = c.properties("some_slot").asInstanceOf[Schema]
       someSlot.`type` shouldBe Some(List(SchemaType.Object))
-      someSlot.additionalProperties.get.asInstanceOf[Schema]
-        .$ref shouldBe Some("#/$defs/SomeOtherClass__simple_dict_value")
+      shouldBeSimpleDictEntryOf(someSlot.additionalProperties.get, "SomeOtherClass")
       schema.$defs.get.keys.toSeq should contain("SomeOtherClass__simple_dict_value")
       val value = schema.$defs.get("SomeOtherClass__simple_dict_value").asInstanceOf[Schema]
       value.`type` shouldBe Some(List(SchemaType.String))
@@ -444,13 +451,11 @@ class JsonSchemaGeneratorSpec extends AnyWordSpec, Matchers {
       val someSlot = node.properties("children").asInstanceOf[Schema]
       someSlot.`type` shouldBe Some(List(SchemaType.Object))
       someSlot.description shouldBe Some("Dictionary of child nodes")
-      val additionalProperties = someSlot.additionalProperties.get.asInstanceOf[Schema]
-      additionalProperties.$ref shouldBe Some("#/$defs/Node__simple_dict_value")
+      shouldBeSimpleDictEntryOf(someSlot.additionalProperties.get, "Node")
       node.description shouldBe Some("Tree of nodes")
       val value = schema.$defs.get("Node__simple_dict_value").asInstanceOf[Schema]
       value.`type` shouldBe Some(List(SchemaType.Object))
-      val valueAdditionalProperties = value.additionalProperties.get.asInstanceOf[Schema]
-      valueAdditionalProperties.$ref shouldBe Some("#/$defs/Node__simple_dict_value")
+      shouldBeSimpleDictEntryOf(value.additionalProperties.get, "Node")
     }
 
     "carry over the titles and descriptions" in {
@@ -766,8 +771,7 @@ class JsonSchemaGeneratorSpec extends AnyWordSpec, Matchers {
         )
 
         val schema = JsonSchemaGenerator().generate()
-        schema.additionalProperties.get.asInstanceOf[Schema]
-          .$ref shouldBe Some("#/$defs/C1__simple_dict_value")
+        shouldBeSimpleDictEntryOf(schema.additionalProperties.get, "C1")
 
         schema.$defs.get.keys should contain("C1__simple_dict_value")
       }
@@ -853,8 +857,7 @@ class JsonSchemaGeneratorSpec extends AnyWordSpec, Matchers {
             JsonSchemaGenerator.Options(treeRootInlineType = Some("simple_dict")),
           )
 
-        schema.additionalProperties.get.asInstanceOf[Schema]
-          .$ref shouldBe Some("#/$defs/C1__simple_dict_value")
+        shouldBeSimpleDictEntryOf(schema.additionalProperties.get, "C1")
 
         schema.$defs.get.keys should contain("C1__simple_dict_value")
       }

--- a/generator/test/src/eu/neverblink/linkml/generator/linkml/LinkMlGeneratorSpec.scala
+++ b/generator/test/src/eu/neverblink/linkml/generator/linkml/LinkMlGeneratorSpec.scala
@@ -355,6 +355,52 @@ class LinkMlGeneratorSpec extends AnyWordSpec, Matchers {
       yaml should include("""description: "3.14"""")
     }
 
+    "round-trip unique_keys" in {
+      val sv = SchemaIssues.orThrow(SchemaView.loadSchemaViewFromString("""name: unique_keys
+          |id: https://example.org/unique-keys
+          |types:
+          |  string:
+          |    base: str
+          |classes:
+          |  SomeClass:
+          |    slots:
+          |      - a
+          |      - b
+          |    unique_keys:
+          |      compound:
+          |        unique_key_slots:
+          |          - a
+          |          - b
+          |      collapsed_list:
+          |        - a
+          |      collapsed_scalar: b
+          |slots:
+          |  a:
+          |    range: string
+          |  b:
+          |    range: string
+          |""".stripMargin))
+
+      val options = LinkMlGenerator.Options(skipClassDerivation = true)
+      val yaml = LinkMlGenerator(using sv).serialize(options)
+      // The two collapsed input forms normalize to the full form as well
+      yaml should include("""    unique_keys:
+          |      compound:
+          |        unique_key_slots:
+          |          - a
+          |          - b
+          |      collapsed_list:
+          |        unique_key_slots:
+          |          - a
+          |      collapsed_scalar:
+          |        unique_key_slots:
+          |          - b
+          |""".stripMargin)
+
+      val reloaded = SchemaIssues.orThrow(SchemaView.loadSchemaViewFromString(yaml))
+      LinkMlGenerator(using reloaded).serialize(options) shouldBe yaml
+    }
+
     "generate all catalogue models without errors" when {
       for entry <- ModelCatalogue.all.filter(m => !skipModels.contains(m.model.root.name)) do
         s"model '${entry.model.root.name}'" in {

--- a/generator/test/src/eu/neverblink/linkml/generator/linkml/LinkMlGeneratorSpec.scala
+++ b/generator/test/src/eu/neverblink/linkml/generator/linkml/LinkMlGeneratorSpec.scala
@@ -381,24 +381,32 @@ class LinkMlGeneratorSpec extends AnyWordSpec, Matchers {
           |    range: string
           |""".stripMargin))
 
-      val options = LinkMlGenerator.Options(skipClassDerivation = true)
-      val yaml = LinkMlGenerator(using sv).serialize(options)
-      // The two collapsed input forms normalize to the full form as well
-      yaml should include("""    unique_keys:
-          |      compound:
-          |        unique_key_slots:
-          |          - a
-          |          - b
-          |      collapsed_list:
-          |        unique_key_slots:
-          |          - a
-          |      collapsed_scalar:
-          |        unique_key_slots:
-          |          - b
-          |""".stripMargin)
+      // Derivation turns the slots into attributes.
+      // The macro validator must be aware of the class context (attributes) to load such
+      // a schema, so we test it here.
+      for options <- Seq(
+          LinkMlGenerator.Options(),
+          LinkMlGenerator.Options(skipClassDerivation = true),
+        )
+      do {
+        val yaml = LinkMlGenerator(using sv).serialize(options)
+        // The two collapsed input forms normalize to the full form as well
+        yaml should include("""    unique_keys:
+            |      compound:
+            |        unique_key_slots:
+            |          - a
+            |          - b
+            |      collapsed_list:
+            |        unique_key_slots:
+            |          - a
+            |      collapsed_scalar:
+            |        unique_key_slots:
+            |          - b
+            |""".stripMargin)
 
-      val reloaded = SchemaIssues.orThrow(SchemaView.loadSchemaViewFromString(yaml))
-      LinkMlGenerator(using reloaded).serialize(options) shouldBe yaml
+        val reloaded = SchemaIssues.orThrow(SchemaView.loadSchemaViewFromString(yaml))
+        LinkMlGenerator(using reloaded).serialize(options) shouldBe yaml
+      }
     }
 
     "generate all catalogue models without errors" when {

--- a/runtime/src/eu/neverblink/linkml/runtime/MacroUtils.scala
+++ b/runtime/src/eu/neverblink/linkml/runtime/MacroUtils.scala
@@ -134,6 +134,11 @@ trait MacroUtils(using val quotes: Quotes) {
     "scala.collection.immutable.Map",
   ).typeRef.appliedTo(wildcardBounds :: wildcardBounds :: Nil)
 
+  /** True if the type serializes to a sequence or a map rather than to a single scalar or object.
+    */
+  def isCollectionTpe(tpe: TypeRepr): Boolean =
+    tpe <:< seqOfWildcardTpe || tpe <:< mapOfWildcardsTpe
+
   /** Reports an error during macro expansion and immediately aborts the compilation.
     *
     * @param msg

--- a/schemaview/src/eu/neverblink/linkml/schemaview/MacroValidator.scala
+++ b/schemaview/src/eu/neverblink/linkml/schemaview/MacroValidator.scala
@@ -314,7 +314,9 @@ private class ReferenceValidatorImpl(using Quotes) extends MacroUtils {
                 sv,
                 fieldInfo.mappedName match {
                   case "range" => '{ $vc.asRange }
-                  case "unique_key_slots" => '{ $vc.asLocalSlotRef }
+                  // LinkML scopes these to the enclosing class, they may reference its attributes.
+                  case "unique_key_slots" | "defining_slots" | "slot_group" =>
+                    '{ $vc.asLocalSlotRef }
                   case _ => vc
                 },
               )

--- a/schemaview/src/eu/neverblink/linkml/schemaview/MacroValidator.scala
+++ b/schemaview/src/eu/neverblink/linkml/schemaview/MacroValidator.scala
@@ -108,19 +108,42 @@ private trait MacroValidator[T] {
   *   Whether to treat omitted ranges as an error
   * @param isRange
   *   Whether this particular slot is a range and should be additionally checked
+  * @param classScope
+  *   Name of the class definition this slot is nested in, if any
+  * @param slotsMayBeLocal
+  *   Whether a slot reference here may reference a slot (attribute) of [[classScope]] rather than
+  *   only a top-level one
   */
 final class ValidatorContext private (
     val defaultRangeAllowed: Boolean,
     val isRange: Boolean,
     val fromSchema: Uri,
+    val classScope: Option[String],
+    val slotsMayBeLocal: Boolean,
 ):
   /** Mark continue validating this slot as a range. SHOULD NOT BE USED OUTSIDE THE MACRO */
   def asRange: ValidatorContext =
-    new ValidatorContext(defaultRangeAllowed, true, fromSchema)
+    new ValidatorContext(defaultRangeAllowed, true, fromSchema, classScope, slotsMayBeLocal)
+
+  /** Enter the scope of a class definition. SHOULD NOT BE USED OUTSIDE THE MACRO */
+  def withClassScope(className: String): ValidatorContext =
+    new ValidatorContext(
+      defaultRangeAllowed,
+      isRange,
+      fromSchema,
+      Some(className),
+      slotsMayBeLocal,
+    )
+
+  /** Allow this slot reference to reference a slot (attribute) local to the enclosing class. SHOULD
+    * NOT BE USED OUTSIDE THE MACRO
+    */
+  def asLocalSlotRef: ValidatorContext =
+    new ValidatorContext(defaultRangeAllowed, isRange, fromSchema, classScope, true)
 
 object ValidatorContext:
   def apply(defaultRangeAllowed: Boolean, fromSchema: Uri): ValidatorContext =
-    new ValidatorContext(defaultRangeAllowed, false, fromSchema)
+    new ValidatorContext(defaultRangeAllowed, false, fromSchema, None, false)
 
 private object MacroValidator {
   given MacroValidator[LinkmlAny] = new MacroValidator[LinkmlAny] {
@@ -141,6 +164,13 @@ private object MacroValidator {
     }
   }
 
+  /** Whether the reference references a slot of the enclosing class rather than a top-level one. */
+  private def isLocalSlot(
+      name: String,
+  )(using sv: SchemaView, vc: ValidatorContext): Boolean =
+    vc.slotsMayBeLocal && vc.classScope.flatMap(sv.classes.get)
+      .exists(_.isSlotFromAttributes(new Reference[SlotDefinition](name)))
+
   given referenceValidator[T <: Element]: MacroValidator[Reference[T]] =
     new MacroValidator[Reference[T]] {
       def validate(
@@ -156,6 +186,7 @@ private object MacroValidator {
             ValidatorResult(invalidRanges =
               Seq(InvalidRange("", t.value, formatRangeType(value), vc.fromSchema)),
             )
+        case None if isLocalSlot(t.value) => ValidatorResult.ok
         case None =>
           ValidatorResult(unknownReferences = Seq(UnknownReference("", t.value, vc.fromSchema)))
       }
@@ -268,6 +299,7 @@ private class ReferenceValidatorImpl(using Quotes) extends MacroUtils {
 
     def genValidateFields(
         kvs: Expr[mutable.Growable[ValidatorResult]],
+        vc: Expr[ValidatorContext],
     )(using Quotes): Expr[Unit] = {
       Block(
         fields.map { fieldInfo =>
@@ -280,8 +312,11 @@ private class ReferenceValidatorImpl(using Quotes) extends MacroUtils {
                 fTpe,
                 getter.asInstanceOf[Expr[ft]],
                 sv,
-                if fieldInfo.mappedName != "range" then vc
-                else '{ $vc.asRange },
+                fieldInfo.mappedName match {
+                  case "range" => '{ $vc.asRange }
+                  case "unique_key_slots" => '{ $vc.asLocalSlotRef }
+                  case _ => vc
+                },
               )
               '{
                 // Skip ok results to save on array expansion and folding
@@ -293,9 +328,15 @@ private class ReferenceValidatorImpl(using Quotes) extends MacroUtils {
         '{}.asTerm,
       ).asExpr.asInstanceOf[Expr[Unit]]
     }
+    // Class-scoped slot references nested anywhere under this class resolve against its attributes
+    val enterScope =
+      if (tpe <:< classDefinitionTpe)
+        '{ $vc.withClassScope(${ x.asInstanceOf[Expr[ClassDefinition]] }.name) }
+      else vc
     '{
       val kvs = Seq.newBuilder[ValidatorResult]
-      ${ genValidateFields('kvs) }
+      val fieldVc = $enterScope
+      ${ genValidateFields('kvs, 'fieldVc) }
       kvs.result().fold(ValidatorResult.ok)(_ + _)
     }
   }
@@ -356,6 +397,7 @@ private class ReferenceValidatorImpl(using Quotes) extends MacroUtils {
     new mutable.HashMap[TypeRepr, Option[Expr[MacroValidator[?]]]]
   private val validateRefs = new mutable.HashMap[TypeRepr, Ref]
   private val defs = new mutable.ListBuffer[Definition]
+  private val classDefinitionTpe = TypeRepr.of[ClassDefinition]
   private val referenceValidatorTpe =
     Symbol.requiredClass("eu.neverblink.linkml.schemaview.MacroValidator").typeRef
   private val schemaViewTpe =

--- a/schemaview/test/src/eu/neverblink/linkml/schemaview/SchemaValidatorSpec.scala
+++ b/schemaview/test/src/eu/neverblink/linkml/schemaview/SchemaValidatorSpec.scala
@@ -225,6 +225,60 @@ class SchemaValidatorSpec extends AnyWordSpec, Matchers {
       )
     }
 
+    "resolve defining_slots and slot_group against the class's own attributes" in {
+      load(
+        s"""$schemaShared
+           |types:
+           |  string:
+           |    base: str
+           |classes:
+           |  SomeClass:
+           |    attributes:
+           |      a:
+           |        range: string
+           |        slot_group: b
+           |      b:
+           |        range: string
+           |        is_grouping_slot: true
+           |    defining_slots: [b]
+           |""".stripMargin,
+      )
+    }
+
+    "find unknown references in defining_slots and slot_group" in {
+      val schemaYaml =
+        s"""$schemaShared
+           |types:
+           |  string:
+           |    base: str
+           |classes:
+           |  SomeClass:
+           |    attributes:
+           |      a:
+           |        range: string
+           |        slot_group: typo
+           |    defining_slots: [alsoTypo]
+           |""".stripMargin
+      loadFailure(schemaYaml) shouldBe
+        """Unknown reference 'typo' at /classes/SomeClass/attributes/a/slot_group/
+          |Unknown reference 'alsoTypo' at /classes/SomeClass/defining_slots/0/""".stripMargin
+    }
+
+    "keep slot_group strict on a top-level slot, which has no class scope" in {
+      val schemaYaml =
+        s"""$schemaShared
+           |types:
+           |  string:
+           |    base: str
+           |slots:
+           |  a:
+           |    range: string
+           |    slot_group: nope
+           |""".stripMargin
+      loadFailure(schemaYaml) shouldBe
+        """Unknown reference 'nope' at /slots/a/slot_group/""".stripMargin
+    }
+
     "resolve unique_key_slots against inherited attributes" in {
       load(
         s"""$schemaShared

--- a/schemaview/test/src/eu/neverblink/linkml/schemaview/SchemaValidatorSpec.scala
+++ b/schemaview/test/src/eu/neverblink/linkml/schemaview/SchemaValidatorSpec.scala
@@ -205,6 +205,93 @@ class SchemaValidatorSpec extends AnyWordSpec, Matchers {
       }
     }
 
+    "resolve unique_key_slots against the class's own attributes" in {
+      load(
+        s"""$schemaShared
+           |types:
+           |  string:
+           |    base: str
+           |classes:
+           |  SomeClass:
+           |    attributes:
+           |      a:
+           |        range: string
+           |      b:
+           |        range: string
+           |    unique_keys:
+           |      k:
+           |        unique_key_slots: [a, b]
+           |""".stripMargin,
+      )
+    }
+
+    "resolve unique_key_slots against inherited attributes" in {
+      load(
+        s"""$schemaShared
+           |types:
+           |  string:
+           |    base: str
+           |classes:
+           |  Base:
+           |    attributes:
+           |      inherited:
+           |        range: string
+           |  Mix:
+           |    mixin: true
+           |    attributes:
+           |      mixed:
+           |        range: string
+           |  SomeClass:
+           |    is_a: Base
+           |    mixins: [Mix]
+           |    unique_keys:
+           |      k:
+           |        unique_key_slots: [inherited, mixed]
+           |""".stripMargin,
+      )
+    }
+
+    "find unknown references in unique_key_slots" in {
+      val schemaYaml =
+        s"""$schemaShared
+           |types:
+           |  string:
+           |    base: str
+           |classes:
+           |  Unrelated:
+           |    attributes:
+           |      elsewhere:
+           |        range: string
+           |  SomeClass:
+           |    attributes:
+           |      a:
+           |        range: string
+           |    unique_keys:
+           |      k:
+           |        unique_key_slots: [typo, elsewhere]
+           |""".stripMargin
+      loadFailure(schemaYaml) shouldBe
+        """Unknown reference 'typo' at /classes/SomeClass/unique_keys/k/unique_key_slots/0/
+          |Unknown reference 'elsewhere' at /classes/SomeClass/unique_keys/k/unique_key_slots/1/""".stripMargin
+    }
+
+    "not let the unique_key_slots scope leak into a class's slots" in {
+      val schemaYaml =
+        s"""$schemaShared
+           |types:
+           |  string:
+           |    base: str
+           |classes:
+           |  SomeClass:
+           |    attributes:
+           |      a:
+           |        range: string
+           |    slots: [a]
+           |""".stripMargin
+      loadFailure(schemaYaml) shouldBe
+        """Unknown reference 'a' at /classes/SomeClass/slots/0/""".stripMargin
+    }
+
     "fail on ranges referencing slots" in {
       val schemaYaml =
         s"""$schemaShared

--- a/yaml/src/eu/neverblink/linkml/yaml/LinkmlYamlCodec.scala
+++ b/yaml/src/eu/neverblink/linkml/yaml/LinkmlYamlCodec.scala
@@ -455,7 +455,10 @@ private class LinkmlYamlCodecImpl(using Quotes) extends MacroUtils {
                     case n: Node.MappingNode =>
                       val kvs = LinkmlYamlCodec.getFields(n)
                       ${ genDecodeFields('kvs) }
-                    case _: Node.ScalarNode =>
+                    // Anything that is not a map is the SimpleDict form, where the node only has
+                    // the '@value' field set. It may be a sequence, since the primary value slot
+                    // can be multivalued.
+                    case _ =>
                       ${
                         var index = -1
                         classInfo.genNew(
@@ -488,7 +491,6 @@ private class LinkmlYamlCodecImpl(using Quotes) extends MacroUtils {
                           }.toList),
                         ).asExpr
                       }
-                    case n => LinkmlYamlCodec.decodeError("map, string or null value", n)
                   }
                 case _ =>
                   val kvs = $node match {
@@ -564,7 +566,13 @@ private class LinkmlYamlCodecImpl(using Quotes) extends MacroUtils {
         case '[ft] => genEncode[ft](fTpe, getter.asInstanceOf[Expr[ft]], fSkipId)
       }
     } else if (
-      fields.exists(_.kind == FieldKind.Id) && fields.exists(_.kind == FieldKind.Value) &&
+      fields.exists(_.kind == FieldKind.Id) &&
+      fields.exists(f =>
+        // The LinkML spec allows a multivalued primary value, but LinkML-Py only reads a
+        // collapsed sequence since 1.10.0, and its own dumper writes the full form anyway.
+        // Keep the full form for clarity.
+        f.kind == FieldKind.Value && !isCollectionTpe(f.resolvedTpe),
+      ) &&
       // A '@serializeDefault' field must always be written, so the class cannot collapse to the
       // compact (bare value) form. Decoding of that form stays supported either way.
       fields.forall(x =>

--- a/yaml/test/src/eu/neverblink/linkml/yaml/LinkmlYamlCodecSpec.scala
+++ b/yaml/test/src/eu/neverblink/linkml/yaml/LinkmlYamlCodecSpec.scala
@@ -433,7 +433,7 @@ class LinkmlYamlCodecSpec extends AnyWordSpec, Matchers, ScalaCheckPropertyCheck
           |^""".stripMargin,
       )
     }
-    "not use the collapsed form for simple dictionaries with a collection value" in {
+    "not use the SimpleDict form for dictionaries with a collection value" in {
       case class SeqEntry(@id k: String, @value v: Seq[String])
       case class MapEntry(@id k: String, @value v: Map[String, String])
 

--- a/yaml/test/src/eu/neverblink/linkml/yaml/LinkmlYamlCodecSpec.scala
+++ b/yaml/test/src/eu/neverblink/linkml/yaml/LinkmlYamlCodecSpec.scala
@@ -433,6 +433,47 @@ class LinkmlYamlCodecSpec extends AnyWordSpec, Matchers, ScalaCheckPropertyCheck
           |^""".stripMargin,
       )
     }
+    "not use the collapsed form for simple dictionaries with a collection value" in {
+      case class SeqEntry(@id k: String, @value v: Seq[String])
+      case class MapEntry(@id k: String, @value v: Map[String, String])
+
+      case class MyClass(
+          @simpleDict s: Map[String, SeqEntry] = Map(),
+          @simpleDict m: Map[String, MapEntry] = Map(),
+          x: Option[Int] = None,
+      ) derives LinkmlYamlCodec
+
+      roundTrip(
+        MyClass(s = Map("a" -> SeqEntry("a", Seq("x", "y")))),
+        """s:
+          |  a:
+          |    v:
+          |      - x
+          |      - y
+          |""".stripMargin,
+      )
+      roundTrip(
+        MyClass(m = Map("a" -> MapEntry("a", Map("x" -> "y")))),
+        """m:
+          |  a:
+          |    v:
+          |      x: y
+          |""".stripMargin,
+      )
+      // A collapsed sequence is still accepted on decode, as is a lone scalar
+      decode[MyClass](
+        """s:
+          |  a:
+          |    - x
+          |    - y
+          |""".stripMargin,
+        MyClass(s = Map("a" -> SeqEntry("a", Seq("x", "y")))),
+      )
+      decode[MyClass](
+        "s:\n  a: x\n",
+        MyClass(s = Map("a" -> SeqEntry("a", Seq("x")))),
+      )
+    }
     "decode and encode case classes with compact dictionaries" in {
       case class DictEntry(@id k: String, v: Int, e: Boolean)
 


### PR DESCRIPTION
- `unique_keys` was serialized in a form that we could not read and to be honest it's a little weird and even LinkML-Py older than 1.10 could not read it. So, I made it always serialize in the full form.
- Fixed the decoder to read both forms
- Fixed the JSON Schema generator to create any_of that permits both forms.
- The second issue is that if `unique_key` referenced attributes (not schema-level slots), the macro validator would fail because it doesn't see the class's attributes. I added extra context to handle it, also for some other metaslots that have this issue.


FUN LINKML FACT: there is a metaslot called `inverse` that refers to a slot of another class. This works if the slot is defined in the top-level (in the schema). After derivation, the slot goes into attributes, so we can't tell what `inverse` is pointing to anymore, and the schema becomes invalid and impossible to recover. FUN. I think this is just a fundamental logical flaw.