### PR TITLE
Fix round-tripping object-valued extensions

### DIFF
--- a/yaml/src/eu/neverblink/linkml/yaml/LinkmlYamlCodec.scala
+++ b/yaml/src/eu/neverblink/linkml/yaml/LinkmlYamlCodec.scala
@@ -414,7 +414,23 @@ private class LinkmlYamlCodecImpl(using Quotes) extends MacroUtils {
                   }
                 case v =>
                   ${
-                    Assign(Ref(valDef.symbol), genDecode[ft](fTpe, 'v, '{ None }).asTerm).asExpr
+                    val assign =
+                      Assign(Ref(valDef.symbol), genDecode[ft](fTpe, 'v, '{ None }).asTerm).asExpr
+                    // A class inlined in a dict has its id written twice: as the enclosing key and,
+                    // optionally, as a field of its own body. We raise an error if the two disagree.
+                    if (fieldInfo.kind == FieldKind.Id) {
+                      val fromBody = genDecode[ft](fTpe, 'v, '{ None })
+                      val fromKey = Ref(valDef.symbol).asExpr
+                      '{
+                        if ($id.isDefined && $fromBody != $fromKey) {
+                          LinkmlYamlCodec.decodeError(
+                            s"field '${$mappedName}' of '${$tpeName}' to match the enclosing key '${$id.get}'",
+                            v,
+                          )
+                        }
+                        $assign
+                      }
+                    } else assign
                   }
               }
             }.asTerm.changeOwner(Symbol.spliceOwner))
@@ -581,8 +597,7 @@ private class LinkmlYamlCodecImpl(using Quotes) extends MacroUtils {
         case '[ft] =>
           val encodeVal = genEncode[ft](fTpe, getter.asInstanceOf[Expr[ft]], fSkipId)
           '{
-            if ($skipId) $encodeVal
-            else {
+            def fullForm: Node = {
               val kvs = ListMap.newBuilder[
                 Node,
                 Node,
@@ -590,6 +605,12 @@ private class LinkmlYamlCodecImpl(using Quotes) extends MacroUtils {
               ${ genEncodeFields('kvs) }
               Node.MappingNode(kvs.result())
             }
+            if ($skipId) {
+              val collapsed = $encodeVal
+              // A map in the collapsed position cannot be distinguished from the full form when
+              // decoding (both are an object). So, for this case we always keep the full form.
+              if (collapsed.isInstanceOf[Node.MappingNode]) fullForm else collapsed
+            } else fullForm
           }
       }
     } else {

--- a/yaml/test/src/eu/neverblink/linkml/yaml/LinkmlYamlCodecSpec.scala
+++ b/yaml/test/src/eu/neverblink/linkml/yaml/LinkmlYamlCodecSpec.scala
@@ -674,6 +674,49 @@ class LinkmlYamlCodecSpec extends AnyWordSpec, Matchers, ScalaCheckPropertyCheck
       )
     }
 
+    "not use the collapsed form for a simple dictionary value that is a map at runtime" in {
+      case class Entry(@id k: String, @value v: LinkmlAny)
+
+      case class MyClass(@simpleDict d: Map[String, Entry], x: Option[Int] = None)
+          derives LinkmlYamlCodec
+
+      // 'LinkmlAny' is not statically a collection, so whether the collapsed form is safe can
+      // only be decided from the value.
+      roundTrip(
+        MyClass(Map("a" -> Entry("a", LinkmlAny("plain\n")))),
+        "d:\n  a: plain\n",
+      )
+      roundTrip(
+        MyClass(Map("a" -> Entry("a", LinkmlAny("- x\n- y\n")))),
+        "d:\n  a:\n    - x\n    - y\n",
+      )
+      // A map would be read back as the full form, so it keeps the 'v' wrapper
+      roundTrip(
+        MyClass(Map("a" -> Entry("a", LinkmlAny("m: 1\n")))),
+        "d:\n  a:\n    v:\n      m: 1\n",
+      )
+    }
+
+    "reject an id field that disagrees with the enclosing dict key" in {
+      case class Annotable(
+          @simpleDict
+          annotations: Map[String, Annotation],
+          x: Option[String] = None,
+      )
+      case class Annotation(@id tag: String, @value value: String)
+
+      implicit val codec: LinkmlYamlCodec[Annotable] = LinkmlYamlCodec.derived
+
+      decode[Annotable](
+        "annotations:\n  someTag:\n    tag: someTag\n    value: v\n",
+        Annotable(Map("someTag" -> Annotation("someTag", "v"))),
+      )
+      decodeError[Annotable](
+        "annotations:\n  someTag:\n    tag: other\n    value: v\n",
+        "Expected field 'tag' of 'Annotation' to match the enclosing key 'someTag'",
+      )
+    }
+
     "decode nested mixed simple/compact Dicts" in {
       case class Annotable(
           @simpleDict


### PR DESCRIPTION
**MERGE #223 FIRST, THEN REBASE THIS. Then it should pass.**

More fun bugs.

If we have an object-valued extension, so, something like:

```yaml
extensions:
  obj:
    tag: obj
    value:
      a: 1
      b: 2
```

this would get encoded as:

```yaml
extensions:
  obj:
    a: 1
    b: 2
```

which is bad, because we can't tell if we should parse this as the full form or the compact form (both are a JSON object). So, I made the encoder always use the full form in this case.

Somewhat relatedly, if we had:

```yaml
extensions:
  obj:
    tag: not_obj_hahaha
    value: whatever
```

then the tag has two different incoherent values. Now our decoder will throw on something like that (LinkML-Py does too).