### PR TITLE
Update scala-yaml to 0.3.19

### DIFF
--- a/build.mill
+++ b/build.mill
@@ -181,7 +181,7 @@ object yaml extends Module, NativeOptional {
 
   trait YamlModule extends CommonModule {
     def mvnDeps = Seq(
-      mvn"com.github.plokhotnyuk.scala-yaml::scala-yaml::0.3.18",
+      mvn"com.github.plokhotnyuk.scala-yaml::scala-yaml::0.3.19",
     )
   }
 }


### PR DESCRIPTION
Fixes redundant line feeds when serializing sequences with nested sequences or mappings