### PR TITLE
Ossie importer

### DIFF
--- a/build.mill
+++ b/build.mill
@@ -361,7 +361,7 @@ object schemaview extends Module, NativeOptional {
     )
 
     // fastparse's `rep`/`StringIn` macros trip -Xcheck-macros ("Expression created in a splice was
-    // used outside of that splice") on Scala 3.8. The generated parsers are correct -- it's a
+    // used outside of that splice") on Scala 3.9. The generated parsers are correct -- it's a
     // scope-tracking bug in fastparse's quotes, fixed upstream but unreleased (3.1.1 is latest).
     // Scoped to this module so the rest of the build keeps the check.
     override def scalacOptions = super.scalacOptions().filterNot(_ == "-Xcheck-macros")
@@ -539,6 +539,9 @@ object generator extends Module, NativeOptional {
       mvn"com.softwaremill.sttp.apispec::apispec-model::0.11.10",
       mvn"com.github.plokhotnyuk.jsoniter-scala::jsoniter-scala-macros::2.40.1",
     )
+
+    // Same fastparse macro bug as in SchemaViewModule
+    override def scalacOptions = super.scalacOptions().filterNot(_ == "-Xcheck-macros")
   }
 }
 

--- a/cli/src/eu/neverblink/linkml/cli/App.scala
+++ b/cli/src/eu/neverblink/linkml/cli/App.scala
@@ -38,6 +38,7 @@ final class App private[cli] (
     ErDiagram,
     Translation,
     Ossie,
+    FromOssie,
     Version,
   )
 

--- a/cli/src/eu/neverblink/linkml/cli/BaseCommand.scala
+++ b/cli/src/eu/neverblink/linkml/cli/BaseCommand.scala
@@ -4,7 +4,7 @@ import caseapp.*
 import eu.neverblink.linkml.schemaview.{SchemaIssues, SchemaView}
 import eu.neverblink.linkml.runtime.FastUtils.*
 
-import java.io.{ByteArrayOutputStream, PrintStream}
+import java.io.{ByteArrayOutputStream, OutputStream, PrintStream}
 
 /** Thrown instead of a real process exit when a command runs in test mode. */
 final case class ExitException(code: Int) extends RuntimeException
@@ -42,6 +42,18 @@ abstract class BaseCommand[T: {Parser, Help}] extends Command[T] {
           )
           err("Cannot load schema: " + formatted)
       }
+    }
+
+  /** Write to `file`, or to the command's stdout when there is none. */
+  protected final def writeToFileOrStdout(file: Option[String], write: OutputStream => Unit): Unit =
+    file.foldFast {
+      // `out` is the command's stdout (redirected in tests). Flush but never close it.
+      write(outStream)
+      outStream.flush()
+    } { value =>
+      val stream = os.write.over.outputStream(os.Path(value, os.pwd))
+      try write(stream)
+      finally stream.close()
     }
 
   /** Runs the whole CLI (via [[App]]) with the given args, capturing stdout and stderr. For tests

--- a/cli/src/eu/neverblink/linkml/cli/From.scala
+++ b/cli/src/eu/neverblink/linkml/cli/From.scala
@@ -1,0 +1,88 @@
+package eu.neverblink.linkml.cli
+
+import caseapp.*
+import eu.neverblink.linkml.generator.ossie.OssieImporter
+import eu.neverblink.linkml.generator.util.JsonOutputFormat
+
+import java.io.{InputStream, OutputStream}
+
+final case class FromOptions(
+    @HelpMessage(
+      "Destination file. If not specified, output will be written to stdout.",
+    )
+    to: Option[String] = None,
+)
+object FromOptions:
+  given Parser[FromOptions] = Parser.derive
+  given Help[FromOptions] = Help.derive
+
+trait HasFromOptions:
+  @Recurse
+  val common: FromOptions
+
+/** A `from <format>` command: reads a document in some other format and returns the corresponding
+  * LinkML schema. The opposite of `generate <name>`.
+  */
+abstract class From[T <: HasFromOptions: {Parser, Help}] extends BaseCommand[T] {
+  protected def formatName: String
+
+  /** Read the document from `in` and write the LinkML schema to `out`. */
+  protected def convert(options: T, in: InputStream, out: OutputStream): Unit
+
+  override final def group = "from"
+
+  final override def names: List[List[String]] = List(
+    List("from", formatName),
+  )
+
+  final override def run(options: T, remainingArgs: RemainingArgs): Unit =
+    val inputs = remainingArgs.remaining
+    if inputs.sizeIs > 1 then
+      err(
+        s"`from $formatName` takes a single input file, but ${inputs.size} were given: " +
+          s"${inputs.mkString(", ")}.",
+      )
+    val input = inputs.headOption.getOrElse(err("Input file is required."))
+    val path = os.Path(input, os.pwd)
+    if !os.exists(path) then err(s"No such file: $input")
+    val in = os.read.inputStream(path)
+    try writeToFileOrStdout(options.common.to, out => convert(options, in, out))
+    finally in.close()
+}
+
+// Ossie
+
+@HelpMessage(
+  "Read an Apache Ossie ontology and produce a corresponding LinkML schema.",
+)
+@ArgsName("<input-file>")
+final case class FromOssieOptions(
+    @Recurse
+    common: FromOptions,
+    @HelpMessage(
+      "The `id` of the schema to produce. The default " +
+        "is a placeholder built from the ontology's name.",
+    )
+    schemaId: Option[String] = None,
+    @HelpMessage(outputFormatHelp)
+    format: String = "yaml",
+) extends HasFromOptions
+
+object FromOssie extends From[FromOssieOptions] {
+  override protected def formatName: String = "ossie"
+
+  override protected def convert(
+      options: FromOssieOptions,
+      in: InputStream,
+      out: OutputStream,
+  ): Unit =
+    OssieImporter().writeTo(
+      in,
+      out,
+      OssieImporter.Options(
+        schemaId = options.schemaId,
+        outputFormat = JsonOutputFormat.parse(options.format)
+          .getOrElse(err(JsonOutputFormat.unknownFormat(options.format))),
+      ),
+    )
+}

--- a/cli/src/eu/neverblink/linkml/cli/Generate.scala
+++ b/cli/src/eu/neverblink/linkml/cli/Generate.scala
@@ -51,17 +51,6 @@ sealed abstract class Generate[T <: HasGenerateOptions: {Parser, Help}] extends 
         else writeToFileOrStdout(to, out => g.generateSingle(options, out)(using sv))
     }
 
