### PR TITLE
LNK-169: Add reserved Scala word escaping

### DIFF
--- a/cli/test/src/eu/neverblink/linkml/cli/GenerateSpec.scala
+++ b/cli/test/src/eu/neverblink/linkml/cli/GenerateSpec.scala
@@ -11,8 +11,9 @@ class GenerateSpec extends AnyWordSpec, Matchers {
     """id: https://neverblink.eu/test/
       |name: test
       |default_range: string
-      |types:
-      |  string:
+      |imports:
+      |  - linkml:types
+      |
       |classes:
       |  Root:
       |    tree_root: true
@@ -43,8 +44,9 @@ class GenerateSpec extends AnyWordSpec, Matchers {
     """id: https://neverblink.eu/test/
       |name: test
       |default_range: string
-      |types:
-      |  string:
+      |imports:
+      |  - linkml:types
+      |
       |classes:
       |  Root:
       |    tree_root: true

--- a/generator/src/eu/neverblink/linkml/generator/scala/ScalaRenamer.scala
+++ b/generator/src/eu/neverblink/linkml/generator/scala/ScalaRenamer.scala
@@ -5,24 +5,27 @@ import eu.neverblink.linkml.metamodel.{PermissibleValue, SlotDefinition}
 import eu.neverblink.linkml.schemaview.{Case, ClassView, EnumView, SlotView, TypeView}
 
 trait ScalaRenamer extends Renamer {
-  private val scalaKeywords: Set[String] = (
-    "abstract case catch class def do else extends final finally for " +
-      "forSome if implicit import lazy match new object override package protected return sealed super " +
-      "this throw trait try type val var while with yield inline derives end extension using as"
-  ).split(' ').toSet
 
+  /** Get the scala `PascalCase` name, dodge leading digits/reserved words with an underscore. No
+    * need to check for keywords - all start with lowercase.
+    */
   protected def scalaPascal(baseName: String): String = {
     val name = Case.baseToPascal(baseName)
     if name.isEmpty then "__"
     else if Case.isNumeric(name.head) then "_" + name
+    else if ScalaWords.reserved.contains(name) then "_" + name
     else name
   }
 
+  /** Get the scala `camelCase` name, dodge leading digits/reserved words with an underscore, and
+    * quote Scala keywords in backticks.
+    */
   protected def scalaCamel(baseName: String): String = {
     val name = Case.baseToCamel(baseName)
     if name.isEmpty then "__"
     else if Case.isNumeric(name.head) then "_" + name
-    else if scalaKeywords.contains(name) then s"`$name`"
+    else if ScalaWords.keywords.contains(name) then s"`$name`"
+    else if ScalaWords.reserved.contains(name) then "_" + name
     else name
   }
 
@@ -32,9 +35,6 @@ trait ScalaRenamer extends Renamer {
     el.derivedAttributes(attr.name),
   )
 
-  /** Get the scala `lowerCamelCase` name for a slot, dodge leading digits with an underscore, and
-    * quote Scala keywords in backticks.
-    */
   override def slotName(el: SlotView): String = scalaCamel(el.baseName)
 
   override def typeName(el: TypeView): String = scalaPascal(el.baseName)

--- a/generator/src/eu/neverblink/linkml/generator/scala/ScalaWords.scala
+++ b/generator/src/eu/neverblink/linkml/generator/scala/ScalaWords.scala
@@ -1,0 +1,79 @@
+package eu.neverblink.linkml.generator.scala
+
+/** Scala keywords and reserved words. Keywords may be escaped with backticks (`). Reserved words
+  * must be escaped with an underscore instead.
+  */
+object ScalaWords {
+  val keywords: Set[String] = Set(
+    "abstract",
+    "case",
+    "catch",
+    "class",
+    "def",
+    "do",
+    "else",
+    "extends",
+    "final",
+    "finally",
+    "for",
+    "forSome",
+    "if",
+    "implicit",
+    "import",
+    "lazy",
+    "match",
+    "new",
+    "object",
+    "override",
+    "package",
+    "protected",
+    "return",
+    "sealed",
+    "super",
+    "this",
+    "throw",
+    "trait",
+    "try",
+    "type",
+    "val",
+    "var",
+    "while",
+    "with",
+    "yield",
+    "inline",
+    "derives",
+    "end",
+    "extension",
+    "using",
+    "as",
+  )
+
+  val reserved: Set[String] = Set(
+    // java.lang.Object
+    "hashCode",
+    "notify",
+    "toString",
+    "getClass",
+    "notifyAll",
+    "synchronized",
+    "wait",
+    // Scala runtime types
+    "String",
+    "Int",
+    "Float",
+    "Double",
+    "Boolean",
+    "BigDecimal",
+    // LinkML runtime types
+    "LinkmlAny",
+    "LinkmlDate",
+    "LinkmlDateTime",
+    "LinkmlTime",
+    "UriOrCurie",
+    "Uri",
+    "Curie",
+    "NcName",
+    "LocalizedText",
+    "Unknown",
+  )
+}

--- a/generator/test/src-jvm/eu/neverblink/linkml/generator/scala/ScalaGeneratorCompileSpec.scala
+++ b/generator/test/src-jvm/eu/neverblink/linkml/generator/scala/ScalaGeneratorCompileSpec.scala
@@ -52,7 +52,5 @@ class ScalaGeneratorCompileSpec extends AnyWordSpec, Matchers, ModelCatalogueSpe
 
 object ScalaGeneratorCompileSpec {
   val skipModels: Map[String, String] = Map(
-    "nonHermetic" ->
-      "LNK-169: a type whose base has the same name generates a cyclic alias (`type Int = Int`)",
   )
 }

--- a/generator/test/src/eu/neverblink/linkml/generator/scala/ScalaGeneratorSpec.scala
+++ b/generator/test/src/eu/neverblink/linkml/generator/scala/ScalaGeneratorSpec.scala
@@ -1103,6 +1103,31 @@ class ScalaGeneratorSpec extends AnyWordSpec, Matchers {
       files("Langstring.scala") should include("type Langstring = LocalizedText")
     }
 
+    "dodge reserved words with underscores" in {
+      val input =
+        s"""$schemaShared
+           |types:
+           |  Int:
+           |    base: int
+           |classes:
+           |  LocalizedText:
+           |    attributes:
+           |      hashCode:
+           |        range: Int
+           |""".stripMargin
+      val files =
+        ScalaGenerator(using decode(input)).generate(ScalaGenerator.Options(testPkg)).toMap
+
+      files.keys should contain theSameElementsAs Seq(
+        "_LocalizedText.scala",
+        "_Int.scala",
+      )
+
+      files("_LocalizedText.scala") should include("_hashCode: Option[_Int]")
+      files("_Int.scala") should include("type _Int = Int")
+
+    }
+
     "generate the metamodel" in {
       val sv =
         SchemaIssues.orThrow(SchemaView.loadSchemaViewFromUri("https://w3id.org/linkml/meta"))

--- a/metamodel/src/eu/neverblink/linkml/metamodel/PvFormulaOptions.scala
+++ b/metamodel/src/eu/neverblink/linkml/metamodel/PvFormulaOptions.scala
@@ -25,14 +25,14 @@ object PvFormulaOptions {
     * @see
     *   From schema: https://w3id.org/linkml/meta
     */
-  @named("CURIE") case object Curie extends PvFormulaOptions
+  @named("CURIE") case object _Curie extends PvFormulaOptions
 
   /** The permissible values are the set of code URIs in the code set
     *
     * @see
     *   From schema: https://w3id.org/linkml/meta
     */
-  @named("URI") case object Uri extends PvFormulaOptions
+  @named("URI") case object _Uri extends PvFormulaOptions
 
   /** The permissible values are the set of FHIR coding elements derived from the code set
     *


### PR DESCRIPTION
I wanted to add the entire default import but turns out it's big and annoying. Let's just keep it small and fix it as it comes up.