### PR TITLE
Fix Scala 3.9 keywords

### DIFF
--- a/generator/src/eu/neverblink/linkml/generator/scala/ScalaRenamer.scala
+++ b/generator/src/eu/neverblink/linkml/generator/scala/ScalaRenamer.scala
@@ -22,10 +22,13 @@ trait ScalaRenamer extends Renamer {
     */
   protected def scalaCamel(baseName: String): String = {
     val name = Case.baseToCamel(baseName)
-    if name.isEmpty then "__"
-    else if Case.isNumeric(name.head) then "_" + name
-    else if ScalaWords.keywords.contains(name) then s"`$name`"
-    else if ScalaWords.reserved.contains(name) then "_" + name
+    val len = name.length
+    if (len == 0) "__"
+    else if (
+      Case.isNumeric(name.charAt(0)) ||
+      len <= ScalaWords.maxReservedLength && ScalaWords.reserved.contains(name)
+    ) "_".concat(name)
+    else if (len <= ScalaWords.maxKeywordLength && ScalaWords.keywords.contains(name)) s"`$name`"
     else name
   }
 

--- a/generator/src/eu/neverblink/linkml/generator/scala/ScalaWords.scala
+++ b/generator/src/eu/neverblink/linkml/generator/scala/ScalaWords.scala
@@ -1,53 +1,67 @@
 package eu.neverblink.linkml.generator.scala
 
-/** Scala keywords and reserved words. Keywords may be escaped with backticks (`). Reserved words
-  * must be escaped with an underscore instead.
+/** Scala 3.9 LTS keywords and reserved words. Keywords may be escaped with backticks (`). Soft
+  * keywords are listed but commented - they can be used in standard identifiers like class, trait,
+  * method, or fields. Reserved words must be escaped with an underscore instead.
   */
 object ScalaWords {
   val keywords: Set[String] = Set(
     "abstract",
+    // "as", soft keyword, example: import scala.collection.mutable.{Map as MutableMap}
     "case",
     "catch",
     "class",
     "def",
+    // "derives", soft keyword, example: enum Tree[T] derives CanEqual
     "do",
     "else",
+    // "end", soft keyword, example: end MyClass
+    "enum",
+    // "erased", soft keyword, experimental
+    "export",
     "extends",
+    // "extension", soft keyword, example: extension (s: String) def reformat: String = ...
+    "false",
     "final",
     "finally",
     "for",
-    "forSome",
+    "given",
     "if",
     "implicit",
     "import",
+    // "infix", soft keyword, example: infix def add(other: Int): Int
+    // "inline", soft keyword, example: inline def assert(condition: => Boolean): Unit = ...
+    // "into", soft keyword, example: into trait IntoIterable[A] extends Iterable[A]
     "lazy",
     "match",
     "new",
+    "null",
     "object",
+    // "opaque", soft keyword, example: opaque type Logarithm = Double
+    // "open", soft keyword, example: open class BaseComponent
     "override",
     "package",
+    "private",
     "protected",
     "return",
     "sealed",
     "super",
+    "then",
     "this",
     "throw",
     "trait",
+    // "transparent", soft keyword, example: transparent inline def choose(b: Boolean) = ...
+    "true",
     "try",
     "type",
+    // "using", soft keyword, example: def sort[A](list: List[A])(using ord: Ord[A]) = ...
     "val",
     "var",
     "while",
     "with",
     "yield",
-    "inline",
-    "derives",
-    "end",
-    "extension",
-    "using",
-    "as",
   )
-
+  val maxKeywordLength = keywords.foldLeft(0)(_ max _.length)
   val reserved: Set[String] = Set(
     // java.lang.Object
     "hashCode",
@@ -76,4 +90,5 @@ object ScalaWords {
     "LocalizedText",
     "Unknown",
   )
+  val maxReservedLength = reserved.foldLeft(0)(_ max _.length)
 }

--- a/generator/test/src/eu/neverblink/linkml/generator/scala/ScalaWordsSpec.scala
+++ b/generator/test/src/eu/neverblink/linkml/generator/scala/ScalaWordsSpec.scala
@@ -1,0 +1,68 @@
+package eu.neverblink.linkml.generator.scala
+
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
+
+import scala.annotation.nowarn
+
+class ScalaWordsSpec extends AnyWordSpec, Matchers {
+  "ScalaWords" should {
+    "not compile keywords as class names" in {
+      assertDoesNotCompile("class abstract")
+      assertDoesNotCompile("class case")
+      assertDoesNotCompile("class catch")
+      assertDoesNotCompile("class class")
+      assertDoesNotCompile("class def")
+      assertDoesNotCompile("class do")
+      assertDoesNotCompile("class else")
+      assertDoesNotCompile("class enum")
+      assertDoesNotCompile("class export")
+      assertDoesNotCompile("class extends")
+      assertDoesNotCompile("class false")
+      assertDoesNotCompile("class final")
+      assertDoesNotCompile("class finally")
+      assertDoesNotCompile("class for")
+      assertDoesNotCompile("class given")
+      assertDoesNotCompile("class if")
+      assertDoesNotCompile("class implicit")
+      assertDoesNotCompile("class import")
+      assertDoesNotCompile("class lazy")
+      assertDoesNotCompile("class match")
+      assertDoesNotCompile("class new")
+      assertDoesNotCompile("class null")
+      assertDoesNotCompile("class object")
+      assertDoesNotCompile("class override")
+      assertDoesNotCompile("class package")
+      assertDoesNotCompile("class private")
+      assertDoesNotCompile("class protected")
+      assertDoesNotCompile("class return")
+      assertDoesNotCompile("class sealed")
+      assertDoesNotCompile("class super")
+      assertDoesNotCompile("class then")
+      assertDoesNotCompile("class this")
+      assertDoesNotCompile("class throw")
+      assertDoesNotCompile("class trait")
+      assertDoesNotCompile("class true")
+      assertDoesNotCompile("class try")
+      assertDoesNotCompile("class type")
+      assertDoesNotCompile("class val")
+      assertDoesNotCompile("class var")
+      assertDoesNotCompile("class while")
+      assertDoesNotCompile("class with")
+      assertDoesNotCompile("class yield")
+    }
+    "compile soft keywords as class names" in {
+      @nowarn class as {}
+      @nowarn class derives {}
+      @nowarn class end {}
+      @nowarn class extension {}
+      @nowarn class infix {}
+      @nowarn class inline {}
+      @nowarn class into {}
+      @nowarn class opaque {}
+      @nowarn class open {}
+      @nowarn class transparent {}
+      @nowarn class using {}
+    }
+  }
+}


### PR DESCRIPTION
Fix Scala 3.9 keywords:
- remove Scala 2 keyword
- comment out soft keywords
- add missing keywords
- add unit test for keywords
- sort keywords alphabetically
- more efficient escaping of keywords
- more efficient prefixing of reserved words