-  private def writeToFileOrStdout(file: Option[String], write: OutputStream => Unit): Unit =
-    file.foldFast {
-      // `out` is the command's stdout (redirected in tests). Flush but never close it.
-      write(outStream)
-      outStream.flush()
-    } { value =>
-      val stream = os.write.over.outputStream(os.Path(value, os.pwd))
-      try write(stream)
-      finally stream.close()
-    }
-
   private def writeManyFiles(to: Option[String], files: Iterable[(String, String)]): Unit =
     if files.isEmpty then err("No files generated.")
     to.foldFast {

--- a/cli/src/eu/neverblink/linkml/cli/GenerateImpl.scala
+++ b/cli/src/eu/neverblink/linkml/cli/GenerateImpl.scala
@@ -185,8 +185,7 @@ private val outputFormatHelp: String =
 // LinkML -> LinkML
 
 @HelpMessage(
-  "Materialize a derived LinkML schema from a LinkML model. " +
-    "Resolves imports, derives classes, and prunes unreachable elements.",
+  "Materialize a derived LinkML schema from a LinkML model.",
 )
 @ArgsName("<input-file>")
 final case class LinkMlOptions(
@@ -221,11 +220,9 @@ object LinkMl extends StreamGenerate[LinkMlOptions] {
 
 @HelpMessage(
   "Generate a Frictionless Data Package from a LinkML model. " +
-    "Every class becomes a CSV table, described by its own Table Schema, and references between " +
-    "classes become foreign keys between the tables.\n" +
     "If --to is a directory, the package is written as a datapackage.json file plus one " +
     "schemas/<table>.json per table. If --to is a .json file, or with no --to at all, it is " +
-    "written as a single descriptor with every table schema inlined.",
+    "written as a single file with table schemas inlined.",
 )
 @ArgsName("<input-file>")
 final case class FrictionlessOptions(
@@ -266,7 +263,6 @@ object Frictionless extends SplitGenerate[FrictionlessOptions] {
 
 @HelpMessage(
   "Generate a GraphQL Schema from a LinkML model. " +
-    "Provides a @linkml_uri directive for all elements with an URI. " +
     "Only generates types/interfaces/scalar/enums, queries must be added manually.",
 )
 @ArgsName("<input-file>")
@@ -292,9 +288,7 @@ object GraphQl extends StreamGenerate[GraphQlOptions] {
 // Apache Ossie ontology
 
 @HelpMessage(
-  "Generate an Apache Ossie ontology from a LinkML model. " +
-    "Classes become entity types, enums and named types become value types, and slots become " +
-    "the relationships grouped under the concept that plays their first role.",
+  "Generate an Apache Ossie ontology from a LinkML model.",
 )
 @ArgsName("<input-file>")
 final case class OssieOptions(
@@ -360,7 +354,8 @@ object ErDiagram extends StreamGenerate[ErDiagramOptions] {
 }
 
 @HelpMessage(
-  "Generate translation dictionaries (in JSON), from the original names used in the schema to the names used in generated outputs.",
+  "Generate translation dictionaries (in JSON), " +
+    "from the original names used in the schema to the names used in generated outputs.",
 )
 @ArgsName("<input-file>")
 final case class TranslationOptions(

--- a/cli/test/src/eu/neverblink/linkml/cli/FromSpec.scala
+++ b/cli/test/src/eu/neverblink/linkml/cli/FromSpec.scala
@@ -1,0 +1,120 @@
+package eu.neverblink.linkml.cli
+
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
+
+import java.nio.file.Files
+
+class FromSpec extends AnyWordSpec, Matchers {
+
+  private val ontology =
+    """version: 0.2.0.dev0
+      |name: flights
+      |description: A tiny ontology.
+      |ontology:
+      |  - concept: Airport
+      |    type: EntityType
+      |    identify_by: [code]
+      |    relationships:
+      |      - name: code
+      |        roles: [{concept: String}]
+      |        multiplicity: OneToOne
+      |        verbalizes: ['{Airport} is identified by {String}']
+      |""".stripMargin
+
+  /** Write [[ontology]] to a temporary file and pass its path to the test. */
+  private def withOntology[A](document: String = ontology)(test: String => A): A = {
+    val file = Files.createTempFile("linkml-from", ".yaml")
+    Files.writeString(file, document)
+    try test(file.toString)
+    finally Files.deleteIfExists(file)
+  }
+
+  "from ossie" should {
+    "write the schema to stdout" in {
+      withOntology() { path =>
+        val (out, err, code) = FromOssie.runTestCommandWithExitCode(List("from", "ossie", path))
+        withClue(s"stderr was: $err\nstdout was: $out\n") {
+          code shouldBe 0
+          out should include("name: flights")
+          out should include("Airport:")
+          out should include("identifier: true")
+          out should include("title: is identified by")
+        }
+      }
+    }
+
+    "write JSON when asked to" in {
+      withOntology() { path =>
+        val (out, _, code) =
+          FromOssie.runTestCommandWithExitCode(List("from", "ossie", "--format", "json", path))
+        code shouldBe 0
+        out should startWith("{")
+        out should include("\"name\": \"flights\"")
+      }
+    }
+
+    "use the schema id it was given" in {
+      withOntology() { path =>
+        val (out, _, code) = FromOssie.runTestCommandWithExitCode(
+          List("from", "ossie", "--schema-id", "https://example.com/mine", path),
+        )
+        code shouldBe 0
+        out should include("id: https://example.com/mine")
+      }
+    }
+
+    "replace an existing file at --to" in {
+      withOntology() { path =>
+        val dest = os.temp(contents = "x" * 10_000, suffix = ".yaml")
+        val (_, err, code) = FromOssie.runTestCommandWithExitCode(
+          List("from", "ossie", "--to", dest.toString, path),
+        )
+        withClue(s"stderr was: $err\n")(code shouldBe 0)
+        val written = os.read(dest)
+        written should include("name: flights")
+        written should not include "xxxx"
+      }
+    }
+
+    "refuse more than one input" in {
+      withOntology() { path =>
+        val (_, err, code) =
+          FromOssie.runTestCommandWithExitCode(List("from", "ossie", path, path))
+        code shouldBe 1
+        err should include("single input file")
+      }
+    }
+
+    "say so when there is no input" in {
+      val (_, err, code) = FromOssie.runTestCommandWithExitCode(List("from", "ossie"))
+      code shouldBe 1
+      err should include("Input file is required.")
+    }
+
+    "say so when the file is not there" in {
+      val (_, err, code) =
+        FromOssie.runTestCommandWithExitCode(List("from", "ossie", "/no/such/file.yaml"))
+      code shouldBe 1
+      err should include("No such file")
+    }
+
+    "say so when the format is not one it writes" in {
+      withOntology() { path =>
+        val (_, err, code) =
+          FromOssie.runTestCommandWithExitCode(List("from", "ossie", "--format", "xml", path))
+        code shouldBe 1
+        err should include("xml")
+      }
+    }
+
+    "say so when the document is not an ontology" in {
+      withOntology("name: [unclosed") { path =>
+        val thrown = intercept[RuntimeException](
+          FromOssie.runTestCommandWithExitCode(List("from", "ossie", path)),
+        )
+        thrown.getMessage should include("Ossie ontology")
+      }
+    }
+  }
+}

--- a/docs/ossie_mapping.md
+++ b/docs/ossie_mapping.md
@@ -4,28 +4,30 @@ How the `ossie` generator and importer map between LinkML and [Apache Ossie](htt
 
 ## Document
 
-| Ossie field         | From LinkML                                    |
-|---------------------|------------------------------------------------|
-| `version`           | Hardcoded `0.2.0.dev0`                         |
-| `name`              | `name`                                         |
-| `description`       | `description`                                  |
-| `ontology`          | One component per class, enum, and named type. |
-| `ai_context`        | `extensions.ai_context`                        |
-| `requires`          | **Not emitted.**                               |
-| `ontology_mappings` | **Not emitted.**                               |
+| From LinkML                                    | Ossie field         | To LinkML     |
+|------------------------------------------------|---------------------|---------------|
+| Hardcoded `0.2.0.dev0`                         | `version`           | **Not read.** |
+| `name`                                         | `name`              | Inverse.      |
+| `description`                                  | `description`       | Inverse.      |
+| One component per class, enum, and named type. | `ontology`          | Inverse.      |
+| `extensions.ai_context`                        | `ai_context`        | Inverse.      |
+| **Not emitted.**                               | `requires`          | **Not read.** |
+| **Not emitted.**                               | `ontology_mappings` | **Not read.** |
+
+By default, the importer invents an identifier for the LinkML schema as `https://example.org/` + `name` in snake_case, unless the caller supplies it.
 
 ## Concept (`OntologyComponent`)
 
-| Ossie field     | From LinkML                                                                                                                                          |
-|-----------------|------------------------------------------------------------------------------------------------------------------------------------------------------|
-| `concept`       | Element name in PascalCase.                                                                                                                          |
-| `type`          | `EntityType` for classes, `ValueType` for enums and types.                                                                                           |
-| `description`   | Element `description`, in `--metadata-language`.                                                                                                     |
-| `extends`       | Classes: `is_a` + `mixins`. Enums and types: the built-in value type for their base.                                                                 |
-| `identify_by`   | `identifier`, `key`, or `unique_keys`                                                                                                                |
-| `requires`      | Required slots, as `Concept.relationship`. Enums: `Concept IN ('a', 'b')`. Named types also get their `minimum_value` / `maximum_value` / `pattern`. |
-| `relationships` | The class' derived slots, minus the ones stated identically in a supertype.                                                                          |
-| `derived_by`    | **Not emitted.**                                                                                                                                     |
+| From LinkML                                                                          | Ossie field     | To LinkML                                                                                                         |
+|--------------------------------------------------------------------------------------|-----------------|-------------------------------------------------------------------------------------------------------------------|
+| Element name in PascalCase.                                                          | `concept`       | Inverse. Original spelling kept in `alias`.                                                                       |
+| `EntityType` for classes, `ValueType` for enums and types.                           | `type`          | Inverse.                                                                                                          |
+| Element `description`, in `--metadata-language`.                                     | `description`   | Inverse.                                                                                                          |
+| Classes: `is_a` + `mixins`. Enums and types: the built-in value type for their base. | `extends`       | Last entry is `is_a`, the rest are `mixins`. For a value type it is `typeof`, or `string` if the base is unknown. |
+| `identifier`, `key`, or `unique_keys`                                                | `identify_by`   | One entry, `OneToOne`, or scalar range → `identifier`. Otherwise `unique_keys`.                                   |
+| Required slots: `Concept.relationship`. Enums and named types: see Expressions.      | `requires`      | Inverse. Any other restriction is ignored.                                                                        |
+| The class' derived slots, minus the ones stated identically in a supertype.          | `relationships` | One attribute each.                                                                                               |
+| **Not emitted.**                                                                     | `derived_by`    | **Not read.**                                                                                                     |
 
 Abstract classes and mixins become ordinary concepts – Ossie has no abstract elements.
 
@@ -35,15 +37,15 @@ A subtype only declares what it does not inherit unchanged. If it narrows a slot
 
 One per derived slot of the class. Identified as `Concept.name`, so names only need to be unique within their concept.
 
-| Ossie field    | From LinkML                                                                        |
-|----------------|------------------------------------------------------------------------------------|
-| `name`         | Slot `alias`, else slot name in snake_case.                                        |
-| `verbalizes`   | `{Concept} <title or space-case name> {Range}`                                     |
-| `description`  | Slot `description`, in `--metadata-language`.                                      |
-| `roles`        | Always exactly one, played by the slot's range concept.                            |
-| `multiplicity` | Single-valued identifier/key slot → `OneToOne`. Other single-valued → `ManyToOne`. |
-| `requires`     | Slot `minimum_value` / `maximum_value` / `pattern`, as expressions over the role.  |
-| `derived_by`   | **Not emitted.**                                                                   |
+| From LinkML                                                                       | Ossie field    | To LinkML                                                      |
+|-----------------------------------------------------------------------------------|----------------|----------------------------------------------------------------|
+| Slot `alias`, else slot name in snake_case.                                       | `name`         | Slot name in snake_case, original spelling in `alias`.         |
+| `{Concept} <title or space-case name> {Range}`                                    | `verbalizes`   | **Not read.**                                                  |
+| Slot `description`, in `--metadata-language`.                                     | `description`  | Inverse.                                                       |
+| Always exactly one, played by the slot's range concept.                           | `roles`        | The first role's concept is the range. Any others are dropped. |
+| Single-valued identifier/key slot → `OneToOne`. Others → `ManyToOne`.             | `multiplicity` | Absent → `multivalued: true`.                                  |
+| Slot `minimum_value` / `maximum_value` / `pattern`, as expressions over the role. | `requires`     | Inverse.                                                       |
+| **Not emitted.**                                                                  | `derived_by`   | **Not read.**                                                  |
 
 ### Roles
 
@@ -54,22 +56,33 @@ range is its own class. `Person.parent_of` becomes `roles: [{concept: Person, na
 
 Primitive LinkML types map straight onto Ossie's built-in concepts:
 
-| LinkML                                           | Ossie      |
-|--------------------------------------------------|------------|
-| `string`, `uri`, `uriorcurie`, `curie`, `ncname` | `String`   |
-| `integer`                                        | `Integer`  |
-| `float`, `double`                                | `Float`    |
-| `decimal`                                        | `Decimal`  |
-| `boolean`                                        | `Boolean`  |
-| `date`                                           | `Date`     |
-| `datetime`                                       | `DateTime` |
-| `time`                                           | `String`   |
-| localized text                                   | `String`   |
-| `linkml:Any`, unknown base                       | `Any`      |
+| From LinkML                                      | Ossie      | To LinkML                            |
+|--------------------------------------------------|------------|--------------------------------------|
+| `string`, `uri`, `uriorcurie`, `curie`, `ncname` | `String`   | `string`                             |
+| `integer`                                        | `Integer`  | `integer`                            |
+| `float`, `double`                                | `Float`    | `float`                              |
+| `decimal`                                        | `Decimal`  | `decimal`                            |
+| `boolean`                                        | `Boolean`  | `boolean`                            |
+| `date`                                           | `Date`     | `date`                               |
+| `datetime`                                       | `DateTime` | `datetime`                           |
+| `time`                                           | `String`   | `string`                             |
+| localized text                                   | `String`   | `string`                             |
+| `linkml:Any`, unknown base                       | `Any`      | A class with `class_uri: linkml:Any` |
+
+Several LinkML types share one Ossie concept, so the last column is not the inverse of the first: a `uri` comes back as a `string`, and a `double` as a `float`.
 
 A non-primitive LinkML type becomes its own `ValueType` concept extending a built-in.
 
 An **enum** becomes a `ValueType` extending `String`, with its permissible values as a `requires` expression. Enum inheritance and dynamic enums are not mapped.
+
+## Expressions
+
+| From LinkML                      | Ossie                   | To LinkML |
+|----------------------------------|-------------------------|-----------|
+| `required: true`                 | `Concept.relationship`  | Inverse.  |
+| `permissible_values`             | `Ref IN ('a', 'b')`     | Inverse.  |
+| `minimum_value`, `maximum_value` | `Ref >= v`, `Ref <= v`  | Inverse.  |
+| `pattern`                        | `REGEXP_LIKE(Ref, 'p')` | Inverse.  |
 
 ## Not mapped from LinkML
 

--- a/docs/ossie_mapping.md
+++ b/docs/ossie_mapping.md
@@ -37,15 +37,16 @@ A subtype only declares what it does not inherit unchanged. If it narrows a slot
 
 One per derived slot of the class. Identified as `Concept.name`, so names only need to be unique within their concept.
 
-| From LinkML                                                                       | Ossie field    | To LinkML                                                      |
-|-----------------------------------------------------------------------------------|----------------|----------------------------------------------------------------|
-| Slot `alias`, else slot name in snake_case.                                       | `name`         | Slot name in snake_case, original spelling in `alias`.         |
-| `{Concept} <title or space-case name> {Range}`                                    | `verbalizes`   | **Not read.**                                                  |
-| Slot `description`, in `--metadata-language`.                                     | `description`  | Inverse.                                                       |
-| Always exactly one, played by the slot's range concept.                           | `roles`        | The first role's concept is the range. Any others are dropped. |
-| Single-valued identifier/key slot → `OneToOne`. Others → `ManyToOne`.             | `multiplicity` | Absent → `multivalued: true`.                                  |
-| Slot `minimum_value` / `maximum_value` / `pattern`, as expressions over the role. | `requires`     | Inverse.                                                       |
-| **Not emitted.**                                                                  | `derived_by`   | **Not read.**                                                  |
+| From LinkML                                                                       | Ossie field            | To LinkML                                                                                            |
+|-----------------------------------------------------------------------------------|------------------------|------------------------------------------------------------------------------------------------------|
+| Slot `alias`, else slot name in snake_case.                                       | `name`                 | Slot name in snake_case, original spelling in `alias`.                                               |
+| `{Concept} <title or space-case name> {Range}`                                    | `verbalizes`           | The phrase becomes the slot `title`, unless it is just the space-cased name. Only the first is read. |
+| Slot `description`, in `--metadata-language`.                                     | `description`          | Inverse.                                                                                             |
+| Always exactly one, played by the slot's range concept.                           | `roles`                | The first role's concept is the range. Any others are dropped.                                       |
+| Single-valued identifier/key slot → `OneToOne`. Others → `ManyToOne`.             | `multiplicity`         | Absent → `multivalued: true`.                                                                        |
+| Slot `minimum_value` / `maximum_value` / `pattern`, as expressions over the role. | `requires`             | Inverse.                                                                                             |
+| **Not emitted.**                                                                  | `derived_by`           | **Not read.**                                                                                        |
+| `rank` of the slot                                                                | *(relationship order)* | Inverse.                                                                                             |
 
 ### Roles
 

--- a/docs/ossie_mapping.md
+++ b/docs/ossie_mapping.md
@@ -1,6 +1,6 @@
-# LinkML → Apache Ossie ontology mapping
+# LinkML <-> Apache Ossie ontology mapping
 
-How the `ossie` generator maps LinkML onto [Apache Ossie](https://github.com/apache/ossie) ontology spec (`ontology/ontology.json`, version `0.2.0.dev0`).
+How the `ossie` generator and importer map between LinkML and [Apache Ossie](https://github.com/apache/ossie) ontologies (`ontology/ontology.json`, version `0.2.0.dev0`).
 
 ## Document
 
@@ -38,7 +38,7 @@ One per derived slot of the class. Identified as `Concept.name`, so names only n
 | Ossie field    | From LinkML                                                                        |
 |----------------|------------------------------------------------------------------------------------|
 | `name`         | Slot `alias`, else slot name in snake_case.                                        |
-| `verbalizes`   | `{Concept} <space-case name> {Range}`                                              |
+| `verbalizes`   | `{Concept} <title or space-case name> {Range}`                                     |
 | `description`  | Slot `description`, in `--metadata-language`.                                      |
 | `roles`        | Always exactly one, played by the slot's range concept.                            |
 | `multiplicity` | Single-valued identifier/key slot → `OneToOne`. Other single-valued → `ManyToOne`. |
@@ -76,7 +76,7 @@ An **enum** becomes a `ValueType` extending `String`, with its permissible value
 Ossie does not support arbitrary extensions, so the following LinkML features are not mapped:
 
 - URIs and CURIEs of any kind (`class_uri`, `slot_uri`, `prefixes`)
-- `title`, `deprecated`, `annotations`, `extensions`, `subsets`, `see_also` and other metadata
+- `deprecated`, `annotations`, `extensions`, `subsets`, `see_also` and other metadata
 - `unit`, `default` / `ifabsent`, `recommended`
 - Cardinality counts (`minimum_cardinality`, `maximum_cardinality`)
 - `rules`, `any_of` / `all_of` / `none_of` / `exactly_one_of`

--- a/docs/python_bindings.md
+++ b/docs/python_bindings.md
@@ -54,7 +54,7 @@ All three take `infer_messages=True`, which fills in each issue's human-readable
 Fatal problems raise `SchemaLoadError`, which carries the report as `.report`. Errors and warnings do
 not: a schema can load and still have things to say about it.
 
-### Generating
+### Generating from LinkML
 
 ```python
 schema.json_schema(open=False, tree_root=None, tree_root_inline_type=None, indentation_step=2)
@@ -75,7 +75,15 @@ which return a filename-to-content dict.
 `shacl()` and `rdfs()` take a `format`: `"ttl"` for Turtle, the default, which is prefixed and
 pretty-printed, or `"nt"` for N-Triples.
 
-**These are generated, not written.** Each method mirrors the `Options` case class of the generator it calls – `ShaclGenerator.Options` and so on – so the names, types, defaults and docstrings are whatever the Scala declares. See [`mill-build/src/PyBindingsGen.scala`](../mill-build/src/PyBindingsGen.scala).
+### Converting to LinkML
+
+We currently support one importer for Apache Ossie (incubating) ontologies:
+
+```python
+linkml_scala.from_ossie(ontology, schema_id=None, output_format="yaml")
+```
+
+It returns the LinkML schema as a string. Pass that to `load_string()` to run a generator over it.
 
 ### Validating
 

--- a/generator/npm/README.md
+++ b/generator/npm/README.md
@@ -87,6 +87,7 @@ Load a schema into a `SchemaView` handle (see above), then pass that handle to a
 | `translation(view, target)`                                                  | `string`                 | Translation dictionary for generator outputs                                   |
 | `lint(view, inferMessages?)`                                                 | `object`                 | `SchemaValidationReport` (JSON)                                                |
 | `buildInfo()`                                                                | `object`                 | `BuildInfo` (JSON) – version and build metadata                                |
+| `fromOssie(ontology, schemaId?, outFormat?)`                                 | `string`                 | the LinkML schema from an Apache Ossie ontology                                |
 
 See [`index.d.ts`](./index.d.ts) for full type signatures.
 

--- a/generator/src-js/eu/neverblink/linkml/js/LinkMlJsApi.scala
+++ b/generator/src-js/eu/neverblink/linkml/js/LinkMlJsApi.scala
@@ -3,7 +3,7 @@ package eu.neverblink.linkml.js
 import eu.neverblink.linkml.generator.erdiagram.ErDiagramGenerator
 import eu.neverblink.linkml.generator.graphql.GraphQlGenerator
 import eu.neverblink.linkml.generator.jsonschema.JsonSchemaGenerator
-import eu.neverblink.linkml.generator.ossie.OssieGenerator
+import eu.neverblink.linkml.generator.ossie.{OssieGenerator, OssieImporter}
 import eu.neverblink.linkml.generator.rdf.RdfFormat
 import eu.neverblink.linkml.generator.scala.ScalaGenerator
 import eu.neverblink.linkml.generator.shacl.ShaclGenerator
@@ -453,6 +453,34 @@ object LinkMlJsApi {
       ),
     )
   }
+
+  /** Read an Apache Ossie ontology and produce the LinkML schema it describes.
+    *
+    * The opposite of [[ossie]]. Feed the result to [[loadFromString]]
+    * if you want to run a generator over it.
+    *
+    * @param ontology
+    *   The ontology document, as YAML or JSON.
+    * @param schemaId
+    *   The `id` of the schema to produce. An Ossie ontology has none of its own, so by default it
+    *   is a placeholder built from the ontology's name.
+    * @param outFormat
+    *   Output serialization format to use. One of yaml|json. Default: yaml
+    * @return
+    *   The LinkML schema, serialized in the specified format.
+    */
+  def fromOssie(
+      ontology: String,
+      schemaId: js.UndefOr[String] = js.undefined,
+      outFormat: String = "yaml",
+  ): String =
+    OssieImporter().serializeFromString(
+      ontology,
+      OssieImporter.Options(
+        schemaId = schemaId.toOption,
+        outputFormat = outputFormat(outFormat),
+      ),
+    )
 
   /** Lint a loaded LinkML schema, finding problems that may cause issues when using the model. This
     * method returns a structured JSON that follows the validation-report.yaml model.

--- a/generator/src-js/eu/neverblink/linkml/js/LinkMlJsApi.scala
+++ b/generator/src-js/eu/neverblink/linkml/js/LinkMlJsApi.scala
@@ -456,8 +456,8 @@ object LinkMlJsApi {
 
   /** Read an Apache Ossie ontology and produce the LinkML schema it describes.
     *
-    * The opposite of [[ossie]]. Feed the result to [[loadFromString]]
-    * if you want to run a generator over it.
+    * The opposite of [[ossie]]. Feed the result to [[loadFromString]] if you want to run a
+    * generator over it.
     *
     * @param ontology
     *   The ontology document, as YAML or JSON.

--- a/generator/src/eu/neverblink/linkml/generator/SchemaImporter.scala
+++ b/generator/src/eu/neverblink/linkml/generator/SchemaImporter.scala
@@ -1,0 +1,59 @@
+package eu.neverblink.linkml.generator
+
+import eu.neverblink.linkml.generator.util.{JsonOutputFormat, JsonUtil}
+import eu.neverblink.linkml.metamodel.{Codec, SchemaDefinitionImpl}
+
+import java.io.{ByteArrayInputStream, ByteArrayOutputStream, InputStream, OutputStream}
+import java.nio.charset.StandardCharsets.UTF_8
+
+/** Reads a document in some other format and produces a LinkML schema - more-or-less the opposite
+  * of a [[DocumentGenerator]].
+  *
+  * The result is a [[SchemaDefinitionImpl]].
+  *
+  * @tparam O
+  *   the importer's own `Options` type
+  */
+trait SchemaImporter[O <: SchemaImporter.Options] {
+
+  /** Options to use when the caller does not pass any. */
+  protected def defaultOptions: O
+
+  /** Read a document from `in` and build the LinkML schema it describes.
+    *
+    * Does not close the input stream, because the caller may have more to read from it.
+    */
+  def importSchema(in: InputStream, options: O = defaultOptions): SchemaDefinitionImpl
+
+  /** Read a document that is already in memory. */
+  final def importSchemaFromString(
+      input: String,
+      options: O = defaultOptions,
+  ): SchemaDefinitionImpl =
+    importSchema(ByteArrayInputStream(input.getBytes(UTF_8)), options)
+
+  /** The schema as a LinkML document. Prefer [[writeTo]] where an output stream exists. */
+  final def serialize(in: InputStream, options: O = defaultOptions): String =
+    JsonUtil.write(Codec.codec.encode(importSchema(in, options)), options.outputFormat)
+
+  /** Write the schema to `out`. Flushes, but closes neither stream. */
+  final def writeTo(in: InputStream, out: OutputStream, options: O = defaultOptions): Unit =
+    JsonUtil.write(Codec.codec.encode(importSchema(in, options)), options.outputFormat, out)
+
+  protected final def readUtf8(in: InputStream): String = {
+    val buffer = ByteArrayOutputStream()
+    val chunk = new Array[Byte](8 * 1024)
+    var n = in.read(chunk)
+    while n >= 0 do {
+      buffer.write(chunk, 0, n)
+      n = in.read(chunk)
+    }
+    String(buffer.toByteArray, UTF_8)
+  }
+}
+
+object SchemaImporter {
+  trait Options {
+    def outputFormat: JsonOutputFormat
+  }
+}

--- a/generator/src/eu/neverblink/linkml/generator/SchemaImporter.scala
+++ b/generator/src/eu/neverblink/linkml/generator/SchemaImporter.scala
@@ -36,6 +36,13 @@ trait SchemaImporter[O <: SchemaImporter.Options] {
   final def serialize(in: InputStream, options: O = defaultOptions): String =
     JsonUtil.write(Codec.codec.encode(importSchema(in, options)), options.outputFormat)
 
+  /** The same, for a document that is already in memory. */
+  final def serializeFromString(input: String, options: O = defaultOptions): String =
+    JsonUtil.write(
+      Codec.codec.encode(importSchemaFromString(input, options)),
+      options.outputFormat,
+    )
+
   /** Write the schema to `out`. Flushes, but closes neither stream. */
   final def writeTo(in: InputStream, out: OutputStream, options: O = defaultOptions): Unit =
     JsonUtil.write(Codec.codec.encode(importSchema(in, options)), options.outputFormat, out)

--- a/generator/src/eu/neverblink/linkml/generator/linkml/LinkMlGenerator.scala
+++ b/generator/src/eu/neverblink/linkml/generator/linkml/LinkMlGenerator.scala
@@ -1,11 +1,10 @@
 package eu.neverblink.linkml.generator.linkml
 
 import eu.neverblink.linkml.generator.DocumentGenerator
-import eu.neverblink.linkml.generator.util.JsonOutputFormat.{json, yaml}
-import eu.neverblink.linkml.generator.util.{JsonUtil, JsonOutputFormat, PruningMode, Utf8ByteSink}
+import eu.neverblink.linkml.generator.util.JsonOutputFormat.yaml
+import eu.neverblink.linkml.generator.util.{JsonUtil, JsonOutputFormat, PruningMode}
 import eu.neverblink.linkml.metamodel.*
 import eu.neverblink.linkml.schemaview.SchemaView
-import org.virtuslab.yaml.NodeOps
 
 import java.io.OutputStream
 
@@ -97,30 +96,15 @@ class LinkMlGenerator(using sv: SchemaView) extends DocumentGenerator[LinkMlGene
     */
   override def serialize(
       options: LinkMlGenerator.Options = LinkMlGenerator.Options(),
-  ): String = {
-    val node = Codec.codec.encode(generate(options))
-    if (options.outputFormat == json) JsonUtil.yamlToJson(node)
-    else node.asYaml
-  }
+  ): String =
+    JsonUtil.write(Codec.codec.encode(generate(options)), options.outputFormat)
 
-  /** Generate a derived [[SchemaDefinition]] and write it to [[out]].
-    *
-    * JSON goes straight out through jsoniter. YAML still builds the whole document as a string
-    * first, because scala-yaml's writer has no streaming form. This could be improved in the future
-    * to reduce peak memory usage.
-    */
+  /** Generate a derived [[SchemaDefinition]] and write it to [[out]]. */
   override def writeTo(
       out: OutputStream,
       options: LinkMlGenerator.Options = LinkMlGenerator.Options(),
-  ): Unit = {
-    val node = Codec.codec.encode(generate(options))
-    if (options.outputFormat == json) JsonUtil.writeJson(node, out)
-    else {
-      val sink = new Utf8ByteSink(out)
-      sink.append(node.asYaml)
-      sink.flush()
-    }
-  }
+  ): Unit =
+    JsonUtil.write(Codec.codec.encode(generate(options)), options.outputFormat, out)
 }
 
 object LinkMlGenerator {

--- a/generator/src/eu/neverblink/linkml/generator/ossie/OssieGenerator.scala
+++ b/generator/src/eu/neverblink/linkml/generator/ossie/OssieGenerator.scala
@@ -1,13 +1,13 @@
 package eu.neverblink.linkml.generator.ossie
 
 import eu.neverblink.linkml.generator.DocumentGenerator
-import eu.neverblink.linkml.generator.util.JsonOutputFormat.{json, yaml}
-import eu.neverblink.linkml.generator.util.{JsonOutputFormat, JsonUtil, PruningMode, Utf8ByteSink}
+import eu.neverblink.linkml.generator.util.JsonOutputFormat.yaml
+import eu.neverblink.linkml.generator.ossie.expression.{Constraints, Expression, Literal, Ref}
+import eu.neverblink.linkml.generator.util.{JsonOutputFormat, JsonUtil, PruningMode}
 import eu.neverblink.linkml.metamodel.Extensible
-import eu.neverblink.linkml.runtime.LinkmlAny
 import eu.neverblink.linkml.runtime.FastUtils.*
 import eu.neverblink.linkml.schemaview.*
-import org.virtuslab.yaml.{Node, NodeOps, parseYaml}
+import org.virtuslab.yaml.{Node, parseYaml}
 
 import java.io.OutputStream
 import scala.collection.mutable
@@ -78,23 +78,11 @@ class OssieGenerator(using sv: SchemaView)
       .find(_.extensionTag.original == "ai_context")
       .flatMap(ext => parseYaml(ext.extensionValue.toString).toOption)
 
-  override def serialize(options: Options = Options()): String = {
-    val node = OssieOntology.codec.encode(generate(options))
-    if options.outputFormat == json then JsonUtil.yamlToJson(node)
-    else node.asYaml
-  }
+  override def serialize(options: Options = Options()): String =
+    JsonUtil.write(OssieOntology.codec.encode(generate(options)), options.outputFormat)
 
-  /** JSON streams out through jsoniter. YAML builds the whole string first.
-    */
-  override def writeTo(out: OutputStream, options: Options = Options()): Unit = {
-    val node = OssieOntology.codec.encode(generate(options))
-    if options.outputFormat == json then JsonUtil.writeJson(node, out)
-    else {
-      val sink = new Utf8ByteSink(out)
-      sink.append(node.asYaml)
-      sink.flush()
-    }
-  }
+  override def writeTo(out: OutputStream, options: Options = Options()): Unit =
+    JsonUtil.write(OssieOntology.codec.encode(generate(options)), options.outputFormat, out)
 
   /** A class, plus the relationships it declares rather than inherits. */
   private def classConcept(
@@ -114,7 +102,8 @@ class OssieGenerator(using sv: SchemaView)
         .flatMap(slot => declared(cv.name).find(_.slotName == slot))
         .map(_.relationship.name),
       // Only this concept's own required relationships - a supertype already states its own.
-      requires = own.filter(_.required).map(r => s"$name.${r.relationship.name}"),
+      requires =
+        own.filter(_.required).map(r => Expression.Member(Ref(name), r.relationship.name).render),
       relationships = own.map(_.relationship),
     )
   }
@@ -210,7 +199,7 @@ class OssieGenerator(using sv: SchemaView)
       extendsConcepts = Seq(BuiltInConcept.string),
       requires =
         if values.isEmpty then Nil
-        else Seq(s"$name IN (${values.map(sqlLiteral).mkString(", ")})"),
+        else Seq(Expression.InList(Ref(name), values.map(Literal.Text.apply)).render),
     )
   }
 
@@ -221,12 +210,11 @@ class OssieGenerator(using sv: SchemaView)
       conceptType = ConceptType.ValueType,
       description = tv._type.description.flatMapFast(_.inLanguage(options.metadataLanguage)),
       extendsConcepts = Seq(builtInForType(tv)),
-      requires = constraints(
-        name,
+      requires = Constraints(
         tv._type.minimumValue,
         tv._type.maximumValue,
         tv._type.pattern,
-      ),
+      ).render(Ref(name)).map(_.render),
     )
 
   /** The value constraints the slot itself adds, as expressions over the role that corresponds to
@@ -239,42 +227,10 @@ class OssieGenerator(using sv: SchemaView)
   private def slotConstraints(av: AttributeView, ref: String): Seq[String] = av match {
     case _: TypeAttributeView | _: EnumAttributeView =>
       val slot = av.slotView.slot
-      constraints(ref, slot.minimumValue, slot.maximumValue, slot.pattern)
+      Constraints(slot.minimumValue, slot.maximumValue, slot.pattern)
+        .render(Ref(ref))
+        .map(_.render)
     case _ => Nil
-  }
-
-  private def constraints(
-      ref: String,
-      minimum: Option[LinkmlAny],
-      maximum: Option[LinkmlAny],
-      pattern: Option[String],
-  ): Seq[String] = {
-    val out = Seq.newBuilder[String]
-    minimum.flatMap(bound).foreachFast(v => out += s"$ref >= $v")
-    maximum.flatMap(bound).foreachFast(v => out += s"$ref <= $v")
-    pattern.foreachFast(p => out += s"REGEXP_LIKE($ref, ${sqlLiteral(p)})")
-    out.result()
-  }
-
-  /** Make an Ossie value bound out of a LinkML value, or None if it cannot be expressed. This is
-    * used in the constraint expressions.
-    */
-  private def bound(value: LinkmlAny): Option[String] = {
-    val raw = value.value.strip()
-    val unquoted =
-      if raw.length >= 2 && (raw.head == '"' || raw.head == '\'') && raw.last == raw.head then
-        raw.substring(1, raw.length - 1)
-      else raw
-    if unquoted.isEmpty || unquoted.exists(c => c == '\n' || c == '\r') then None
-    else
-      Some(
-        try {
-          BigDecimal(unquoted)
-          unquoted
-        } catch {
-          case _: NumberFormatException => sqlLiteral(unquoted)
-        },
-      )
   }
 
   /** The concept that plays the role in the range of a slot. */
@@ -355,8 +311,4 @@ object OssieGenerator {
     case _: AnyType.type => BuiltInConcept.any
     case _: UnknownType.type => BuiltInConcept.any
   }
-
-  /** A single-quoted SQL string literal. */
-  private def sqlLiteral(value: String): String = s"'${value.replace("'", "''")}'"
-
 }

--- a/generator/src/eu/neverblink/linkml/generator/ossie/OssieGenerator.scala
+++ b/generator/src/eu/neverblink/linkml/generator/ossie/OssieGenerator.scala
@@ -2,7 +2,13 @@ package eu.neverblink.linkml.generator.ossie
 
 import eu.neverblink.linkml.generator.DocumentGenerator
 import eu.neverblink.linkml.generator.util.JsonOutputFormat.yaml
-import eu.neverblink.linkml.generator.ossie.expression.{Constraints, Expression, Literal, Ref}
+import eu.neverblink.linkml.generator.ossie.expression.{
+  Constraints,
+  Expression,
+  Literal,
+  Ref,
+  Verbalization,
+}
 import eu.neverblink.linkml.generator.util.{JsonOutputFormat, JsonUtil, PruningMode}
 import eu.neverblink.linkml.metamodel.Extensible
 import eu.neverblink.linkml.runtime.FastUtils.*
@@ -161,7 +167,6 @@ class OssieGenerator(using sv: SchemaView)
       // Ossie then requires a role name to tell the two roles apart.
       val selfReference = range == conceptName
       val role = Role(range, if selfReference then Some(name) else None)
-      val target = if selfReference then s"{$range:$name}" else s"{$range}"
 
       val multiplicity =
         if slot.multivalued then None
@@ -172,12 +177,16 @@ class OssieGenerator(using sv: SchemaView)
         relationship = Relationship(
           name = name,
           // Ossie requires at least one verbalization.
-          verbalizes = {
-            // Title or space-cased slot name
-            val title = slot.title.flatMapFast(_.inLanguage(options.metadataLanguage))
-              .getOrElse(Case.base(name).replace('_', ' '))
-            Seq(s"{$conceptName} $title $target")
-          },
+          verbalizes = Seq(
+            Verbalization(
+              Ref(conceptName),
+              // Title or space-cased slot name
+              slot.title.flatMapFast(_.inLanguage(options.metadataLanguage))
+                .getOrElse(Case.base(name).replace('_', ' ')),
+              Ref(range),
+              Option.when(selfReference)(name),
+            ).render,
+          ),
           description = slot.description.flatMapFast(_.inLanguage(options.metadataLanguage)),
           roles = Seq(role),
           multiplicity = multiplicity,

--- a/generator/src/eu/neverblink/linkml/generator/ossie/OssieImporter.scala
+++ b/generator/src/eu/neverblink/linkml/generator/ossie/OssieImporter.scala
@@ -1,0 +1,254 @@
+package eu.neverblink.linkml.generator.ossie
+
+import eu.neverblink.linkml.generator.SchemaImporter
+import eu.neverblink.linkml.generator.ossie.expression.{Constraints, Expression, Ref}
+import eu.neverblink.linkml.generator.util.JsonOutputFormat
+import eu.neverblink.linkml.generator.util.JsonOutputFormat.yaml
+import eu.neverblink.linkml.metamodel.*
+import eu.neverblink.linkml.runtime.{LinkmlAny, PlainText, Reference, Uri, UriOrCurie}
+import eu.neverblink.linkml.schemaview.Case
+import org.virtuslab.yaml.{NodeOps, parseYaml}
+
+import java.io.InputStream
+
+import scala.collection.immutable.VectorMap
+
+/** Reads an Apache Ossie (incubating) ontology and produces a LinkML schema. */
+class OssieImporter extends SchemaImporter[OssieImporter.Options] {
+
+  import OssieImporter.*
+
+  override protected def defaultOptions: Options = Options()
+
+  override def importSchema(in: InputStream, options: Options = Options()): SchemaDefinitionImpl =
+    Conversion(decode(readUtf8(in)), options).schema
+
+  /** Parse and decode an ontology document. Accepts JSON too, since JSON is YAML. */
+  private def decode(input: String): OssieOntology =
+    parseYaml(input) match {
+      case Right(node) => OssieOntology.codec.decode(node)
+      case Left(error) => throw RuntimeException(s"Not a readable Ossie ontology: ${error.msg}")
+    }
+}
+
+object OssieImporter {
+
+  /** Options for [[OssieImporter]].
+    *
+    * @param schemaId
+    *   The `id` of the schema to produce. By default it is a placeholder built from the ontology's
+    *   name.
+    * @param outputFormat
+    *   Output serialization format to use.
+    */
+  final case class Options(
+      schemaId: Option[String] = None,
+      outputFormat: JsonOutputFormat = yaml,
+  ) extends SchemaImporter.Options
+
+  /** The LinkML type behind each of Ossie's built-in value types. */
+  private val linkmlTypes: Map[String, String] = Map(
+    BuiltInConcept.boolean -> "boolean",
+    BuiltInConcept.date -> "date",
+    BuiltInConcept.dateTime -> "datetime",
+    BuiltInConcept.decimal -> "decimal",
+    BuiltInConcept.float -> "float",
+    BuiltInConcept.integer -> "integer",
+    BuiltInConcept.string -> "string",
+    BuiltInConcept.any -> "string", // TODO: decide what to do with Any as a type...
+  )
+
+  /** The class standing in for Ossie's `Any`, declared only when something actually refers to it.
+    */
+  private val anyClass = "Any"
+
+  /** Ossie's `identify_by` key has no name of its own, so a compound key one is named after the
+    * field.
+    */
+  private val uniqueKeyName = "identify_by"
+
+  /** One ontology file import. */
+  private final class Conversion(ontology: OssieOntology, options: Options) {
+
+    /** Concept name to LinkML element name. */
+    private val elementNames: Map[String, String] = {
+      val pairs = ontology.ontology.map(c => c.concept -> Case.baseToPascal(Case.base(c.concept)))
+      val clashes = pairs.groupBy(_._2).filter(_._2.sizeIs > 1)
+      if clashes.nonEmpty then
+        throw RuntimeException(
+          "Concepts that differ only in naming style cannot both be imported: " +
+            clashes.toSeq.sortBy(_._1).map { (element, from) =>
+              s"${from.map(_._1).mkString(" and ")} would both become '$element'"
+            }.mkString("; "),
+        )
+      pairs.toMap
+    }
+
+    private val (valueTypes, entityTypes) =
+      ontology.ontology.partition(_.conceptType == ConceptType.ValueType)
+
+    private val (enumConcepts, typeConcepts) =
+      valueTypes.partition(c => permissibleValues(c).isDefined)
+
+    private val typeNames: Set[String] = typeConcepts.map(c => elementNames(c.concept)).toSet
+
+    def schema: SchemaDefinitionImpl = {
+      val classes = entityTypes.map(classOf)
+      // Any class is only declared when something actually refers to it.
+      // TODO: should this be a built-in type/class hybrid instead?
+      val any = Option.when(
+        classes.exists(_.attributes.values.exists(_.range.contains(Reference(anyClass)))) &&
+          !classes.exists(_.name == anyClass),
+      )(ClassDefinitionImpl(name = anyClass, classUri = Some(UriOrCurie("linkml:Any"))))
+
+      SchemaDefinitionImpl(
+        id = Uri(options.schemaId.getOrElse {
+          val slug = Case.base(ontology.name)
+          "https://example.org/" + (if slug.isEmpty then "ontology" else slug)
+        }),
+        name = ontology.name,
+        description = ontology.description.map(PlainText.apply),
+        prefixes = VectorMap(
+          "linkml" -> PrefixImpl("linkml", Uri("https://w3id.org/linkml/")),
+        ),
+        defaultRange = Some(Reference("string")),
+        imports = Seq(UriOrCurie("linkml:types")),
+        extensions = aiContext,
+        classes = byName(classes ++ any),
+        enums = byName(enumConcepts.map(enumOf)),
+        types = byName(typeConcepts.map(typeOf)),
+      )
+    }
+
+    /** The ontology's `ai_context`, as the `extensions` metaslot in LinkML. */
+    private def aiContext: Map[String, ExtensionImpl] =
+      ontology.aiContext.map { node =>
+        val tag = UriOrCurie("ai_context")
+        tag.original -> ExtensionImpl(extensionTag = tag, extensionValue = LinkmlAny(node.asYaml))
+      }.toMap
+
+    private def classOf(concept: Concept): ClassDefinitionImpl = {
+      // The generator lists mixins before `is_a`, so the last entry is the one that was `is_a`.
+      val parents = concept.extendsConcepts.map(name => elementNames.getOrElse(name, name))
+      val declared = concept.relationships.map(r => r.name -> r).toMap
+      val requires = concept.requires.flatMap(Expression.parse)
+      val conceptRef = Ref(concept.concept)
+      val required = requires.collect {
+        case Expression.Member(r, relationship) if r == conceptRef => relationship
+      }.toSet
+
+      val identifier = concept.identifyBy match {
+        case Seq(only) if declared.get(only).exists(canIdentify) => Some(only)
+        case _ => None
+      }
+      val compoundKey = Option.when(
+        identifier.isEmpty && concept.identifyBy.exists(declared.contains),
+      )(
+        UniqueKeyImpl(
+          uniqueKeyName = uniqueKeyName,
+          uniqueKeySlots = concept.identifyBy.map(name => Reference(Case.base(name))),
+        ),
+      )
+
+      val name = elementNames(concept.concept)
+      ClassDefinitionImpl(
+        name = name,
+        alias = Option.when(name != concept.concept)(concept.concept),
+        description = concept.description.map(PlainText.apply),
+        isA = parents.lastOption.map(Reference.apply),
+        mixins = parents.dropRight(1).map(Reference.apply),
+        attributes = VectorMap.from(
+          concept.relationships.map(r =>
+            attributeOf(r, required(r.name), identifier.contains(r.name)),
+          ),
+        ),
+        uniqueKeys = compoundKey.map(uniqueKeyName -> _).toMap,
+      )
+    }
+
+    /** Whether a relationship can become LinkML's `identifier`, which has to be a single-valued
+      * scalar. Others have to go through `unique_keys` instead.
+      */
+    private def canIdentify(relationship: Relationship): Boolean =
+      relationship.multiplicity.contains(Multiplicity.OneToOne) &&
+        relationship.roles.headOption.map(_.concept).exists(c =>
+          linkmlTypes.contains(c) || typeNames.contains(elementNames.getOrElse(c, c)),
+        )
+
+    private def attributeOf(
+        relationship: Relationship,
+        required: Boolean,
+        identifier: Boolean,
+    ): (String, SlotDefinitionImpl) = {
+      val name = Case.base(relationship.name)
+      // We don't support multi-role relationships yet, so we only look at the first one.
+      // TODO: consider synthesizing a LinkML class for the relationship and using it as the range.
+      val role = relationship.roles.headOption
+      val constraints = role
+        .map(r => Constraints.from(Ref(r.ref), relationship.requires.flatMap(Expression.parse)))
+        .getOrElse(Constraints())
+      name -> SlotDefinitionImpl(
+        name = name,
+        alias = Option.when(name != relationship.name)(relationship.name),
+        description = relationship.description.map(PlainText.apply),
+        range = role.map(r => Reference(rangeOf(r.concept))),
+        multivalued = relationship.multiplicity.isEmpty,
+        required = required,
+        identifier = identifier,
+        minimumValue = constraints.minimumValue,
+        maximumValue = constraints.maximumValue,
+        pattern = constraints.pattern,
+      )
+    }
+
+    private def enumOf(concept: Concept): EnumDefinitionImpl =
+      EnumDefinitionImpl(
+        name = elementNames(concept.concept),
+        description = concept.description.map(PlainText.apply),
+        permissibleValues = VectorMap.from(
+          permissibleValues(concept).getOrElse(Nil).map(v => v -> PermissibleValueImpl(text = v)),
+        ),
+      )
+
+    private def typeOf(concept: Concept): TypeDefinitionImpl = {
+      val constraints =
+        Constraints.from(Ref(concept.concept), concept.requires.flatMap(Expression.parse))
+      TypeDefinitionImpl(
+        name = elementNames(concept.concept),
+        description = concept.description.map(PlainText.apply),
+        typeof =
+          Some(Reference(concept.extendsConcepts.headOption.map(baseOf).getOrElse("string"))),
+        minimumValue = constraints.minimumValue,
+        maximumValue = constraints.maximumValue,
+        pattern = constraints.pattern,
+      )
+    }
+
+    /** The type a value type is based on. */
+    private def baseOf(concept: String): String =
+      linkmlTypes.getOrElse(
+        concept, {
+          val element = elementNames.getOrElse(concept, concept)
+          if typeNames.contains(element) then element else "string"
+        },
+      )
+
+    /** The LinkML range for the concept playing a role. */
+    private def rangeOf(concept: String): String =
+      if concept == BuiltInConcept.any then anyClass
+      else linkmlTypes.getOrElse(concept, elementNames.getOrElse(concept, concept))
+
+    /** The values a value type allows, if it is the enumerated kind. */
+    private def permissibleValues(concept: Concept): Option[Seq[String]] =
+      concept.requires match {
+        case Seq(only) =>
+          Expression.parse(only).collect {
+            case Expression.InList(r, values) if r == Ref(concept.concept) => values.map(_.value)
+          }
+        case _ => None
+      }
+  }
+
+  private def byName[T <: Element](elements: Seq[T]): Map[String, T] =
+    VectorMap.from(elements.map(e => e.name -> e))
+}

--- a/generator/src/eu/neverblink/linkml/generator/ossie/OssieImporter.scala
+++ b/generator/src/eu/neverblink/linkml/generator/ossie/OssieImporter.scala
@@ -1,7 +1,7 @@
 package eu.neverblink.linkml.generator.ossie
 
 import eu.neverblink.linkml.generator.SchemaImporter
-import eu.neverblink.linkml.generator.ossie.expression.{Constraints, Expression, Ref}
+import eu.neverblink.linkml.generator.ossie.expression.*
 import eu.neverblink.linkml.generator.util.JsonOutputFormat
 import eu.neverblink.linkml.generator.util.JsonOutputFormat.yaml
 import eu.neverblink.linkml.metamodel.*
@@ -158,8 +158,8 @@ object OssieImporter {
         isA = parents.lastOption.map(Reference.apply),
         mixins = parents.dropRight(1).map(Reference.apply),
         attributes = VectorMap.from(
-          concept.relationships.map(r =>
-            attributeOf(r, required(r.name), identifier.contains(r.name)),
+          concept.relationships.zipWithIndex.map((r, i) =>
+            attributeOf(r, required(r.name), identifier.contains(r.name), i + 1),
           ),
         ),
         uniqueKeys = compoundKey.map(uniqueKeyName -> _).toMap,
@@ -179,6 +179,7 @@ object OssieImporter {
         relationship: Relationship,
         required: Boolean,
         identifier: Boolean,
+        rank: Int,
     ): (String, SlotDefinitionImpl) = {
       val name = Case.base(relationship.name)
       // We don't support multi-role relationships yet, so we only look at the first one.
@@ -187,9 +188,18 @@ object OssieImporter {
       val constraints = role
         .map(r => Constraints.from(Ref(r.ref), relationship.requires.flatMap(Expression.parse)))
         .getOrElse(Constraints())
+      // Try to get a title from the verbalization, but only if it is not empty
+      // and not the same as the space-cased relationship name.
+      val title = relationship.verbalizes.headOption
+        .flatMap(Verbalization.parse)
+        .map(_.phrase)
+        .filter(phrase => phrase.nonEmpty && phrase != name.replace('_', ' '))
+
       name -> SlotDefinitionImpl(
         name = name,
+        rank = Some(rank),
         alias = Option.when(name != relationship.name)(relationship.name),
+        title = title.map(PlainText.apply),
         description = relationship.description.map(PlainText.apply),
         range = role.map(r => Reference(rangeOf(r.concept))),
         multivalued = relationship.multiplicity.isEmpty,

--- a/generator/src/eu/neverblink/linkml/generator/ossie/expression/Constraints.scala
+++ b/generator/src/eu/neverblink/linkml/generator/ossie/expression/Constraints.scala
@@ -1,0 +1,43 @@
+package eu.neverblink.linkml.generator.ossie.expression
+
+import eu.neverblink.linkml.generator.ossie.expression.Expression.{AtLeast, AtMost, RegexpLike}
+import eu.neverblink.linkml.runtime.FastUtils.*
+import eu.neverblink.linkml.runtime.LinkmlAny
+
+/** The value constraints used in Ossie in the `requires` field, for one specific [[Ref]].
+  *
+  * This is the subset of the constraints that can be expressed in LinkML currently.
+  */
+private[ossie] final case class Constraints(
+    minimumValue: Option[LinkmlAny] = None,
+    maximumValue: Option[LinkmlAny] = None,
+    pattern: Option[String] = None,
+) {
+
+  /** As expressions over [[ref]]. A bound that cannot be written as an Ossie value is left out. */
+  def render(ref: Ref): Seq[Expression] = {
+    val out = Seq.newBuilder[Expression]
+    minimumValue.flatMap(Literal.fromLinkml).foreachFast(v => out += AtLeast(ref, v))
+    maximumValue.flatMap(Literal.fromLinkml).foreachFast(v => out += AtMost(ref, v))
+    pattern.foreachFast(p => out += RegexpLike(ref, Literal.Text(p)))
+    out.result()
+  }
+}
+
+private[ossie] object Constraints {
+
+  /** Gather constraints [[expressions]] place on [[ref]] into [[Constraints]].
+    *
+    * This method will ignore any expressions that do not apply to [[ref]], and any expressions that
+    * cannot be expressed in LinkML.
+    */
+  def from(ref: Ref, expressions: Seq[Expression]): Constraints =
+    expressions.filter(_.ref == ref).foldLeft(Constraints()) { (acc, expression) =>
+      expression match {
+        case AtLeast(_, v) => acc.copy(minimumValue = Some(v.toLinkml))
+        case AtMost(_, v) => acc.copy(maximumValue = Some(v.toLinkml))
+        case RegexpLike(_, p) => acc.copy(pattern = Some(p.value))
+        case _ => acc
+      }
+    }
+}

--- a/generator/src/eu/neverblink/linkml/generator/ossie/expression/Expression.scala
+++ b/generator/src/eu/neverblink/linkml/generator/ossie/expression/Expression.scala
@@ -1,0 +1,101 @@
+package eu.neverblink.linkml.generator.ossie.expression
+
+import fastparse.*
+import fastparse.NoWhitespace.given
+
+/** One expression of the SQL-like expression language used in the Ossie ontology specification.
+  *
+  * This is a model of a subset of the language, as supported in LinkML-Scala. As of Ossie 0.2.0 the
+  * language has no formal grounding, so this is rough in places. We will try to make it more robust
+  * when the language is better defined.
+  *
+  * We ignore unparseable expressions, or those that we don't support yet.
+  */
+private[ossie] sealed trait Expression {
+
+  /** The name this expression is about. */
+  def ref: Ref
+
+  /** Render this expression as a string, in the same form that [[parse]] can read. */
+  def render: String
+}
+
+private[ossie] object Expression {
+
+  /** `Ref.relationship` - how a concept states that a relationship is mandatory. */
+  final case class Member(ref: Ref, relationship: String) extends Expression {
+    override def render: String = s"${ref.name}.$relationship"
+  }
+
+  /** `Ref IN ('a', 'b')` - how an enumerated value type states the values it allows. */
+  final case class InList(ref: Ref, values: Seq[Literal.Text]) extends Expression {
+    override def render: String =
+      s"${ref.name} IN (${values.map(_.render).mkString(", ")})"
+  }
+
+  /** `Ref >= 1` */
+  final case class AtLeast(ref: Ref, value: Literal) extends Expression {
+    override def render: String = s"${ref.name} >= ${value.render}"
+  }
+
+  /** `Ref <= 10` */
+  final case class AtMost(ref: Ref, value: Literal) extends Expression {
+    override def render: String = s"${ref.name} <= ${value.render}"
+  }
+
+  /** `REGEXP_LIKE(Ref, '^x')` */
+  final case class RegexpLike(ref: Ref, pattern: Literal.Text) extends Expression {
+    override def render: String =
+      s"REGEXP_LIKE(${ref.name}, ${pattern.render})"
+  }
+
+  /** Read an expression, or None if it is not one of the shapes above. */
+  def parse(text: String): Option[Expression] =
+    fastparse.parse(text, expression(using _)) match {
+      case Parsed.Success(e, _) => Some(e)
+      case _: Parsed.Failure => None
+    }
+
+  private def expression[$: P]: P[Expression] =
+    P(ws ~ (regexpLike | inList | atLeast | atMost | member) ~ ws ~ End)
+
+  /** Ossie cannot quote a name, so a name is a bare identifier and nothing else. */
+  private def ident[$: P]: P[String] =
+    P((CharPred(Ref.isStart) ~ CharsWhile(Ref.isPart, 0)).!)
+
+  private def ref[$: P]: P[Ref] = ident.map(Ref.apply)
+
+  /** A single-quoted string, in which a doubled quote is an escaped one. */
+  private def literalStr[$: P]: P[Literal.Text] =
+    P("'" ~ (P("''").map(_ => "'") | CharPred(_ != '\'').!).rep ~ "'")
+      .map(_.mkString).map(Literal.Text.apply)
+
+  /** A bare number. Read as a whole token and checked with the same test [[Literal.fromLinkml]]
+    * uses, so the writer and the reader cannot disagree about what counts as one.
+    */
+  private def literalNum[$: P]: P[Literal.Number] =
+    P(CharsWhile(c => c != ' ' && c != '\t' && c != ',' && c != ')').!)
+      .filter(Literal.isNumber)
+      .map(Literal.Number.apply)
+
+  private def value[$: P]: P[Literal] = P(literalStr | literalNum)
+
+  private def member[$: P]: P[Member] = P(ref ~ "." ~ ident).map(Member.apply)
+
+  private def inList[$: P]: P[InList] =
+    P(ref ~ ws1 ~ "IN" ~ ws ~ "(" ~ ws ~ literalStr.rep(sep = ws ~ "," ~ ws) ~ ws ~ ")")
+      .map(InList.apply)
+
+  private def atLeast[$: P]: P[AtLeast] = P(ref ~ ws ~ ">=" ~ ws ~ value).map(AtLeast.apply)
+
+  private def atMost[$: P]: P[AtMost] = P(ref ~ ws ~ "<=" ~ ws ~ value).map(AtMost.apply)
+
+  private def regexpLike[$: P]: P[RegexpLike] =
+    P("REGEXP_LIKE" ~ ws ~ "(" ~ ws ~ ref ~ ws ~ "," ~ ws ~ literalStr ~ ws ~ ")").map(
+      RegexpLike.apply,
+    )
+
+  private def ws[$: P]: P[Unit] = P(CharsWhileIn(" \t", 0))
+
+  private def ws1[$: P]: P[Unit] = P(CharsWhileIn(" \t"))
+}

--- a/generator/src/eu/neverblink/linkml/generator/ossie/expression/Literal.scala
+++ b/generator/src/eu/neverblink/linkml/generator/ossie/expression/Literal.scala
@@ -1,0 +1,59 @@
+package eu.neverblink.linkml.generator.ossie.expression
+
+import eu.neverblink.linkml.runtime.LinkmlAny
+import org.virtuslab.yaml.{Node, NodeOps, StringNode, parseYaml}
+
+/** A value written into an Ossie expression. */
+private[ossie] sealed trait Literal {
+
+  /** The literal as it appears in an expression. */
+  def render: String
+
+  /** The LinkML value this stands for. */
+  def toLinkml: LinkmlAny
+}
+
+private[ossie] object Literal {
+
+  /** A bare number, kept exactly as written rather than normalized. */
+  final case class Number(text: String) extends Literal {
+    override def render: String = text
+
+    override def toLinkml: LinkmlAny = LinkmlAny(text)
+  }
+
+  /** A single-quoted string. [[value]] is unescaped. */
+  final case class Text(value: String) extends Literal {
+    override def render: String = "'" + value.replace("'", "''") + "'"
+
+    override def toLinkml: LinkmlAny = LinkmlAny(StringNode(value).asYaml.strip())
+  }
+
+  /** The Ossie literal for a LinkML value, or None if it cannot be written as one.
+    *
+    * LinkML provides these as raw YAML, so the source is read as YAML.
+    */
+  def fromLinkml(value: LinkmlAny): Option[Literal] = {
+    val raw = value.value.strip()
+    if raw.isEmpty then None
+    else
+      parseYaml(raw) match {
+        case Right(node: Node.ScalarNode) =>
+          val text = node.value
+          if text == null || text.isEmpty || text.exists(c => c == '\n' || c == '\r') then None
+          else if isNumber(text) then Some(Number(text))
+          else Some(Text(text))
+        // Anything that is not a plain scalar - a mapping, a sequence, unreadable YAML - has no
+        // Ossie value to stand for it.
+        case _ => None
+      }
+  }
+
+  private[expression] def isNumber(text: String): Boolean =
+    try {
+      BigDecimal(text)
+      true
+    } catch {
+      case _: NumberFormatException => false
+    }
+}

--- a/generator/src/eu/neverblink/linkml/generator/ossie/expression/Ref.scala
+++ b/generator/src/eu/neverblink/linkml/generator/ossie/expression/Ref.scala
@@ -1,0 +1,18 @@
+package eu.neverblink.linkml.generator.ossie.expression
+
+/** A name as it appears in an Ossie expression: a concept on a concept-level expression or the role
+  * in a relationship constraint.
+  */
+private[ossie] opaque type Ref = String
+
+private[ossie] object Ref {
+  def apply(name: String): Ref = name
+
+  /** What a name may start with. */
+  def isStart(c: Char): Boolean = (c.isLetter && c < 128) || c == '_'
+
+  /** What a name may continue with. There is no quoting/escaping support in Ossie right now. */
+  def isPart(c: Char): Boolean = isStart(c) || (c >= '0' && c <= '9')
+
+  extension (r: Ref) def name: String = r
+}

--- a/generator/src/eu/neverblink/linkml/generator/ossie/expression/Verbalization.scala
+++ b/generator/src/eu/neverblink/linkml/generator/ossie/expression/Verbalization.scala
@@ -1,0 +1,43 @@
+package eu.neverblink.linkml.generator.ossie.expression
+
+import fastparse.*
+import fastparse.NoWhitespace.given
+
+/** How a relationship is said out loud: `{Concept} phrase {Range}`, or `{Concept} phrase
+  * {Range:role}`, where `role` needs disambiguation.
+  */
+private[ossie] final case class Verbalization(
+    concept: Ref,
+    phrase: String,
+    range: Ref,
+    role: Option[String],
+) {
+  def render: String = {
+    val target = role.fold(s"{${range.name}}")(r => s"{${range.name}:$r}")
+    s"{${concept.name}} $phrase $target"
+  }
+}
+
+private[ossie] object Verbalization {
+
+  /** Read a verbalization, or None if it is not a supported shape. */
+  def parse(text: String): Option[Verbalization] =
+    fastparse.parse(text, verbalization(using _)) match {
+      case Parsed.Success(v, _) => Some(v)
+      case _: Parsed.Failure => None
+    }
+
+  private def verbalization[$: P]: P[Verbalization] =
+    P(ws ~ "{" ~ name ~ "}" ~ phrase ~ "{" ~ name ~ (":" ~ role).? ~ "}" ~ ws ~ End).map {
+      (concept, phrase, range, role) =>
+        Verbalization(Ref(concept), phrase, Ref(range), role)
+    }
+
+  private def name[$: P]: P[String] = P(CharsWhile(c => c != '{' && c != '}' && c != ':').!)
+
+  private def phrase[$: P]: P[String] = P(CharsWhile(c => c != '{' && c != '}').!).map(_.trim)
+
+  private def role[$: P]: P[String] = P(CharsWhile(_ != '}').!)
+
+  private def ws[$: P]: P[Unit] = P(CharsWhileIn(" \t", 0))
+}

--- a/generator/src/eu/neverblink/linkml/generator/util/JsonUtil.scala
+++ b/generator/src/eu/neverblink/linkml/generator/util/JsonUtil.scala
@@ -2,7 +2,7 @@ package eu.neverblink.linkml.generator.util
 
 import com.github.plokhotnyuk.jsoniter_scala.core.*
 import com.github.plokhotnyuk.jsoniter_scala.macros.JsonCodecMaker
-import org.virtuslab.yaml.{Node, Tag}
+import org.virtuslab.yaml.{Node, NodeOps, Tag}
 
 import java.io.OutputStream
 import scala.util.control.NonFatal
@@ -17,6 +17,19 @@ object JsonUtil {
   /** Serialize scala-yaml [[Node]] as pretty JSON straight to [[out]], skipping the string. */
   def writeJson(yaml: Node, out: OutputStream): Unit =
     writeToStream(yaml, out, WriterConfig.withIndentionStep(2))
+
+  /** Serialize scala-yaml [[Node]] in [[format]]. */
+  def write(yaml: Node, format: JsonOutputFormat): String =
+    if (format == JsonOutputFormat.json) yamlToJson(yaml) else yaml.asYaml
+
+  /** Serialize scala-yaml [[Node]] in [[format]] straight to [[out]]. */
+  def write(yaml: Node, format: JsonOutputFormat, out: OutputStream): Unit =
+    if (format == JsonOutputFormat.json) writeJson(yaml, out)
+    else {
+      val sink = new Utf8ByteSink(out)
+      sink.append(yaml.asYaml)
+      sink.flush()
+    }
 
   private implicit val yamlCodec: JsonValueCodec[Node] = new JsonValueCodec[Node] {
     override def decodeValue(in: JsonReader, default: Node): Node = ???

--- a/generator/test/src-jvm/eu/neverblink/linkml/generator/ossie/OssieIntegrationSpec.scala
+++ b/generator/test/src-jvm/eu/neverblink/linkml/generator/ossie/OssieIntegrationSpec.scala
@@ -6,10 +6,23 @@ import eu.neverblink.linkml.schemaview.{SchemaIssues, SchemaView}
 import eu.neverblink.linkml.tests.{ModelCatalogue, ModelCatalogueSpec}
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
+import org.virtuslab.yaml.parseYaml
+
+import java.io.ByteArrayInputStream
+import java.nio.charset.StandardCharsets.UTF_8
 
 /** Checks the `ossie` generator's output against Apache Ossie's own JSON Schema. */
 class OssieIntegrationSpec extends AnyWordSpec, Matchers, ModelCatalogueSpec {
   import OssieIntegrationSpec.*
+
+  /** The Ossie flights example, or a cancelled test when there is no checkout to read it from. */
+  private def flightsExample: os.Path =
+    ossieRepo.map(_ / "examples" / "flights.yaml").filter(os.exists).getOrElse(
+      cancel(
+        "No apache/ossie checkout to read the examples from. Set LINKML_OSSIE_REPO to one - the " +
+          "`ossieRepo` mill task clones it.",
+      ),
+    )
 
   "OssieGenerator" should {
     for entry <- ModelCatalogue.all do
@@ -63,6 +76,28 @@ class OssieIntegrationSpec extends AnyWordSpec, Matchers, ModelCatalogueSpec {
           }
         }
       }
+  }
+
+  // A real ontology from the Ossie repo.
+  "the flights example" when {
+    lazy val original = os.read(flightsExample)
+    lazy val once = OssieGenerator(using linkmlFor(original)).serialize()
+
+    "every concept round-trips" in {
+      conceptsOf(once) should contain theSameElementsAs conceptsOf(original)
+    }
+
+    "every relationship round-trips, on the same concept" in {
+      relationshipsOf(once) shouldBe relationshipsOf(original)
+    }
+
+    "a second pass changes nothing" in {
+      OssieGenerator(using linkmlFor(once)).serialize() shouldBe once
+    }
+
+    "the result is still a valid ontology" in {
+      OssieSchema.validate(once, InputFormat.YAML) shouldBe empty
+    }
   }
 
   "ai_context" should {
@@ -137,17 +172,37 @@ object OssieIntegrationSpec {
   private val repoRoot: os.Path =
     Option(System.getenv("MILL_WORKSPACE_ROOT")).map(os.Path(_)).getOrElse(os.pwd)
 
+  /** The apache/ossie checkout, if one is configured. */
+  private lazy val ossieRepo: Option[os.Path] =
+    Option(System.getenv("LINKML_OSSIE_REPO")).filter(_.nonEmpty).map(os.Path(_, os.pwd))
+
   /** Python interpreter and apache/ossie checkout to run the upstream validator with, if both are
     * available.
     */
   private lazy val upstreamValidator: Option[(os.Path, os.Path)] = {
     val python = repoRoot / ".venv" / "bin" / "python"
-    val repo = Option(System.getenv("LINKML_OSSIE_REPO")).filter(_.nonEmpty).map(os.Path(_, os.pwd))
     for
-      r <- repo
+      r <- ossieRepo
       if os.exists(r / "validation" / "validate.py") && os.exists(r / "ontology" / "ontology.json")
       if os.exists(python)
       if os.call((python, "-c", "import jsonschema, yaml"), check = false).exitCode == 0
     yield (python, r)
   }
+
+  private def linkmlFor(ontology: String): SchemaView =
+    SchemaIssues.orThrow(
+      SchemaView.loadSchemaViewFromString(
+        OssieImporter().serialize(ByteArrayInputStream(ontology.getBytes(UTF_8))),
+      ),
+    )
+
+  private def decode(document: String): OssieOntology =
+    OssieOntology.codec.decode(
+      parseYaml(document).getOrElse(throw AssertionError(s"not readable YAML:\n$document")),
+    )
+
+  private def conceptsOf(document: String): Seq[String] = decode(document).ontology.map(_.concept)
+
+  private def relationshipsOf(document: String): Map[String, Set[String]] =
+    decode(document).ontology.map(c => c.concept -> c.relationships.map(_.name).toSet).toMap
 }

--- a/generator/test/src/eu/neverblink/linkml/generator/ossie/OssieCases.scala
+++ b/generator/test/src/eu/neverblink/linkml/generator/ossie/OssieCases.scala
@@ -1,0 +1,442 @@
+package eu.neverblink.linkml.generator.ossie
+
+/** The LinkML schemas for Ossie tests.
+  *
+  * Each body is spliced into a minimal schema by [[OssieFixtures.schemaOf]].
+  */
+object OssieCases {
+  final case class Case(label: String, body: String)
+
+  private def of(label: String)(body: String): Case = Case(label, body)
+
+  val classWithDescription: Case = of("a described class")("""
+    |classes:
+    |  Book:
+    |    description: A book.
+    |    attributes:
+    |      title: {}
+    """)
+
+  val enumeration: Case = of("an enum")("""
+    |enums:
+    |  Status:
+    |    permissible_values:
+    |      ALIVE: {}
+    |      DEAD: {}
+    |classes:
+    |  Person:
+    |    attributes:
+    |      status:
+    |        range: Status
+    """)
+
+  val enumValueWithApostrophe: Case = of("an enum value holding an apostrophe")("""
+    |enums:
+    |  Kind:
+    |    permissible_values:
+    |      "it's": {}
+    |classes:
+    |  Thing:
+    |    attributes:
+    |      kind:
+    |        range: Kind
+    """)
+
+  val namedType: Case = of("a named type over a base")("""
+    |types:
+    |  SmallInt:
+    |    base: int
+    |    uri: xsd:integer
+    |classes:
+    |  Thing:
+    |    attributes:
+    |      n:
+    |        range: SmallInt
+    """)
+
+  val typeofChain: Case = of("a named type reached through typeof")("""
+    |types:
+    |  PositiveInt:
+    |    typeof: integer
+    |    minimum_value: 1
+    |classes:
+    |  Thing:
+    |    attributes:
+    |      n:
+    |        range: PositiveInt
+    """)
+
+  val snakeCasedClassName: Case = of("a snake_cased class name")("""
+    |classes:
+    |  order_line:
+    |    attributes:
+    |      x: {}
+    """)
+
+  val primitiveRanges: Case = of("every primitive range")("""
+    |classes:
+    |  Thing:
+    |    attributes:
+    |      s: { range: string }
+    |      i: { range: integer }
+    |      f: { range: float }
+    |      d: { range: double }
+    |      dec: { range: decimal }
+    |      b: { range: boolean }
+    |      dt: { range: date }
+    |      dtt: { range: datetime }
+    |      t: { range: time }
+    |      u: { range: uri }
+    |      c: { range: curie }
+    """)
+
+  val anyRange: Case = of("a linkml:Any range")("""
+    |classes:
+    |  Any:
+    |    class_uri: linkml:Any
+    |  Thing:
+    |    attributes:
+    |      whatever:
+    |        range: Any
+    """)
+
+  val unknownBase: Case = of("a named type whose base is unknown")("""
+    |types:
+    |  Weird:
+    |    base: NotABaseWeKnow
+    |    uri: xsd:string
+    |classes:
+    |  Thing:
+    |    attributes:
+    |      x:
+    |        range: Weird
+    """)
+
+  val classRanges: Case = of("class ranges, inlined and not")("""
+    |classes:
+    |  Author:
+    |    attributes:
+    |      id:
+    |        identifier: true
+    |  Book:
+    |    attributes:
+    |      by:
+    |        range: Author
+    |      inline_by:
+    |        range: Author
+    |        inlined: true
+    """)
+
+  val multiWordSlot: Case = of("a multi-word slot name")("""
+    |classes:
+    |  Person:
+    |    attributes:
+    |      full_name: {}
+    """)
+
+  val aliasedSlot: Case = of("an aliased slot")("""
+    |classes:
+    |  Person:
+    |    attributes:
+    |      full_name:
+    |        alias: fullName
+    """)
+
+  val aliasedClass: Case = of("an aliased class")("""
+    |classes:
+    |  http_thing:
+    |    alias: HTTPThing
+    |    attributes:
+    |      x: {}
+    """)
+
+  val selfReference: Case = of("a slot pointing at its own class")("""
+    |classes:
+    |  Person:
+    |    attributes:
+    |      id:
+    |        identifier: true
+    |      parent_of:
+    |        range: Person
+    |        multivalued: true
+    """)
+
+  val multivalued: Case = of("a multivalued slot next to a single-valued one")("""
+    |classes:
+    |  Person:
+    |    attributes:
+    |      one: {}
+    |      many:
+    |        multivalued: true
+    """)
+
+  val requiredSlot: Case = of("a required slot")("""
+    |classes:
+    |  Person:
+    |    attributes:
+    |      name:
+    |        required: true
+    |      nickname: {}
+    """)
+
+  val numericBounds: Case = of("numeric bounds on a slot")("""
+    |classes:
+    |  Thing:
+    |    attributes:
+    |      n:
+    |        range: integer
+    |        minimum_value: -1
+    |        maximum_value: 10
+    """)
+
+  val pattern: Case = of("a pattern on a slot")("""
+    |classes:
+    |  Thing:
+    |    attributes:
+    |      code:
+    |        pattern: '^[A-Z]{3}$'
+    """)
+
+  val patternWithApostrophe: Case = of("a pattern holding an apostrophe")("""
+    |classes:
+    |  Thing:
+    |    attributes:
+    |      code:
+    |        pattern: "it's"
+    """)
+
+  val nonNumericBound: Case = of("a bound that is not a number")("""
+    |classes:
+    |  Thing:
+    |    attributes:
+    |      when:
+    |        range: date
+    |        minimum_value: 2020-01-01
+    |      n:
+    |        range: integer
+    |        minimum_value: 5
+    """)
+
+  val quotedNumberBound: Case = of("a quoted number as a bound")("""
+    |classes:
+    |  Thing:
+    |    attributes:
+    |      n:
+    |        range: integer
+    |        minimum_value: "5"
+    """)
+
+  val typeConstraints: Case = of("constraints on a named type")("""
+    |types:
+    |  SmallInt:
+    |    base: int
+    |    uri: xsd:integer
+    |    minimum_value: 1
+    |classes:
+    |  Thing:
+    |    attributes:
+    |      n:
+    |        range: SmallInt
+    """)
+
+  val inheritance: Case = of("is_a and mixins together")("""
+    |classes:
+    |  Base:
+    |    attributes:
+    |      a: {}
+    |  Mixed:
+    |    mixin: true
+    |    attributes:
+    |      b: {}
+    |  Sub:
+    |    is_a: Base
+    |    mixins: [Mixed]
+    |    attributes:
+    |      c: {}
+    """)
+
+  val inheritedUnchanged: Case = of("a slot a subtype inherits unchanged")("""
+    |classes:
+    |  Base:
+    |    attributes:
+    |      a: {}
+    |  Sub:
+    |    is_a: Base
+    |    attributes:
+    |      b: {}
+    """)
+
+  val narrowedRange: Case = of("a slot a subtype narrows the range of")("""
+    |classes:
+    |  Cat:
+    |    attributes:
+    |      id:
+    |        identifier: true
+    |  Base:
+    |    attributes:
+    |      pet: {}
+    |  Sub:
+    |    is_a: Base
+    |    slot_usage:
+    |      pet:
+    |        range: Cat
+    """)
+
+  val narrowedRequired: Case = of("a slot a subtype only makes required")("""
+    |classes:
+    |  Base:
+    |    attributes:
+    |      name: {}
+    |  Sub:
+    |    is_a: Base
+    |    slot_usage:
+    |      name:
+    |        required: true
+    """)
+
+  val identifierSlot: Case = of("an identifier slot")("""
+    |classes:
+    |  Person:
+    |    attributes:
+    |      id:
+    |        identifier: true
+    """)
+
+  val keySlot: Case = of("a key slot")("""
+    |classes:
+    |  Person:
+    |    attributes:
+    |      code:
+    |        key: true
+    """)
+
+  val compoundKey: Case = of("a compound unique key")("""
+    |slots:
+    |  order: {}
+    |  nr:
+    |    range: integer
+    |classes:
+    |  OrderLine:
+    |    slots: [order, nr]
+    |    unique_keys:
+    |      line:
+    |        unique_key_slots: [order, nr]
+    """)
+
+  val describedSchema: Case = of("a described schema")("""
+    |description: A demo schema.
+    |classes:
+    |  Thing:
+    |    attributes:
+    |      x: {}
+    """)
+
+  val multilingualDescriptions: Case = of("descriptions in several languages")("""
+    |classes:
+    |  Book:
+    |    description:
+    |      en: A book.
+    |      pl: Książka.
+    |    attributes:
+    |      title:
+    |        description:
+    |          en: Its title.
+    |          pl: Jej tytuł.
+    """)
+
+  val aiContextObject: Case = of("an object-valued ai_context")("""
+    |extensions:
+    |  ai_context:
+    |    value:
+    |      instructions: Prefer the full name.
+    |      synonyms: [human, individual]
+    |classes:
+    |  Thing:
+    |    attributes:
+    |      x: {}
+    """)
+
+  val aiContextString: Case = of("a string-valued ai_context")("""
+    |extensions:
+    |  ai_context: Answer questions about people.
+    |classes:
+    |  Thing:
+    |    attributes:
+    |      x: {}
+    """)
+
+  val plain: Case = of("a schema with nothing else on it")("""
+    |classes:
+    |  Thing:
+    |    attributes:
+    |      x: {}
+    """)
+
+  val treeRoot: Case = of("a tree root next to an unreachable class")("""
+    |classes:
+    |  Root:
+    |    tree_root: true
+    |    attributes:
+    |      x: {}
+    |  Orphan:
+    |    attributes:
+    |      y: {}
+    """)
+
+  val severalKinds: Case = of("classes, an enum and a self-reference together")("""
+    |enums:
+    |  Status:
+    |    permissible_values:
+    |      OK: {}
+    |classes:
+    |  Person:
+    |    attributes:
+    |      id:
+    |        identifier: true
+    |      status:
+    |        range: Status
+    |      friend:
+    |        range: Person
+    |        multivalued: true
+    """)
+
+  /** Every case, for the specs that walk all of them. */
+  val all: Seq[Case] = Seq(
+    classWithDescription,
+    enumeration,
+    enumValueWithApostrophe,
+    namedType,
+    typeofChain,
+    snakeCasedClassName,
+    primitiveRanges,
+    anyRange,
+    unknownBase,
+    classRanges,
+    multiWordSlot,
+    aliasedSlot,
+    aliasedClass,
+    selfReference,
+    multivalued,
+    requiredSlot,
+    numericBounds,
+    pattern,
+    patternWithApostrophe,
+    nonNumericBound,
+    quotedNumberBound,
+    typeConstraints,
+    inheritance,
+    inheritedUnchanged,
+    narrowedRange,
+    narrowedRequired,
+    identifierSlot,
+    keySlot,
+    compoundKey,
+    describedSchema,
+    multilingualDescriptions,
+    aiContextObject,
+    aiContextString,
+    plain,
+    treeRoot,
+    severalKinds,
+  )
+}

--- a/generator/test/src/eu/neverblink/linkml/generator/ossie/OssieFixtures.scala
+++ b/generator/test/src/eu/neverblink/linkml/generator/ossie/OssieFixtures.scala
@@ -1,0 +1,58 @@
+package eu.neverblink.linkml.generator.ossie
+
+import eu.neverblink.linkml.generator.ossie.OssieCases.Case
+import eu.neverblink.linkml.schemaview.{SchemaIssues, SchemaView}
+
+/** Utilities for working with Ossie ontologies. */
+trait OssieFixtures {
+
+  /** A SchemaView over a minimal schema with [[body]] spliced in. */
+  def schemaOf(body: String): SchemaView = {
+    val schema =
+      s"""id: https://example.org/spec
+         |name: spec
+         |prefixes:
+         |  linkml: https://w3id.org/linkml/
+         |  xsd: http://www.w3.org/2001/XMLSchema#
+         |  ex: https://example.org/
+         |default_prefix: ex
+         |default_range: string
+         |imports:
+         |  - linkml:types
+         |${body.stripMargin}
+         |""".stripMargin
+    SchemaIssues.orThrow(SchemaView.loadSchemaViewFromString(schema))
+  }
+
+  def schemaOf(c: Case): SchemaView = schemaOf(c.body)
+
+  def ontologyOf(body: String): OssieOntology = OssieGenerator(using schemaOf(body)).generate()
+
+  def ontologyOf(c: Case): OssieOntology = ontologyOf(c.body)
+
+  def yamlOf(body: String): String = OssieGenerator(using schemaOf(body)).serialize()
+
+  def yamlOf(c: Case): String = yamlOf(c.body)
+
+  def concept(o: OssieOntology, name: String): Concept =
+    o.ontology.find(_.concept == name).getOrElse(
+      throw AssertionError(s"no concept '$name' in ${o.ontology.map(_.concept)}"),
+    )
+
+  def relationship(o: OssieOntology, conceptName: String, name: String): Relationship = {
+    val c = concept(o, conceptName)
+    c.relationships.find(_.name == name).getOrElse(
+      throw AssertionError(s"no relationship '$name' on '$conceptName' in ${names(o, conceptName)}"),
+    )
+  }
+
+  /** The single role of a relationship, which is the only shape the generator emits. */
+  def role(o: OssieOntology, conceptName: String, name: String): Role =
+    relationship(o, conceptName, name).roles match {
+      case Seq(only) => only
+      case other => throw AssertionError(s"expected exactly one role, got $other")
+    }
+
+  def names(o: OssieOntology, conceptName: String): Seq[String] =
+    concept(o, conceptName).relationships.map(_.name)
+}

--- a/generator/test/src/eu/neverblink/linkml/generator/ossie/OssieGeneratorSpec.scala
+++ b/generator/test/src/eu/neverblink/linkml/generator/ossie/OssieGeneratorSpec.scala
@@ -1,112 +1,56 @@
 package eu.neverblink.linkml.generator.ossie
 
+import eu.neverblink.linkml.generator.ossie.OssieCases.*
 import eu.neverblink.linkml.generator.util.PruningMode
-import eu.neverblink.linkml.schemaview.{SchemaIssues, SchemaView}
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
 import org.virtuslab.yaml.parseYaml
 
-/** Feature-level tests for the LinkML -> Ossie mapping, one behavior at a time. */
-class OssieGeneratorSpec extends AnyWordSpec, Matchers {
-  import OssieGeneratorSpec.*
+/** Feature-level tests for the LinkML -> Ossie mapping, one behavior at a time.
+  *
+  * The schemas live in [[OssieCases]], which `OssieImporterSpec` reads back in the other direction.
+  */
+class OssieGeneratorSpec extends AnyWordSpec, Matchers, OssieFixtures {
 
   "concepts" should {
     "make an EntityType out of a class" in {
-      val c = concept(
-        ontologyOf("""
-          |classes:
-          |  Book:
-          |    description: A book.
-          |    attributes:
-          |      title: {}
-          """),
-        "Book",
-      )
+      val c = concept(ontologyOf(classWithDescription), "Book")
       c.conceptType shouldBe ConceptType.EntityType
       c.description shouldBe Some("A book.")
     }
 
     "make a ValueType out of an enum, constrained to its permissible values" in {
-      val c = concept(
-        ontologyOf("""
-          |enums:
-          |  Status:
-          |    permissible_values:
-          |      ALIVE: {}
-          |      DEAD: {}
-          |classes:
-          |  Person:
-          |    attributes:
-          |      status:
-          |        range: Status
-          """),
-        "Status",
-      )
+      val c = concept(ontologyOf(enumeration), "Status")
       c.conceptType shouldBe ConceptType.ValueType
       c.extendsConcepts shouldBe Seq(BuiltInConcept.string)
       c.requires shouldBe Seq("Status IN ('ALIVE', 'DEAD')")
     }
 
     "quote an enum value that contains an apostrophe" in {
-      concept(
-        ontologyOf("""
-          |enums:
-          |  Kind:
-          |    permissible_values:
-          |      "it's": {}
-          |classes:
-          |  Thing:
-          |    attributes:
-          |      kind:
-          |        range: Kind
-          """),
-        "Kind",
-      ).requires shouldBe Seq("Kind IN ('it''s')")
+      concept(ontologyOf(enumValueWithApostrophe), "Kind").requires shouldBe
+        Seq("Kind IN ('it''s')")
     }
 
     "make a ValueType out of a named type, extending the built-in for its base" in {
-      concept(
-        ontologyOf("""
-          |types:
-          |  SmallInt:
-          |    base: int
-          |    uri: xsd:integer
-          |classes:
-          |  Thing:
-          |    attributes:
-          |      n:
-          |        range: SmallInt
-          """),
-        "SmallInt",
-      ).extendsConcepts shouldBe Seq(BuiltInConcept.integer)
+      concept(ontologyOf(namedType), "SmallInt").extendsConcepts shouldBe Seq(
+        BuiltInConcept.integer,
+      )
     }
 
     "follow a typeof chain to find the base of a named type" in {
-      val o = ontologyOf("""
-        |types:
-        |  PositiveInt:
-        |    typeof: integer
-        |    minimum_value: 1
-        |classes:
-        |  Thing:
-        |    attributes:
-        |      n:
-        |        range: PositiveInt
-        """)
+      val o = ontologyOf(typeofChain)
       concept(o, "PositiveInt").extendsConcepts shouldBe Seq(BuiltInConcept.integer)
       role(o, "Thing", "n").concept shouldBe "PositiveInt"
     }
 
     "PascalCase a concept name" in {
-      concept(
-        ontologyOf("""
-        |classes:
-        |  order_line:
-        |    attributes:
-        |      x: {}
-        """),
-        "OrderLine",
-      ).concept shouldBe "OrderLine"
+      concept(ontologyOf(snakeCasedClassName), "OrderLine").concept shouldBe "OrderLine"
+    }
+
+    "ignore a class' alias" in {
+      val o = ontologyOf(aliasedClass)
+      o.ontology.map(_.concept) shouldBe Seq("HttpThing")
+      relationship(o, "HttpThing", "x").verbalizes shouldBe Seq("{HttpThing} x {String}")
     }
 
     "refuse to emit an ontology with no concepts at all" in {
@@ -120,22 +64,7 @@ class OssieGeneratorSpec extends AnyWordSpec, Matchers {
 
   "ranges" should {
     "map the primitive types onto Ossie's built-in concepts" in {
-      val o = ontologyOf("""
-        |classes:
-        |  Thing:
-        |    attributes:
-        |      s: { range: string }
-        |      i: { range: integer }
-        |      f: { range: float }
-        |      d: { range: double }
-        |      dec: { range: decimal }
-        |      b: { range: boolean }
-        |      dt: { range: date }
-        |      dtt: { range: datetime }
-        |      t: { range: time }
-        |      u: { range: uri }
-        |      c: { range: curie }
-        """)
+      val o = ontologyOf(primitiveRanges)
       def rangeOf(slot: String): String = role(o, "Thing", slot).concept
       rangeOf("s") shouldBe "String"
       rangeOf("i") shouldBe "Integer"
@@ -151,52 +80,17 @@ class OssieGeneratorSpec extends AnyWordSpec, Matchers {
     }
 
     "map linkml:Any onto the Any entity type" in {
-      role(
-        ontologyOf("""
-          |classes:
-          |  Any:
-          |    class_uri: linkml:Any
-          |  Thing:
-          |    attributes:
-          |      whatever:
-          |        range: Any
-          """),
-        "Thing",
-        "whatever",
-      ).concept shouldBe BuiltInConcept.any
+      role(ontologyOf(anyRange), "Thing", "whatever").concept shouldBe BuiltInConcept.any
     }
 
     "fall back to Any for a named type whose base is not one we know" in {
-      val o = ontologyOf("""
-        |types:
-        |  Weird:
-        |    base: NotABaseWeKnow
-        |    uri: xsd:string
-        |classes:
-        |  Thing:
-        |    attributes:
-        |      x:
-        |        range: Weird
-        """)
+      val o = ontologyOf(unknownBase)
       role(o, "Thing", "x").concept shouldBe BuiltInConcept.any
       o.ontology.map(_.concept) should not contain "Weird"
     }
 
     "point a class-ranged slot at the target concept, inlined or not" in {
-      val o = ontologyOf("""
-        |classes:
-        |  Author:
-        |    attributes:
-        |      id:
-        |        identifier: true
-        |  Book:
-        |    attributes:
-        |      by:
-        |        range: Author
-        |      inline_by:
-        |        range: Author
-        |        inlined: true
-        """)
+      val o = ontologyOf(classRanges)
       role(o, "Book", "by").concept shouldBe "Author"
       role(o, "Book", "inline_by").concept shouldBe "Author"
     }
@@ -218,170 +112,62 @@ class OssieGeneratorSpec extends AnyWordSpec, Matchers {
     }
 
     "verbalize as the space-cased name between the two concepts" in {
-      relationship(
-        ontologyOf("""
-          |classes:
-          |  Person:
-          |    attributes:
-          |      full_name: {}
-          """),
-        "Person",
-        "full_name",
-      ).verbalizes shouldBe Seq("{Person} full name {String}")
+      relationship(ontologyOf(multiWordSlot), "Person", "full_name").verbalizes shouldBe
+        Seq("{Person} full name {String}")
     }
 
     "use a slot's alias as the name but still space-case the verbalization" in {
-      val r = relationship(
-        ontologyOf("""
-          |classes:
-          |  Person:
-          |    attributes:
-          |      full_name:
-          |        alias: fullName
-          """),
-        "Person",
-        "fullName",
-      )
+      val r = relationship(ontologyOf(aliasedSlot), "Person", "fullName")
       r.name shouldBe "fullName"
       r.verbalizes shouldBe Seq("{Person} full name {String}")
     }
 
     "name the role and disambiguate the verbalization when a slot points at its own class" in {
-      val r = relationship(
-        ontologyOf("""
-          |classes:
-          |  Person:
-          |    attributes:
-          |      id:
-          |        identifier: true
-          |      parent_of:
-          |        range: Person
-          |        multivalued: true
-          """),
-        "Person",
-        "parent_of",
-      )
+      val r = relationship(ontologyOf(selfReference), "Person", "parent_of")
       r.roles shouldBe Seq(Role("Person", Some("parent_of")))
       r.verbalizes shouldBe Seq("{Person} parent of {Person:parent_of}")
     }
 
     "leave multiplicity off a multivalued slot and set ManyToOne on a single-valued one" in {
-      val o = ontologyOf("""
-        |classes:
-        |  Person:
-        |    attributes:
-        |      one: {}
-        |      many:
-        |        multivalued: true
-        """)
+      val o = ontologyOf(multivalued)
       relationship(o, "Person", "one").multiplicity shouldBe Some(Multiplicity.ManyToOne)
       relationship(o, "Person", "many").multiplicity shouldBe None
     }
 
     "list required slots as concept-level requires" in {
-      concept(
-        ontologyOf("""
-          |classes:
-          |  Person:
-          |    attributes:
-          |      name:
-          |        required: true
-          |      nickname: {}
-          """),
-        "Person",
-      ).requires shouldBe Seq("Person.name")
+      concept(ontologyOf(requiredSlot), "Person").requires shouldBe Seq("Person.name")
     }
   }
 
   "constraints" should {
     "put a slot's own bounds on the relationship, as expressions over the role" in {
-      relationship(
-        ontologyOf("""
-          |classes:
-          |  Thing:
-          |    attributes:
-          |      n:
-          |        range: integer
-          |        minimum_value: -1
-          |        maximum_value: 10
-          """),
-        "Thing",
-        "n",
-      ).requires shouldBe Seq("Integer >= -1", "Integer <= 10")
+      relationship(ontologyOf(numericBounds), "Thing", "n").requires shouldBe
+        Seq("Integer >= -1", "Integer <= 10")
     }
 
     "turn a pattern into a REGEXP_LIKE call over the role" in {
-      relationship(
-        ontologyOf("""
-          |classes:
-          |  Thing:
-          |    attributes:
-          |      code:
-          |        pattern: '^[A-Z]{3}$'
-          """),
-        "Thing",
-        "code",
-      ).requires shouldBe Seq("REGEXP_LIKE(String, '^[A-Z]{3}$')")
+      relationship(ontologyOf(pattern), "Thing", "code").requires shouldBe
+        Seq("REGEXP_LIKE(String, '^[A-Z]{3}$')")
     }
 
     "double an apostrophe inside a pattern rather than ending the literal early" in {
-      relationship(
-        ontologyOf("""
-          |classes:
-          |  Thing:
-          |    attributes:
-          |      code:
-          |        pattern: "it's"
-          """),
-        "Thing",
-        "code",
-      ).requires shouldBe Seq("REGEXP_LIKE(String, 'it''s')")
+      relationship(ontologyOf(patternWithApostrophe), "Thing", "code").requires shouldBe
+        Seq("REGEXP_LIKE(String, 'it''s')")
     }
 
     "quote a bound that is not a number, and leave a number bare" in {
-      val o = ontologyOf("""
-        |classes:
-        |  Thing:
-        |    attributes:
-        |      when:
-        |        range: date
-        |        minimum_value: 2020-01-01
-        |      n:
-        |        range: integer
-        |        minimum_value: 5
-        """)
+      val o = ontologyOf(nonNumericBound)
       relationship(o, "Thing", "when").requires shouldBe Seq("Date >= '2020-01-01'")
       relationship(o, "Thing", "n").requires shouldBe Seq("Integer >= 5")
     }
 
-    "see through the in the original YAML, so a quoted number still goes in bare" in {
-      relationship(
-        ontologyOf("""
-          |classes:
-          |  Thing:
-          |    attributes:
-          |      n:
-          |        range: integer
-          |        minimum_value: "5"
-          """),
-        "Thing",
-        "n",
-      ).requires shouldBe Seq("Integer >= 5")
+    "see through the quotes in the original YAML, so a quoted number still goes in bare" in {
+      relationship(ontologyOf(quotedNumberBound), "Thing", "n").requires shouldBe
+        Seq("Integer >= 5")
     }
 
     "keep a named type's own constraints on the value type, not on every relationship" in {
-      val o = ontologyOf("""
-        |types:
-        |  SmallInt:
-        |    base: int
-        |    uri: xsd:integer
-        |    minimum_value: 1
-        |classes:
-        |  Thing:
-        |    attributes:
-        |      n:
-        |        range: SmallInt
-        """)
+      val o = ontologyOf(typeConstraints)
       concept(o, "SmallInt").requires shouldBe Seq("SmallInt >= 1")
       relationship(o, "Thing", "n").requires shouldBe empty
     }
@@ -389,74 +175,22 @@ class OssieGeneratorSpec extends AnyWordSpec, Matchers {
 
   "inheritance" should {
     "extend is_a and mixins alike" in {
-      concept(
-        ontologyOf("""
-          |classes:
-          |  Base:
-          |    attributes:
-          |      a: {}
-          |  Mixed:
-          |    mixin: true
-          |    attributes:
-          |      b: {}
-          |  Sub:
-          |    is_a: Base
-          |    mixins: [Mixed]
-          |    attributes:
-          |      c: {}
-          """),
-        "Sub",
-      ).extendsConcepts should contain theSameElementsAs Seq("Mixed", "Base")
+      concept(ontologyOf(inheritance), "Sub").extendsConcepts should contain theSameElementsAs
+        Seq("Mixed", "Base")
     }
 
     "leave a relationship off a subtype that inherits it unchanged" in {
-      names(
-        ontologyOf("""
-          |classes:
-          |  Base:
-          |    attributes:
-          |      a: {}
-          |  Sub:
-          |    is_a: Base
-          |    attributes:
-          |      b: {}
-          """),
-        "Sub",
-      ) shouldBe Seq("b")
+      names(ontologyOf(inheritedUnchanged), "Sub") shouldBe Seq("b")
     }
 
     "keep a relationship the subtype narrows" in {
-      val o = ontologyOf("""
-        |classes:
-        |  Cat:
-        |    attributes:
-        |      id:
-        |        identifier: true
-        |  Base:
-        |    attributes:
-        |      pet: {}
-        |  Sub:
-        |    is_a: Base
-        |    slot_usage:
-        |      pet:
-        |        range: Cat
-        """)
+      val o = ontologyOf(narrowedRange)
       role(o, "Sub", "pet").concept shouldBe "Cat"
       role(o, "Base", "pet").concept shouldBe "String"
     }
 
     "keep a relationship the subtype only makes required, so the requires survives" in {
-      val o = ontologyOf("""
-        |classes:
-        |  Base:
-        |    attributes:
-        |      name: {}
-        |  Sub:
-        |    is_a: Base
-        |    slot_usage:
-        |      name:
-        |        required: true
-        """)
+      val o = ontologyOf(narrowedRequired)
       names(o, "Sub") shouldBe Seq("name")
       concept(o, "Sub").requires shouldBe Seq("Sub.name")
       concept(o, "Base").requires shouldBe empty
@@ -465,42 +199,19 @@ class OssieGeneratorSpec extends AnyWordSpec, Matchers {
 
   "identifiers" should {
     "identify by an identifier slot, one-to-one" in {
-      val o = ontologyOf("""
-        |classes:
-        |  Person:
-        |    attributes:
-        |      id:
-        |        identifier: true
-        """)
+      val o = ontologyOf(identifierSlot)
       concept(o, "Person").identifyBy shouldBe Seq("id")
       relationship(o, "Person", "id").multiplicity shouldBe Some(Multiplicity.OneToOne)
     }
 
     "identify by a key slot too" in {
-      val o = ontologyOf("""
-        |classes:
-        |  Person:
-        |    attributes:
-        |      code:
-        |        key: true
-        """)
+      val o = ontologyOf(keySlot)
       concept(o, "Person").identifyBy shouldBe Seq("code")
       relationship(o, "Person", "code").multiplicity shouldBe Some(Multiplicity.OneToOne)
     }
 
     "identify by a compound unique_key, but leave its slots many-to-one" in {
-      val o = ontologyOf("""
-        |slots:
-        |  order: {}
-        |  nr:
-        |    range: integer
-        |classes:
-        |  OrderLine:
-        |    slots: [order, nr]
-        |    unique_keys:
-        |      line:
-        |        unique_key_slots: [order, nr]
-        """)
+      val o = ontologyOf(compoundKey)
       concept(o, "OrderLine").identifyBy shouldBe Seq("order", "nr")
       // Only the tuple is unique - neither slot identifies a line on its own.
       relationship(o, "OrderLine", "order").multiplicity shouldBe Some(Multiplicity.ManyToOne)
@@ -510,31 +221,14 @@ class OssieGeneratorSpec extends AnyWordSpec, Matchers {
 
   "the document" should {
     "include the schema name, description and the pinned spec version" in {
-      val o = ontologyOf("""
-        |description: A demo schema.
-        |classes:
-        |  Thing:
-        |    attributes:
-        |      x: {}
-        """)
+      val o = ontologyOf(describedSchema)
       o.version shouldBe OssieOntology.specVersion
       o.name shouldBe "spec"
       o.description shouldBe Some("A demo schema.")
     }
 
     "take descriptions in the language the caller asked for" in {
-      val sv = schemaOf("""
-        |classes:
-        |  Book:
-        |    description:
-        |      en: A book.
-        |      pl: Książka.
-        |    attributes:
-        |      title:
-        |        description:
-        |          en: Its title.
-        |          pl: Jej tytuł.
-        """)
+      val sv = schemaOf(multilingualDescriptions)
       def descriptions(language: String): (Option[String], Option[String]) = {
         val o = OssieGenerator(using sv).generate(
           OssieGenerator.Options(metadataLanguage = language),
@@ -549,38 +243,15 @@ class OssieGeneratorSpec extends AnyWordSpec, Matchers {
     }
 
     "pass an object-valued ai_context extension through" in {
-      yamlOf("""
-        |extensions:
-        |  ai_context:
-        |    value:
-        |      instructions: Prefer the full name.
-        |classes:
-        |  Thing:
-        |    attributes:
-        |      x: {}
-        """) should include("instructions: Prefer the full name.")
+      yamlOf(aiContextObject) should include("instructions: Prefer the full name.")
     }
 
     "leave ai_context out when the schema declares no such extension" in {
-      ontologyOf("""
-        |classes:
-        |  Thing:
-        |    attributes:
-        |      x: {}
-        """).aiContext shouldBe None
+      ontologyOf(plain).aiContext shouldBe None
     }
 
     "drop the classes that pruning puts out of reach" in {
-      val sv = schemaOf("""
-        |classes:
-        |  Root:
-        |    tree_root: true
-        |    attributes:
-        |      x: {}
-        |  Orphan:
-        |    attributes:
-        |      y: {}
-        """)
+      val sv = schemaOf(treeRoot)
       def concepts(mode: PruningMode): Seq[String] =
         OssieGenerator(using sv).generate(OssieGenerator.Options(pruningMode = mode))
           .ontology.map(_.concept)
@@ -590,74 +261,9 @@ class OssieGeneratorSpec extends AnyWordSpec, Matchers {
     }
 
     "read back into the model it was written from" in {
-      val sv = schemaOf("""
-        |enums:
-        |  Status:
-        |    permissible_values:
-        |      OK: {}
-        |classes:
-        |  Person:
-        |    attributes:
-        |      id:
-        |        identifier: true
-        |      status:
-        |        range: Status
-        |      friend:
-        |        range: Person
-        |        multivalued: true
-        """)
-      val generator = OssieGenerator(using sv)
+      val generator = OssieGenerator(using schemaOf(severalKinds))
       val written = generator.serialize()
       OssieOntology.codec.decode(parseYaml(written).toOption.get) shouldBe generator.generate()
     }
   }
-}
-
-object OssieGeneratorSpec {
-
-  /** A SchemaView over a minimal schema with [[body]] spliced in. */
-  private def schemaOf(body: String): SchemaView = {
-    val schema =
-      s"""id: https://example.org/spec
-         |name: spec
-         |prefixes:
-         |  linkml: https://w3id.org/linkml/
-         |  xsd: http://www.w3.org/2001/XMLSchema#
-         |  ex: https://example.org/
-         |default_prefix: ex
-         |default_range: string
-         |imports:
-         |  - linkml:types
-         |${body.stripMargin}
-         |""".stripMargin
-    SchemaIssues.orThrow(SchemaView.loadSchemaViewFromString(schema))
-  }
-
-  private def ontologyOf(body: String): OssieOntology =
-    OssieGenerator(using schemaOf(body)).generate()
-
-  private def yamlOf(body: String): String =
-    OssieGenerator(using schemaOf(body)).serialize()
-
-  private def concept(o: OssieOntology, name: String): Concept =
-    o.ontology.find(_.concept == name).getOrElse(
-      throw AssertionError(s"no concept '$name' in ${o.ontology.map(_.concept)}"),
-    )
-
-  private def relationship(o: OssieOntology, conceptName: String, name: String): Relationship = {
-    val c = concept(o, conceptName)
-    c.relationships.find(_.name == name).getOrElse(
-      throw AssertionError(s"no relationship '$name' on '$conceptName' in ${names(o, conceptName)}"),
-    )
-  }
-
-  /** The single role of a relationship, which is the only shape this generator emits. */
-  private def role(o: OssieOntology, conceptName: String, name: String): Role =
-    relationship(o, conceptName, name).roles match {
-      case Seq(only) => only
-      case other => throw AssertionError(s"expected exactly one role, got $other")
-    }
-
-  private def names(o: OssieOntology, conceptName: String): Seq[String] =
-    concept(o, conceptName).relationships.map(_.name)
 }

--- a/generator/test/src/eu/neverblink/linkml/generator/ossie/OssieImporterSpec.scala
+++ b/generator/test/src/eu/neverblink/linkml/generator/ossie/OssieImporterSpec.scala
@@ -1,0 +1,605 @@
+package eu.neverblink.linkml.generator.ossie
+
+import eu.neverblink.linkml.generator.ossie.OssieCases.*
+import eu.neverblink.linkml.generator.ossie.expression.{Expression, Literal}
+import eu.neverblink.linkml.generator.util.JsonOutputFormat
+import eu.neverblink.linkml.metamodel.{SchemaDefinitionImpl, SlotDefinitionImpl}
+import eu.neverblink.linkml.runtime.{PlainText, Reference}
+import eu.neverblink.linkml.schemaview.{SchemaIssues, SchemaView}
+import eu.neverblink.linkml.tests.ModelCatalogue
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
+
+import java.io.{ByteArrayInputStream, InputStream}
+import java.nio.charset.StandardCharsets
+
+/** Tests for the Ossie -> LinkML mapping, and for the two directions agreeing with each other. */
+class OssieImporterSpec extends AnyWordSpec, Matchers, OssieFixtures {
+
+  import OssieImporterSpec.*
+
+  "round-tripping" should {
+    "preserve the original Ossie ontology (ossie->linkml->ossie)" when {
+      for c <- OssieCases.all do
+        s"Ossie test case: ${c.label}" in {
+          val original = yamlOf(c)
+          OssieGenerator(using reimport(original)).serialize() shouldBe original
+        }
+
+      for entry <- ModelCatalogue.all do
+        s"Model catalogue: ${entry.name}" in {
+          val original = OssieGenerator(using entry.model)
+            .serialize(OssieGenerator.Options(outputFormat = JsonOutputFormat.json))
+          OssieGenerator(using reimport(original))
+            .serialize(
+              OssieGenerator.Options(outputFormat = JsonOutputFormat.json),
+            ) shouldBe original
+        }
+    }
+
+    "be able to parse expressions written by the Ossie generator" when {
+      for c <- OssieCases.all do
+        c.label in {
+          val o = ontologyOf(c)
+          val requires = o.ontology.flatMap(concept =>
+            concept.requires ++ concept.relationships.flatMap(_.requires),
+          )
+          requires.filter(Expression.parse(_).isEmpty) shouldBe empty
+        }
+    }
+
+    "survive being written and read as JSON" in {
+      val original = OssieGenerator(using schemaOf(severalKinds))
+        .serialize(OssieGenerator.Options(outputFormat = JsonOutputFormat.json))
+      OssieGenerator(using reimport(original))
+        .serialize(OssieGenerator.Options(outputFormat = JsonOutputFormat.json)) shouldBe original
+    }
+  }
+
+  "the document" should {
+    "carry over the name and description" in {
+      val schema = importOf(ossie("""
+        |description: A demo ontology.
+        |ontology:
+        |  - concept: Thing
+        |    type: EntityType
+        """))
+      schema.name shouldBe "spec"
+      schema.description shouldBe Some(PlainText("A demo ontology."))
+    }
+
+    "invent a schema id, since an Ossie ontology has none" in {
+      importOf(ossie("""
+        |ontology:
+        |  - concept: Thing
+        |    type: EntityType
+        """)).id.original shouldBe "https://example.org/spec"
+    }
+
+    "use the schema id the caller asked for instead" in {
+      val schema = OssieImporter().importSchemaFromString(
+        ossie("""
+          |ontology:
+          |  - concept: Thing
+          |    type: EntityType
+          """),
+        OssieImporter.Options(schemaId = Some("https://example.com/mine")),
+      )
+      schema.id.original shouldBe "https://example.com/mine"
+    }
+
+    "import the LinkML types, so that the ranges it writes resolve" in {
+      val schema = importOf(ossie("""
+        |ontology:
+        |  - concept: Thing
+        |    type: EntityType
+        """))
+      schema.imports.map(_.original) shouldBe Seq("linkml:types")
+      schema.prefixes.keys should contain("linkml")
+    }
+
+    "put ai_context back where the generator reads it from" in {
+      val schema = importOf(ossie("""
+        |ai_context:
+        |  instructions: Prefer the full name.
+        |ontology:
+        |  - concept: Thing
+        |    type: EntityType
+        """))
+      val extension = schema.extensions("ai_context")
+      extension.extensionTag.original shouldBe "ai_context"
+      extension.extensionValue.value should include("instructions: Prefer the full name.")
+    }
+
+    "serialize as JSON when asked to" in {
+      val json = OssieImporter().serialize(
+        stream(ossie("""
+          |ontology:
+          |  - concept: Thing
+          |    type: EntityType
+          """)),
+        OssieImporter.Options(outputFormat = JsonOutputFormat.json),
+      )
+      json should startWith("{")
+      json should include("\"name\": \"spec\"")
+    }
+
+    "produce a schema that has nothing wrong with it" in {
+      reimport(yamlOf(severalKinds)).validationProblems shouldBe empty
+    }
+  }
+
+  "reading from a stream" should {
+    "decode UTF-8 across the read buffer" in {
+      val long = "łąka🎸" * 2000
+      val schema = OssieImporter().importSchema(stream(ossie(s"""
+        |description: "$long"
+        |ontology:
+        |  - concept: Thing
+        |    type: EntityType
+        """)))
+      schema.description shouldBe Some(PlainText(long))
+    }
+
+    "not close the stream it was handed" in {
+      var closed = false
+      val document = ossie("""
+        |ontology:
+        |  - concept: Thing
+        |    type: EntityType
+        """)
+      val in = new ByteArrayInputStream(document.getBytes(StandardCharsets.UTF_8)) {
+        override def close(): Unit = closed = true
+      }
+      OssieImporter().importSchema(in)
+      closed shouldBe false
+    }
+  }
+
+  "concepts" should {
+    "make a class out of an EntityType" in {
+      val cls = importOf(ossie("""
+        |ontology:
+        |  - concept: Book
+        |    type: EntityType
+        |    description: A book.
+        """)).classes("Book")
+      cls.description shouldBe Some(PlainText("A book."))
+    }
+
+    "make an enum out of a ValueType that lists the values it allows" in {
+      val e = importOf(ossie("""
+        |ontology:
+        |  - concept: Status
+        |    type: ValueType
+        |    extends: [String]
+        |    requires:
+        |      - Status IN ('ALIVE', 'DEAD')
+        """)).enums("Status")
+      e.permissibleValues.keys.toSeq shouldBe Seq("ALIVE", "DEAD")
+      e.permissibleValues("ALIVE").text shouldBe "ALIVE"
+    }
+
+    "unescape a doubled apostrophe in a permissible value" in {
+      importOf(ossie("""
+        |ontology:
+        |  - concept: Kind
+        |    type: ValueType
+        |    extends: [String]
+        |    requires:
+        |      - Kind IN ('it''s')
+        """)).enums("Kind").permissibleValues.keys.toSeq shouldBe Seq("it's")
+    }
+
+    "make a named type out of a ValueType that does not" in {
+      val t = importOf(ossie("""
+        |ontology:
+        |  - concept: SmallInt
+        |    type: ValueType
+        |    extends: [Integer]
+        |    requires:
+        |      - SmallInt >= 1
+        """)).types("SmallInt")
+      t.typeof shouldBe Some(Reference("integer"))
+      t.minimumValue.map(_.value) shouldBe Some("1")
+    }
+
+    "base a value type on text when it extends nothing LinkML knows" in {
+      importOf(ossie("""
+        |ontology:
+        |  - concept: Mystery
+        |    type: ValueType
+        """)).types("Mystery").typeof shouldBe Some(Reference("string"))
+    }
+
+    "read the last of the extends as is_a and the rest as mixins" in {
+      val cls = importOf(ossie("""
+        |ontology:
+        |  - concept: Mixed
+        |    type: EntityType
+        |  - concept: Base
+        |    type: EntityType
+        |  - concept: Sub
+        |    type: EntityType
+        |    extends: [Mixed, Base]
+        """)).classes("Sub")
+      cls.isA shouldBe Some(Reference("Base"))
+      cls.mixins shouldBe Seq(Reference("Mixed"))
+    }
+
+    "normalize a concept name, keeping the original spelling as the class' alias" in {
+      val cls = importOf(ossie("""
+        |ontology:
+        |  - concept: HTTPThing
+        |    type: EntityType
+        """)).classes("HttpThing")
+      cls.name shouldBe "HttpThing"
+      cls.alias shouldBe Some("HTTPThing")
+    }
+
+    "leave the alias off a concept name that normalizing did not change" in {
+      importOf(ossie("""
+        |ontology:
+        |  - concept: Thing
+        |    type: EntityType
+        """)).classes("Thing").alias shouldBe None
+    }
+
+    "not give back a concept name that normalizing changed" in {
+      val ontology = ossie("""
+        |ontology:
+        |  - concept: HTTPThing
+        |    type: EntityType
+        |  - concept: HTTPStatus
+        |    type: ValueType
+        |    extends: [String]
+        |    requires:
+        |      - HTTPStatus IN ('OK')
+        """)
+      importOf(ontology).enums.keys.toSeq shouldBe Seq("HttpStatus")
+      val out = OssieGenerator(using reimport(ontology)).serialize()
+      out should include("concept: HttpThing")
+      out should include("concept: HttpStatus")
+    }
+
+    "refuse two concepts that differ only in naming style" in {
+      val thrown = intercept[RuntimeException](importOf(ossie("""
+        |ontology:
+        |  - concept: HTTPThing
+        |    type: EntityType
+        |  - concept: HttpThing
+        |    type: EntityType
+        """)))
+      thrown.getMessage should include("HttpThing")
+    }
+  }
+
+  "relationships" should {
+    "become attributes, with the built-in ranges mapped back" in {
+      val attributes = importOf(ossie("""
+        |ontology:
+        |  - concept: Thing
+        |    type: EntityType
+        |    relationships:
+        |      - name: s
+        |        roles: [{concept: String}]
+        |        multiplicity: ManyToOne
+        |        verbalizes: ['{Thing} s {String}']
+        |      - name: n
+        |        roles: [{concept: Integer}]
+        |        multiplicity: ManyToOne
+        |        verbalizes: ['{Thing} n {Integer}']
+        |      - name: when
+        |        roles: [{concept: DateTime}]
+        |        multiplicity: ManyToOne
+        |        verbalizes: ['{Thing} when {DateTime}']
+        """)).classes("Thing").attributes
+      attributes("s").range shouldBe Some(Reference("string"))
+      attributes("n").range shouldBe Some(Reference("integer"))
+      attributes("when").range shouldBe Some(Reference("datetime"))
+    }
+
+    "snake_case the slot name and keep the original as an alias" in {
+      val slot = attributeOf(
+        """
+        |      - name: fullName
+        |        roles: [{concept: String}]
+        |        multiplicity: ManyToOne
+        |        verbalizes: ['{Thing} full name {String}']
+        """,
+        "full_name",
+      )
+      slot.alias shouldBe Some("fullName")
+    }
+
+    "leave the alias off when the name needs no changing" in {
+      attributeOf(
+        """
+        |      - name: full_name
+        |        roles: [{concept: String}]
+        |        multiplicity: ManyToOne
+        |        verbalizes: ['{Thing} full name {String}']
+        """,
+        "full_name",
+      ).alias shouldBe None
+    }
+
+    "read a missing multiplicity as multivalued" in {
+      attributeOf(
+        """
+        |      - name: many
+        |        roles: [{concept: String}]
+        |        verbalizes: ['{Thing} many {String}']
+        """,
+        "many",
+      ).multivalued shouldBe true
+    }
+
+    "read the concept's requires as the slots it makes mandatory" in {
+      val attributes = importOf(ossie("""
+        |ontology:
+        |  - concept: Thing
+        |    type: EntityType
+        |    requires:
+        |      - Thing.name
+        |    relationships:
+        |      - name: name
+        |        roles: [{concept: String}]
+        |        multiplicity: ManyToOne
+        |        verbalizes: ['{Thing} name {String}']
+        |      - name: nickname
+        |        roles: [{concept: String}]
+        |        multiplicity: ManyToOne
+        |        verbalizes: ['{Thing} nickname {String}']
+        """)).classes("Thing").attributes
+      attributes("name").required shouldBe true
+      attributes("nickname").required shouldBe false
+    }
+
+    "read the bounds and the pattern off a relationship's requires" in {
+      val slot = attributeOf(
+        """
+        |      - name: n
+        |        roles: [{concept: Integer}]
+        |        multiplicity: ManyToOne
+        |        requires:
+        |          - Integer >= -1
+        |          - Integer <= 10
+        |          - REGEXP_LIKE(Integer, '^[0-9]+$')
+        |        verbalizes: ['{Thing} n {Integer}']
+        """,
+        "n",
+      )
+      slot.minimumValue.map(_.value) shouldBe Some("-1")
+      slot.maximumValue.map(_.value) shouldBe Some("10")
+      slot.pattern shouldBe Some("^[0-9]+$")
+    }
+
+    "keep a bound that is not a number as the string it was" in {
+      val slot = attributeOf(
+        """
+        |      - name: when
+        |        roles: [{concept: Date}]
+        |        multiplicity: ManyToOne
+        |        requires:
+        |          - Date >= '2020-01-01'
+        |        verbalizes: ['{Thing} when {Date}']
+        """,
+        "when",
+      )
+      slot.minimumValue.flatMap(Literal.fromLinkml) shouldBe Some(Literal.Text("2020-01-01"))
+    }
+
+    "ignore an expression in a shape it did not write" in {
+      val slot = attributeOf(
+        """
+        |      - name: n
+        |        roles: [{concept: Integer}]
+        |        multiplicity: ManyToOne
+        |        requires:
+        |          - Integer <> 3
+        |          - IntegerX >= 5
+        |          - COUNT(Integer) > 1
+        |        verbalizes: ['{Thing} n {Integer}']
+        """,
+        "n",
+      )
+      slot.minimumValue shouldBe None
+      slot.maximumValue shouldBe None
+      slot.pattern shouldBe None
+    }
+
+    "read the constraints over a role's name when it has one" in {
+      val slot = attributeOf(
+        """
+        |      - name: parent_of
+        |        roles: [{concept: Thing, name: parent_of}]
+        |        multiplicity: ManyToOne
+        |        requires:
+        |          - REGEXP_LIKE(parent_of, '^x')
+        |        verbalizes: ['{Thing} parent of {Thing:parent_of}']
+        """,
+        "parent_of",
+      )
+      slot.pattern shouldBe Some("^x")
+    }
+
+    "point at the first role of a relationship Ossie allows but LinkML has no shape for" in {
+      attributeOf(
+        """
+        |      - name: between
+        |        roles: [{concept: String}, {concept: Integer}]
+        |        multiplicity: ManyToOne
+        |        verbalizes: ['{Thing} between {String} and {Integer}']
+        """,
+        "between",
+      ).range shouldBe Some(Reference("string"))
+    }
+
+    "leave the range off a relationship with no roles at all" in {
+      attributeOf(
+        """
+        |      - name: nothing
+        |        multiplicity: ManyToOne
+        |        verbalizes: ['{Thing} nothing']
+        """,
+        "nothing",
+      ).range shouldBe None
+    }
+
+    "pass an unknown concept through, so that schema validation reports it" in {
+      attributeOf(
+        """
+        |      - name: x
+        |        roles: [{concept: NeverDeclared}]
+        |        multiplicity: ManyToOne
+        |        verbalizes: ['{Thing} x {NeverDeclared}']
+        """,
+        "x",
+      ).range shouldBe Some(Reference("NeverDeclared"))
+    }
+  }
+
+  "the Any concept" should {
+    "become a linkml:Any class when something refers to it" in {
+      val schema = importOf(ossie("""
+        |ontology:
+        |  - concept: Thing
+        |    type: EntityType
+        |    relationships:
+        |      - name: whatever
+        |        roles: [{concept: Any}]
+        |        multiplicity: ManyToOne
+        |        verbalizes: ['{Thing} whatever {Any}']
+        """))
+      schema.classes("Any").classUri.map(_.original) shouldBe Some("linkml:Any")
+      schema.classes("Thing").attributes("whatever").range shouldBe Some(Reference("Any"))
+    }
+
+    "stay out of the schema when nothing refers to it" in {
+      importOf(ossie("""
+        |ontology:
+        |  - concept: Thing
+        |    type: EntityType
+        """)).classes.keys should not contain "Any"
+    }
+  }
+
+  "identifiers" should {
+    "make a single one-to-one identify_by into an identifier slot" in {
+      val cls = importOf(ossie("""
+        |ontology:
+        |  - concept: Person
+        |    type: EntityType
+        |    identify_by: [id]
+        |    relationships:
+        |      - name: id
+        |        roles: [{concept: String}]
+        |        multiplicity: OneToOne
+        |        verbalizes: ['{Person} id {String}']
+        """)).classes("Person")
+      cls.attributes("id").identifier shouldBe true
+      cls.uniqueKeys shouldBe empty
+    }
+
+    "make a compound identify_by into a unique key" in {
+      val cls = importOf(ossie("""
+        |ontology:
+        |  - concept: OrderLine
+        |    type: EntityType
+        |    identify_by: [order, nr]
+        |    relationships:
+        |      - name: order
+        |        roles: [{concept: String}]
+        |        multiplicity: ManyToOne
+        |        verbalizes: ['{OrderLine} order {String}']
+        |      - name: nr
+        |        roles: [{concept: Integer}]
+        |        multiplicity: ManyToOne
+        |        verbalizes: ['{OrderLine} nr {Integer}']
+        """)).classes("OrderLine")
+      cls.attributes.values.map(_.identifier) should contain only false
+      cls.uniqueKeys.values.head.uniqueKeySlots shouldBe Seq(Reference("order"), Reference("nr"))
+    }
+
+    "fall back to a unique key when the identifying role is not a value" in {
+      val cls = importOf(ossie("""
+        |ontology:
+        |  - concept: Passport
+        |    type: EntityType
+        |  - concept: Person
+        |    type: EntityType
+        |    identify_by: [passport]
+        |    relationships:
+        |      - name: passport
+        |        roles: [{concept: Passport}]
+        |        multiplicity: OneToOne
+        |        verbalizes: ['{Person} passport {Passport}']
+        """)).classes("Person")
+      cls.attributes("passport").identifier shouldBe false
+      cls.uniqueKeys.values.head.uniqueKeySlots shouldBe Seq(Reference("passport"))
+    }
+
+    "leave an inherited identifier to the supertype that declares it" in {
+      val cls = importOf(ossie("""
+        |ontology:
+        |  - concept: Base
+        |    type: EntityType
+        |    identify_by: [id]
+        |    relationships:
+        |      - name: id
+        |        roles: [{concept: String}]
+        |        multiplicity: OneToOne
+        |        verbalizes: ['{Base} id {String}']
+        |  - concept: Sub
+        |    type: EntityType
+        |    extends: [Base]
+        |    identify_by: [id]
+        """)).classes("Sub")
+      cls.attributes shouldBe empty
+      cls.uniqueKeys shouldBe empty
+    }
+  }
+
+  "an unreadable document" should {
+    "say so rather than producing a broken schema" in {
+      val thrown = intercept[RuntimeException](importOf("name: [unclosed"))
+      thrown.getMessage should include("Ossie ontology")
+    }
+  }
+}
+
+object OssieImporterSpec {
+
+  private def stream(ontology: String): InputStream =
+    ByteArrayInputStream(ontology.getBytes(StandardCharsets.UTF_8))
+
+  private def importOf(ontology: String): SchemaDefinitionImpl =
+    OssieImporter().importSchemaFromString(ontology)
+
+  /** A one-off Ossie document, with [[body]] spliced in after the pinned version and a name. */
+  private def ossie(body: String): String =
+    s"""version: ${OssieOntology.specVersion}
+       |name: spec
+       |${body.stripMargin}
+       |""".stripMargin
+
+  /** The attribute a single relationship on a lone concept turns into. */
+  private def attributeOf(relationship: String, name: String): SlotDefinitionImpl =
+    importOf(ossie(s"""
+      |ontology:
+      |  - concept: Thing
+      |    type: EntityType
+      |    relationships:${relationship.stripMargin}
+      """)).classes("Thing").attributes(name)
+
+  /** The SchemaView an ontology imports to, by way of the LinkML the importer serializes.
+    *
+    * We include LinkML ser/des on purpose, because Ossie uses the LinkML metamodel in weird ways
+    * that the codec might not support.
+    */
+  private def reimport(ontology: String): SchemaView =
+    SchemaIssues.orThrow(
+      SchemaView.loadSchemaViewFromString(OssieImporter().serialize(stream(ontology))),
+    )
+}

--- a/generator/test/src/eu/neverblink/linkml/generator/ossie/OssieImporterSpec.scala
+++ b/generator/test/src/eu/neverblink/linkml/generator/ossie/OssieImporterSpec.scala
@@ -324,6 +324,61 @@ class OssieImporterSpec extends AnyWordSpec, Matchers, OssieFixtures {
       ).alias shouldBe None
     }
 
+    "rank the attributes in the order the relationships were written" in {
+      val cls = importOf(ossie("""
+        |ontology:
+        |  - concept: Thing
+        |    type: EntityType
+        |    relationships:
+        |      - name: zzz
+        |        roles: [{concept: String}]
+        |        multiplicity: ManyToOne
+        |        verbalizes: ['{Thing} zzz {String}']
+        |      - name: aaa
+        |        roles: [{concept: String}]
+        |        multiplicity: ManyToOne
+        |        verbalizes: ['{Thing} aaa {String}']
+        """)).classes("Thing")
+      cls.attributes.values.map(s => s.name -> s.rank).toSeq shouldBe
+        Seq("zzz" -> Some(1), "aaa" -> Some(2))
+    }
+
+    "read the verbalization's phrase as the title" in {
+      attributeOf(
+        """
+        |      - name: full_name
+        |        roles: [{concept: String}]
+        |        multiplicity: ManyToOne
+        |        verbalizes: ['{Thing} has official name {String}']
+        """,
+        "full_name",
+      ).title shouldBe Some(PlainText("has official name"))
+    }
+
+    "leave the title off when the phrase is just the name" in {
+      attributeOf(
+        """
+        |      - name: full_name
+        |        roles: [{concept: String}]
+        |        multiplicity: ManyToOne
+        |        verbalizes: ['{Thing} full name {String}']
+        """,
+        "full_name",
+      ).title shouldBe None
+    }
+
+    "read the phrase of a self-referencing relationship, past the role name" in {
+      attributeOf(
+        """
+        |      - name: parent_of
+        |        roles: [{concept: Thing, name: parent_of}]
+        |        multiplicity: ManyToOne
+        |        verbalizes: ['{Thing} is the parent of {Thing:parent_of}']
+        """,
+        "parent_of",
+      ).title shouldBe Some(PlainText("is the parent of"))
+    }
+
     "read a missing multiplicity as multivalued" in {
       attributeOf(
         """

--- a/generator/test/src/eu/neverblink/linkml/generator/ossie/expression/ExpressionGen.scala
+++ b/generator/test/src/eu/neverblink/linkml/generator/ossie/expression/ExpressionGen.scala
@@ -1,0 +1,76 @@
+package eu.neverblink.linkml.generator.ossie.expression
+
+import org.scalacheck.Gen
+
+/** Scalacheck generators for Ossie expressions. */
+private[ossie] object ExpressionGen {
+
+  import Expression.*
+
+  val ident: Gen[String] = for {
+    first <- Gen.oneOf(Gen.alphaChar, Gen.const('_'))
+    rest <- Gen.listOf(Gen.oneOf(Gen.alphaNumChar, Gen.numChar, Gen.const('_')))
+  } yield (first +: rest).mkString
+
+  val ref: Gen[Ref] = ident.map(Ref.apply)
+
+  /** Text that goes inside a quoted literal. */
+  val text: Gen[String] = Gen.frequency(
+    3 -> Gen.asciiPrintableStr,
+    3 -> Gen.listOf(Gen.oneOf('\'', 'a', ' ', ',', ')', '(')).map(_.mkString),
+    1 -> Gen.const(""),
+    1 -> Gen.const("it's"),
+    1 -> Gen.const("'"),
+    1 -> Gen.const("''"),
+    2 -> Gen.asciiStr,
+  )
+
+  /** A number, as the writer would produce one - anything [[Literal.isNumber]] accepts. */
+  val number: Gen[Literal.Number] = Gen.oneOf(
+    Gen.chooseNum(Int.MinValue, Int.MaxValue).map(_.toString),
+    Gen.chooseNum(-1.0e9, 1.0e9).map(_.toString),
+    Gen.chooseNum(Long.MinValue, Long.MaxValue).map(_.toString),
+  ).filter(Literal.isNumber).map(Literal.Number.apply)
+
+  val literalText: Gen[Literal.Text] = text.map(Literal.Text.apply)
+
+  val literal: Gen[Literal] = Gen.oneOf(number, literalText)
+
+  /** A literal that survives a trip through LinkML.
+    *
+    * TODO: consider trying to fix some of the cases that are excluded on the side of LinkML.
+    */
+  val linkmlSafeLiteral: Gen[Literal] = Gen.oneOf(
+    number,
+    text.map { s =>
+      val oneLine = s.filter(c => c != '\n' && c != '\r')
+      if oneLine.isEmpty || Literal.isNumber(oneLine) then oneLine + "x" else oneLine
+    }.map(Literal.Text.apply),
+  )
+
+  val member: Gen[Member] = for { r <- ref; rel <- ident } yield Member(r, rel)
+
+  val inList: Gen[InList] = for { r <- ref; vs <- Gen.listOf(literalText) } yield InList(r, vs)
+
+  val atLeast: Gen[AtLeast] = for { r <- ref; v <- literal } yield AtLeast(r, v)
+
+  val atMost: Gen[AtMost] = for { r <- ref; v <- literal } yield AtMost(r, v)
+
+  val regexpLike: Gen[RegexpLike] =
+    for { r <- ref; p <- literalText } yield RegexpLike(r, p)
+
+  val expression: Gen[Expression] = Gen.oneOf(member, inList, atLeast, atMost, regexpLike)
+
+  /** The same expression written with the whitespace Ossie allows but [[Expression.render]] does
+    * not produce.
+    */
+  def spaced(e: Expression): String = e match {
+    case Member(r, rel) => s"  ${r.name}.$rel\t"
+    case InList(r, vs) =>
+      val body = vs.map(_.render).mkString(" ,\t")
+      s"\t${r.name}  \t IN \t( $body\t)  "
+    case AtLeast(r, v) => s" ${r.name}\t>=  ${v.render} "
+    case AtMost(r, v) => s"  ${r.name}  <=\t${v.render}\t"
+    case RegexpLike(r, p) => s" REGEXP_LIKE\t( ${r.name} ,\t${p.render}  ) "
+  }
+}

--- a/generator/test/src/eu/neverblink/linkml/generator/ossie/expression/ExpressionSpec.scala
+++ b/generator/test/src/eu/neverblink/linkml/generator/ossie/expression/ExpressionSpec.scala
@@ -1,0 +1,166 @@
+package eu.neverblink.linkml.generator.ossie.expression
+
+import eu.neverblink.linkml.runtime.LinkmlAny
+import org.scalacheck.Gen
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
+import org.scalatestplus.scalacheck.ScalaCheckPropertyChecks
+import org.virtuslab.yaml.{NodeOps, StringNode}
+
+/** Tests for the Ossie expression language parsing and rendering. */
+class ExpressionSpec extends AnyWordSpec, Matchers, ScalaCheckPropertyChecks {
+
+  import Expression.*
+
+  // How many times to run each property test (scalacheck)
+  override implicit val generatorDrivenConfig: PropertyCheckConfiguration =
+    PropertyCheckConfiguration(minSuccessful = 1000)
+
+  private def parsed(text: String): Expression =
+    Expression.parse(text).getOrElse(fail(s"did not parse: '$text'"))
+
+  println(StringNode("2020-01-01").asYaml.strip())
+
+  "rendering" should {
+    "write a member as a dotted pair" in {
+      Member(Ref("Person"), "name").render shouldBe "Person.name"
+    }
+
+    "write an IN list with the values quoted" in {
+      InList(Ref("Status"), Seq(Literal.Text("ALIVE"), Literal.Text("DEAD"))).render shouldBe
+        "Status IN ('ALIVE', 'DEAD')"
+    }
+
+    "double an apostrophe inside a value" in {
+      InList(Ref("Kind"), Seq(Literal.Text("it's"))).render shouldBe "Kind IN ('it''s')"
+    }
+
+    "write a bare number and a quoted string differently" in {
+      AtLeast(Ref("Integer"), Literal.Number("5")).render shouldBe "Integer >= 5"
+      AtLeast(Ref("Date"), Literal.Text("2020-01-01")).render shouldBe "Date >= '2020-01-01'"
+    }
+
+    "write a pattern as a REGEXP_LIKE call" in {
+      RegexpLike(Ref("String"), Literal.Text("^[A-Z]$")).render shouldBe
+        "REGEXP_LIKE(String, '^[A-Z]$')"
+    }
+  }
+
+  "parsing" should {
+    "read each shape back" in {
+      parsed("Person.name") shouldBe Member(Ref("Person"), "name")
+      parsed("Status IN ('ALIVE', 'DEAD')") shouldBe
+        InList(Ref("Status"), Seq(Literal.Text("ALIVE"), Literal.Text("DEAD")))
+      parsed("Integer >= 5") shouldBe AtLeast(Ref("Integer"), Literal.Number("5"))
+      parsed("Integer <= -1") shouldBe AtMost(Ref("Integer"), Literal.Number("-1"))
+      parsed("REGEXP_LIKE(S, '^x')") shouldBe RegexpLike(Ref("S"), Literal.Text("^x"))
+    }
+
+    "unescape a doubled apostrophe" in {
+      parsed("Kind IN ('it''s')") shouldBe InList(Ref("Kind"), Seq(Literal.Text("it's")))
+    }
+
+    "read an empty IN list" in {
+      parsed("Kind IN ()") shouldBe InList(Ref("Kind"), Nil)
+    }
+
+    "tell a quoted bound from a bare one" in {
+      parsed("Date >= '2020-01-01'") shouldBe AtLeast(Ref("Date"), Literal.Text("2020-01-01"))
+      parsed("Integer >= 5") shouldBe AtLeast(Ref("Integer"), Literal.Number("5"))
+    }
+
+    "report the name it actually found" in {
+      parsed("IntegerX >= 5").ref shouldBe Ref("IntegerX")
+      Constraints.from(Ref("Integer"), Seq(parsed("IntegerX >= 5"))) shouldBe Constraints()
+    }
+
+    "refuse a shape it does not write" in {
+      Expression.parse("Integer <> 3") shouldBe None
+      Expression.parse("COUNT(Integer) > 1") shouldBe None
+      Expression.parse("Integer >= ") shouldBe None
+      Expression.parse("") shouldBe None
+    }
+
+    "refuse an unterminated literal" in {
+      Expression.parse("Kind IN ('a)") shouldBe None
+      Expression.parse("REGEXP_LIKE(S, 'x)") shouldBe None
+    }
+
+    "refuse a bound that is neither a number nor a literal" in {
+      Expression.parse("Integer >= abc") shouldBe None
+    }
+
+    "refuse a name that is not a bare identifier" in {
+      Expression.parse("Order.line.nr") shouldBe None
+      Expression.parse("'Order'.nr") shouldBe None
+      Expression.parse("Order line >= 5") shouldBe None
+    }
+
+    "not be fooled by REGEXP_LIKE used as a name" in {
+      parsed("REGEXP_LIKE.x") shouldBe Member(Ref("REGEXP_LIKE"), "x")
+    }
+  }
+
+  "a LinkML value" should {
+    "go in bare when it is a number, quoted when it is not" in {
+      Literal.fromLinkml(LinkmlAny("5")) shouldBe Some(Literal.Number("5"))
+      Literal.fromLinkml(LinkmlAny("abc")) shouldBe Some(Literal.Text("abc"))
+    }
+
+    "go in bare even when the YAML had it quoted" in {
+      Literal.fromLinkml(LinkmlAny("\"5\"")) shouldBe Some(Literal.Number("5"))
+    }
+
+    "unescape the YAML rather than just trimming the quotes" in {
+      Literal.fromLinkml(LinkmlAny("\"a\\\"b\"")) shouldBe Some(Literal.Text("a\"b"))
+      Literal.fromLinkml(LinkmlAny("\"a\\\\b\"")) shouldBe Some(Literal.Text("a\\b"))
+    }
+
+    "fold a wrapped scalar the way YAML does" in {
+      Literal.fromLinkml(LinkmlAny("a\nb")) shouldBe Some(Literal.Text("a b"))
+    }
+
+    "be refused when it cannot be written as one" in {
+      Literal.fromLinkml(LinkmlAny("")) shouldBe None
+      Literal.fromLinkml(LinkmlAny("\"a\\nb\"")) shouldBe None
+      Literal.fromLinkml(LinkmlAny("[1, 2]")) shouldBe None
+    }
+  }
+
+  "the round trip" should {
+    "parse back every expression it wrote" in {
+      forAll(ExpressionGen.expression) { e =>
+        Expression.parse(e.render) shouldBe Some(e)
+      }
+    }
+
+    "accept whitespace it would not have written itself" in {
+      forAll(ExpressionGen.expression) { e =>
+        Expression.parse(ExpressionGen.spaced(e)) shouldBe Some(e)
+      }
+    }
+
+    "parse back every literal that survives LinkML" in {
+      forAll(ExpressionGen.linkmlSafeLiteral) { l =>
+        Literal.fromLinkml(l.toLinkml) shouldBe Some(l)
+      }
+    }
+
+    "keep constraints attached to the name they were written over" in {
+      forAll(ExpressionGen.ref, ExpressionGen.ref, ExpressionGen.linkmlSafeLiteral) { (a, b, v) =>
+        val written = Constraints(minimumValue = Some(v.toLinkml)).render(a)
+        val read = Constraints.from(a, written.map(_.render).flatMap(Expression.parse))
+        read.minimumValue.map(_.value) shouldBe Some(v.toLinkml.value)
+        if a != b then
+          Constraints.from(b, written.map(_.render).flatMap(Expression.parse)) shouldBe
+            Constraints()
+      }
+    }
+
+    "answer rather than throw, whatever it is handed" in {
+      forAll(Gen.oneOf(Gen.asciiStr, Gen.alphaStr, Gen.identifier)) { s =>
+        noException should be thrownBy Expression.parse(s)
+      }
+    }
+  }
+}

--- a/nativelib/include/linkml_scala.h
+++ b/nativelib/include/linkml_scala.h
@@ -67,6 +67,9 @@ char *linkml_ossie(long long handle, const char *options, char **error);
 char *linkml_scala(long long handle, const char *options, char **error);
 char *linkml_frictionless(long long handle, const char *options, char **error);
 
+/* Importers. Each takes a document and returns the LinkML schema it describes. */
+char *linkml_from_ossie(const char *ontology, const char *options, char **error);
+
 /* Release anything the library returned. NULL-safe. */
 void linkml_free(char *buffer);
 

--- a/nativelib/src/eu/neverblink/linkml/nativelib/LinkMlCApi.scala
+++ b/nativelib/src/eu/neverblink/linkml/nativelib/LinkMlCApi.scala
@@ -93,6 +93,15 @@ object LinkMlCApi {
   @exported("linkml_init_threads")
   def initThreads(): CInt = Attach.linkml_init_threads_impl()
 
+  /** Read an Apache Ossie ontology and return the LinkML schema it describes.
+    *
+    * Takes a document rather than a schema handle, so it is hand-written here rather than generated
+    * into `LinkMlCGenerators` with the rest.
+    */
+  @exported("linkml_from_ossie")
+  def fromOssie(ontology: CString, options: CString, error: Ptr[CString]): CString =
+    write(error, out => LinkMlNativeApi.fromOssie(string(ontology), string(options), out))
+
   // Internals
 
   private[nativelib] def document(

--- a/nativelib/src/eu/neverblink/linkml/nativelib/LinkMlNativeApi.scala
+++ b/nativelib/src/eu/neverblink/linkml/nativelib/LinkMlNativeApi.scala
@@ -5,7 +5,7 @@ import eu.neverblink.linkml.generator.frictionless.FrictionlessGenerator
 import eu.neverblink.linkml.generator.graphql.GraphQlGenerator
 import eu.neverblink.linkml.generator.jsonschema.JsonSchemaGenerator
 import eu.neverblink.linkml.generator.linkml.LinkMlGenerator
-import eu.neverblink.linkml.generator.ossie.OssieGenerator
+import eu.neverblink.linkml.generator.ossie.{OssieGenerator, OssieImporter}
 import eu.neverblink.linkml.generator.rdfs.RdfsGenerator
 import eu.neverblink.linkml.generator.scala.ScalaGenerator
 import eu.neverblink.linkml.generator.shacl.ShaclGenerator
@@ -16,7 +16,8 @@ import eu.neverblink.linkml.schemaview.{Importer, SchemaValidator, SchemaView, S
 import eu.neverblink.linkml.validation.{Codec, SchemaIssue, SchemaValidationReportImpl}
 import org.virtuslab.yaml.{Node, StringNode}
 
-import java.io.OutputStream
+import java.io.{ByteArrayInputStream, OutputStream}
+import java.nio.charset.StandardCharsets.UTF_8
 import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.atomic.AtomicLong
 
@@ -35,8 +36,9 @@ object LinkMlNativeApi {
     *   - 2: added `linkml_build_info`; replaced `tableSchema` with `frictionless`.
     *   - 3: rebuilt with Scala Native. The isolate arguments were removed. `linkml_init_threads`
     *     replaces `graal_create_isolate`. `platform` in `linkml_build_info` is now `SCALA_NATIVE`.
+   *      Added `linkml_from_ossie`.
     */
-  final val abiVersion: Int = 3
+  final val abiVersion: Int = 4
 
   private val schemas = new ConcurrentHashMap[java.lang.Long, SchemaView]()
 
@@ -146,6 +148,18 @@ object LinkMlNativeApi {
   def ossie(handle: Long, optionsJson: String, out: OutputStream): Unit = {
     given SchemaView = view(handle)
     OssieGenerator().writeTo(out, Options.ossie(optionsJson))
+  }
+
+  /** The LinkML schema an Apache Ossie ontology describes, as YAML or JSON depending on the
+    * `outputFormat` option.
+    */
+  def fromOssie(ontology: String, optionsJson: String, out: OutputStream): Unit = {
+    if ontology eq null then throw BadRequest("no ontology document was given")
+    OssieImporter().writeTo(
+      ByteArrayInputStream(ontology.getBytes(UTF_8)),
+      out,
+      Options.fromOssie(optionsJson),
+    )
   }
 
   // Results that are structured, and so come back as JSON

--- a/nativelib/src/eu/neverblink/linkml/nativelib/LinkMlNativeApi.scala
+++ b/nativelib/src/eu/neverblink/linkml/nativelib/LinkMlNativeApi.scala
@@ -36,9 +36,9 @@ object LinkMlNativeApi {
     *   - 2: added `linkml_build_info`; replaced `tableSchema` with `frictionless`.
     *   - 3: rebuilt with Scala Native. The isolate arguments were removed. `linkml_init_threads`
     *     replaces `graal_create_isolate`. `platform` in `linkml_build_info` is now `SCALA_NATIVE`.
-   *      Added `linkml_from_ossie`.
+    *     Added `linkml_from_ossie`.
     */
-  final val abiVersion: Int = 4
+  final val abiVersion: Int = 3
 
   private val schemas = new ConcurrentHashMap[java.lang.Long, SchemaView]()
 

--- a/nativelib/src/eu/neverblink/linkml/nativelib/Options.scala
+++ b/nativelib/src/eu/neverblink/linkml/nativelib/Options.scala
@@ -6,7 +6,7 @@ import eu.neverblink.linkml.generator.erdiagram.ErDiagramGenerator
 import eu.neverblink.linkml.generator.graphql.GraphQlGenerator
 import eu.neverblink.linkml.generator.jsonschema.JsonSchemaGenerator
 import eu.neverblink.linkml.generator.linkml.LinkMlGenerator
-import eu.neverblink.linkml.generator.ossie.OssieGenerator
+import eu.neverblink.linkml.generator.ossie.{OssieGenerator, OssieImporter}
 import eu.neverblink.linkml.generator.rdf.RdfFormat
 import eu.neverblink.linkml.generator.rdfs.RdfsGenerator
 import eu.neverblink.linkml.generator.scala.ScalaGenerator
@@ -86,6 +86,9 @@ private object Options {
   }
 
   // Unknown fields are rejected rather than skipped.
+  private given fromOssieOptions: JsonValueCodec[OssieImporter.Options] =
+    JsonCodecMaker.make(CodecMakerConfig.withSkipUnexpectedFields(false))
+
   private given jsonSchemaOptions: JsonValueCodec[JsonSchemaGenerator.Options] =
     JsonCodecMaker.make(CodecMakerConfig.withSkipUnexpectedFields(false))
 
@@ -148,6 +151,8 @@ private object Options {
     apply(json, ErDiagramGenerator.Options())
 
   def ossie(json: String): OssieGenerator.Options = apply(json, OssieGenerator.Options())
+
+  def fromOssie(json: String): OssieImporter.Options = apply(json, OssieImporter.Options())
 
   def scala(json: String): ScalaGenerator.Options = apply(json, ScalaGenerator.Options())
 

--- a/python/README.md
+++ b/python/README.md
@@ -29,6 +29,8 @@ Generators available on a `Schema`: `json_schema()`, `shacl()`, `rdfs()`, `linkm
 `frictionless()`, `graphql()`, `er_diagram()`, `translation()`, `ossie()`, and `scala()`, plus
 `lint()` for validation.
 
+Going the other way, `linkml_scala.from_ossie()` reads an Apache Ossie (incubating) ontology and returns the corresponding LinkML schema as YAML or JSON.
+
 To work from memory instead of the file system, use `load_string()` for a single schema or
 `load_path()` when imports are involved:
 

--- a/python/linkml_scala/__init__.py
+++ b/python/linkml_scala/__init__.py
@@ -42,6 +42,7 @@ __all__ = [
     "Schema",
     "SchemaLoadError",
     "build_info",
+    "from_ossie",
     "library_path",
     "load_file",
     "load_path",
@@ -244,6 +245,30 @@ def load_path(
     return _schema(
         current,
         *current.load_string(path, None, imports, {"inferMessages": infer_messages}),
+    )
+
+
+def from_ossie(
+    ontology: str,
+    *,
+    schema_id: str | None = None,
+    output_format: str = "yaml",
+) -> str:
+    """Read an Apache Ossie ontology and return the LinkML schema it describes.
+
+    The opposite of :meth:`Schema.ossie`. Pass the result to :func:`load_string`
+    to run a generator over it.
+
+    :param ontology: The ontology document, as YAML or JSON.
+    :param schema_id: The ``id`` of the schema to produce. An Ossie ontology has none of its own,
+        so by default it is a placeholder built from the ontology's name.
+    :param output_format: Output serialization format to use, ``yaml`` or ``json``.
+    :raises LinkMlError: if the document could not be read.
+    """
+    return runtime().import_document(
+        "linkml_from_ossie",
+        ontology,
+        {"schemaId": schema_id, "outputFormat": output_format},
     )
 
 

--- a/python/linkml_scala/_runtime.py
+++ b/python/linkml_scala/_runtime.py
@@ -273,6 +273,29 @@ class Runtime:
             raise LinkMlError(message or "linkml_build_info failed without saying why")
         return json.loads(text)
 
+    def import_document(
+        self, function: str, document: str, options: Mapping[str, Any] | None = None
+    ) -> str:
+        """Call an importer, by its exported name, and return the schema it produced.
+
+        Unlike :meth:`document` there is no handle: an importer is what makes schemas.
+
+        :raises LinkMlError: if the library reported a failure.
+        """
+        error = _Chars()
+        result = self._call(
+            getattr(self._lib, function),
+            document.encode("utf-8"),
+            _options(options),
+            ctypes.byref(error),
+        )
+        # Take both, so neither leaks whichever way the call went.
+        message = self._take(error)
+        text = self._take(result)
+        if text is None:
+            raise LinkMlError(message or f"{function} failed without saying why")
+        return text
+
     # Internals
 
     def _loaded(self, handle: int, report: Any, error: Any) -> tuple[int, dict[str, Any]]:
@@ -326,6 +349,10 @@ class Runtime:
         # Takes no schema, so it does not fit the generator shape below.
         self._lib.linkml_build_info.argtypes = [chars_out]
         self._lib.linkml_build_info.restype = _Chars
+
+        # Importers take a document instead of a handle, so they do not fit either.
+        self._lib.linkml_from_ossie.argtypes = [ctypes.c_char_p, ctypes.c_char_p, chars_out]
+        self._lib.linkml_from_ossie.restype = _Chars
 
         # linkml_lint has the same shape but is not a generator, so it is not in the generated
         # list and gets declared alongside it.

--- a/python/test_bindings.py
+++ b/python/test_bindings.py
@@ -79,6 +79,53 @@ BROKEN = schema(
 FIXED = BROKEN.replace("NoSuchThing", "string")
 
 
+class FromOssieTest(unittest.TestCase):
+    ONTOLOGY = textwrap.dedent(
+        """
+        version: 0.2.0.dev0
+        name: flights
+        ontology:
+          - concept: Airport
+            type: EntityType
+            identify_by: [code]
+            relationships:
+              - name: code
+                roles: [{concept: String}]
+                multiplicity: OneToOne
+                verbalizes: ['{Airport} is identified by {String}']
+        """
+    ).strip()
+
+    def test_reads_an_ontology_into_a_schema(self):
+        schema = linkml_scala.from_ossie(self.ONTOLOGY)
+        self.assertIn("name: flights", schema)
+        self.assertIn("Airport:", schema)
+        self.assertIn("identifier: true", schema)
+
+    def test_writes_json_when_asked(self):
+        schema = json.loads(linkml_scala.from_ossie(self.ONTOLOGY, output_format="json"))
+        self.assertEqual("flights", schema["name"])
+
+    def test_uses_the_schema_id_it_was_given(self):
+        schema = linkml_scala.from_ossie(self.ONTOLOGY, schema_id="https://example.com/mine")
+        self.assertIn("id: https://example.com/mine", schema)
+
+    # The point of the round trip: what comes out is a schema the library can load again.
+    def test_result_loads_as_a_schema(self):
+        with linkml_scala.load_string(linkml_scala.from_ossie(self.ONTOLOGY)) as schema:
+            self.assertIn("concept: Airport", schema.ossie())
+
+    def test_unreadable_document_is_rejected(self):
+        with self.assertRaises(LinkMlError) as raised:
+            linkml_scala.from_ossie("name: [unclosed")
+        self.assertIn("Ossie ontology", str(raised.exception))
+
+    def test_unknown_output_format_is_rejected(self):
+        with self.assertRaises(LinkMlError) as raised:
+            linkml_scala.from_ossie(self.ONTOLOGY, output_format="toml")
+        self.assertIn("toml", str(raised.exception))
+
+
 class BuildInfoTest(unittest.TestCase):
     def test_build_info_describes_the_library(self):
         info = linkml_scala.build_info()

--- a/ui/linkml.d.ts
+++ b/ui/linkml.d.ts
@@ -140,6 +140,15 @@ export interface LinkMLApi {
   ossie(schema: SchemaView, pruningMode?: string, treeRoot?: string, outFormat?: string): string;
 
   /**
+   * Read an Apache Ossie ontology and produce the LinkML schema it describes.  The opposite of [[ossie]], and the only method here that starts from a document rather than from a loaded schema, so it takes no [[SchemaViewJs]]. Feed the result to [[loadFromString]] if you want to run a generator over it. See `docs/ossie_mapping.md` for what survives.
+   * @param ontology The ontology document, as YAML or JSON.
+   * @param schemaId The `id` of the schema to produce. An Ossie ontology has none of its own, so by default it is a placeholder built from the ontology's name.
+   * @param outFormat Output serialization format to use. One of yaml|json. Default: yaml
+   * @returns The LinkML schema, serialized in the specified format.
+   */
+  fromOssie(ontology: string, schemaId?: string, outFormat?: string): string;
+
+  /**
    * Lint a loaded LinkML schema, finding problems that may cause issues when using the model. This method returns a structured JSON that follows the validation-report.yaml model.  TODO: consider typing the return value in TypeScript using a TypeScript generator. See: https://github.com/NeverBlink-OSS/linkml-scala/issues/127
    * @param schema A [[SchemaView]] handle created with [[loadFromString]] or [[loadFromPath]].
    * @param inferMessages Whether to fill in each issue's human-readable `message` and `details` from the model's `equals_expression`s. Turn it off to get only the structured fields.

--- a/ui/linkml.d.ts
+++ b/ui/linkml.d.ts
@@ -140,7 +140,7 @@ export interface LinkMLApi {
   ossie(schema: SchemaView, pruningMode?: string, treeRoot?: string, outFormat?: string): string;
 
   /**
-   * Read an Apache Ossie ontology and produce the LinkML schema it describes.  The opposite of [[ossie]], and the only method here that starts from a document rather than from a loaded schema, so it takes no [[SchemaViewJs]]. Feed the result to [[loadFromString]] if you want to run a generator over it. See `docs/ossie_mapping.md` for what survives.
+   * Read an Apache Ossie ontology and produce the LinkML schema it describes.  The opposite of [[ossie]]. Feed the result to [[loadFromString]] if you want to run a generator over it.
    * @param ontology The ontology document, as YAML or JSON.
    * @param schemaId The `id` of the schema to produce. An Ossie ontology has none of its own, so by default it is a placeholder built from the ontology's name.
    * @param outFormat Output serialization format to use. One of yaml|json. Default: yaml


### PR DESCRIPTION
- There is a new base class `SchemaImporter` for things that generate LinkML schemas.
  - Let it be noted that I don't particularly like it, but it works and I don't want to over-engineer it at this point.
  - Later I think we should have a generic Converter trait (anything to anything) specialized into specific input types (e.g., linkml->X) or output types (e.g., X->linkml). Or something like that.
- We do a best effort to round-trip things through Ossie. For now, everything that we can write into Ossie can be parsed back into LinkML and then back into Ossie and no information is lost.
  - The goal should really be to progressively increase coverage of Ossie & LinkML features. They both have a lot of power in expressions & restrictions, for example. However, neither has a good spec of these expression languages, which makes the conversion quite challenging.
- For expressions I wrote fastparse parsers + scalacheck fuzzing tests.
- CLI has a new `from ossie` command.
  - I also trimmed down the CLI help texts of some generators, because it was a horrible wall of text.
- Added APIs for JS, native/C, and Python.
- I also want to add support in the playground, but let's merge #228 first to not make too many conflicts.